### PR TITLE
fix: remove all legacy .cursor/ path references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,5 @@ whisper_models/
 **/.*
 
 # Exceptions (keep these visible)
-!.cursor/
 !.gitignore
 !.git/
-
-.cursor/mcp/temp_servers

--- a/agents/3d_print_finder/README.md
+++ b/agents/3d_print_finder/README.md
@@ -57,7 +57,7 @@ For each top model, provides:
 ```
 
 ### Via Context
-Open any file in `.cursor/agents/3d_print_finder/` or mention 3D printing keywords.
+Open any file in `agents/3d_print_finder/` or mention 3D printing keywords.
 
 ### Manual Routing
 Keywords: `3d print`, `stl`, `thingiverse`, `printables`, `3d model`
@@ -268,7 +268,7 @@ Agent:
 ## Files
 
 ```
-.cursor/agents/3d_print_finder/
+agents/3d_print_finder/
 ├── system_prompt.mdc      # Main agent definition
 ├── README.md              # This file
 └── examples/

--- a/agents/3d_print_finder/README.md
+++ b/agents/3d_print_finder/README.md
@@ -278,8 +278,6 @@ agents/3d_print_finder/
 ## Integration
 
 This agent integrates with:
-- **Core Protocol** (`@agents/common/core-protocol.mdc`)
-- **Response Footer** (`@agents/common/response-footer.mdc`)
 - **Skill: 3D Print Search** (`@skills/skill-3d-print-search.mdc`)
 - **Skill: Critical Analysis** (`@skills/skill-analysis-critical.mdc`)
 

--- a/agents/3d_print_finder/system_prompt.mdc
+++ b/agents/3d_print_finder/system_prompt.mdc
@@ -18,8 +18,7 @@ routing:
   trigger_command: "/3dprint"
 context:
   file_globs:
-    - ".cursor/agents/3d_print_finder/**"
-    - ".cursor/commands/3dprint.md"
+    - "agents/3d_print_finder/**"
     - "**/*.stl"
     - "**/*.obj"
     - "**/*.3mf"

--- a/agents/agent_builder/system_prompt.mdc
+++ b/agents/agent_builder/system_prompt.mdc
@@ -48,7 +48,7 @@ You are the **Agent Builder**, a specialized architect responsible for expanding
 
 3.  **GENERATION**
     *   **Agent System Prompt**: `agents/<name>/system_prompt.mdc` (Follow MDC structure, DO NOT include `## Context` boilerplate).
-        *   **FORBIDDEN**: Do NOT add `@agents/common/core-protocol.mdc` inline — Core Protocol is auto-loaded by the MCP engine.
+        *   **FORBIDDEN**: Do NOT add `@agents/common/core-protocol.mdc` inline — it is deprecated. Skills, implants, and capability directives are compiled directly into the agent's system prompt by the MCP engine.
         *   Add `capabilities:` list to frontmatter when applicable.
         *   Routing is handled via `trigger_command` in frontmatter — no separate rule or command files needed.
     *   **Skills**: Create `skills/skill-<new-skill>.mdc` if needed (without `globs` field).

--- a/agents/agent_builder/system_prompt.mdc
+++ b/agents/agent_builder/system_prompt.mdc
@@ -52,7 +52,7 @@ You are the **Agent Builder**, a specialized architect responsible for expanding
         *   Add `capabilities:` list to frontmatter when applicable.
         *   Routing is handled via `trigger_command` in frontmatter — no separate rule or command files needed.
     *   **Skills**: Create `skills/skill-<new-skill>.mdc` if needed (without `globs` field).
-        *   **REQUIRED**: Add `compiled:` field to skill frontmatter — a dense ~1-line actionable summary used in token-saving mode.
+        *   **Recommended**: Add `compiled:` field to skill frontmatter — a dense ~1-line actionable summary used in token-saving mode. The engine falls back to `description` if omitted.
     *   **Capabilities**: If the new agent's skill set maps to an existing capability in `registry.yaml`, reuse it. If not, consider adding a new capability entry.
 
 4.  **INTERACTION EXAMPLE**

--- a/agents/agent_builder/system_prompt.mdc
+++ b/agents/agent_builder/system_prompt.mdc
@@ -13,11 +13,9 @@ routing:
   trigger_command: /new_agent
 context:
   file_globs:
-  - .cursor/agents/**
-  - .cursor/rules/**
-  - .cursor/skills/**
-  - .cursor/commands/**
-  - .cursor/agents/common/agent-schema.json
+  - agents/**
+  - skills/**
+  - agents/common/agent-schema.json
 static_skills:
 - skill-content-structure.mdc
 - skill-tech-writing.mdc
@@ -38,10 +36,10 @@ You are the **Agent Builder**, a specialized architect responsible for expanding
 ## Protocol
 
 1.  **INTERVIEW & SCHEMA POPULATION**
-    *   Load `.cursor/agents/common/agent-schema.json`.
+    *   Load `agents/common/agent-schema.json`.
     *   Systematically ask questions to fill every field: Identity, Routing, Context, Static Skills, Preferred Skills, **Capabilities**.
     *   **Proactively suggest** standard skills like `skill-content-structure.mdc` (for output formatting) or `skill-analysis-critical.mdc` (for complex tasks).
-    *   **Capabilities**: Load `.cursor/capabilities/registry.yaml` and suggest relevant capabilities instead of (or in addition to) individual skills. Capabilities compose skills + directives — prefer them over raw skill lists.
+    *   **Capabilities**: Load `agents/capabilities/registry.yaml` and suggest relevant capabilities instead of (or in addition to) individual skills. Capabilities compose skills + directives — prefer them over raw skill lists.
     *   **IMPORTANT**: Use `static_skills` (with .mdc extension) for fallback mode and `preferred_skills` (without extension) for MCP dynamic loading. Do NOT use deprecated `skills` field.
 
 2.  **CONFIRMATION**
@@ -49,12 +47,11 @@ You are the **Agent Builder**, a specialized architect responsible for expanding
     *   Ask for confirmation to proceed.
 
 3.  **GENERATION**
-    *   **Agent System Prompt**: `.cursor/agents/<name>/system_prompt.mdc` (Follow MDC structure, DO NOT include `## Context` boilerplate).
-        *   **FORBIDDEN**: Do NOT add `@agents/common/core-protocol.mdc` inline — Core Protocol is auto-loaded via Cursor rules (`alwaysApply: true`).
+    *   **Agent System Prompt**: `agents/<name>/system_prompt.mdc` (Follow MDC structure, DO NOT include `## Context` boilerplate).
+        *   **FORBIDDEN**: Do NOT add `@agents/common/core-protocol.mdc` inline — Core Protocol is auto-loaded by the MCP engine.
         *   Add `capabilities:` list to frontmatter when applicable.
-    *   **Rule File**: `.cursor/rules/10-<name>.mdc` (Minimal pointer format - description, globs, Load reference only).
-    *   **Command File**: `.cursor/commands/<command_name>.md` (Documentation).
-    *   **Skills**: Create `.cursor/skills/skill-<new-skill>.mdc` if needed (without `globs` field).
+        *   Routing is handled via `trigger_command` in frontmatter — no separate rule or command files needed.
+    *   **Skills**: Create `skills/skill-<new-skill>.mdc` if needed (without `globs` field).
         *   **REQUIRED**: Add `compiled:` field to skill frontmatter — a dense ~1-line actionable summary used in token-saving mode.
     *   **Capabilities**: If the new agent's skill set maps to an existing capability in `registry.yaml`, reuse it. If not, consider adding a new capability entry.
 

--- a/agents/ai_senior_engineer/system_prompt.mdc
+++ b/agents/ai_senior_engineer/system_prompt.mdc
@@ -15,7 +15,7 @@ routing:
   trigger_command: "/ai_architect"
 context:
   file_globs:
-    - ".cursor/agents/ai_senior_engineer/**"
+    - "agents/ai_senior_engineer/**"
 static_skills:
   - "skill-content-structure.mdc"
 preferred_skills:

--- a/agents/alerts_describer/system_prompt.mdc
+++ b/agents/alerts_describer/system_prompt.mdc
@@ -17,8 +17,7 @@ routing:
   trigger_command: "/alerts_describer"
 context:
   file_globs:
-    - ".cursor/agents/alerts_describer/**"
-    - ".cursor/commands/alerts_describer.md"
+    - "agents/alerts_describer/**"
 static_skills:
   - "skill-content-structure.mdc"
   - "skill-dense-summarization.mdc"

--- a/agents/bio_hacker/system_prompt.mdc
+++ b/agents/bio_hacker/system_prompt.mdc
@@ -15,7 +15,7 @@ routing:
   trigger_command: "/bio_protocol"
 context:
   file_globs:
-    - ".cursor/agents/bio_hacker/**"
+    - "agents/bio_hacker/**"
 static_skills:
   - "skill-bio-mechanism.mdc"
   - "skill-bio-protocols.mdc"

--- a/agents/black_hole_finder/system_prompt.mdc
+++ b/agents/black_hole_finder/system_prompt.mdc
@@ -17,8 +17,8 @@ routing:
   trigger_command: "/find_black_hole"
 context:
   file_globs:
-    - ".cursor/agents/black_hole_finder/**"
-    - ".cursor/skills/skill-agnotology.mdc"
+    - "agents/black_hole_finder/**"
+    - "skills/skill-agnotology.mdc"
 static_skills:
   - "skill-agnotology.mdc"
   - "skill-analysis-critical.mdc"

--- a/agents/child_psychologist/system_prompt.mdc
+++ b/agents/child_psychologist/system_prompt.mdc
@@ -27,7 +27,7 @@ routing:
   trigger_command: "/child_psy"
 context:
   file_globs:
-    - ".cursor/agents/child_psychologist/**"
+    - "agents/child_psychologist/**"
 static_skills:
   - "skill-psy-cbt.mdc"
   - "skill-psy-nvc.mdc"
@@ -55,7 +55,7 @@ Always determine the child's age first. Adapt ALL communication, techniques, and
 
 | Stage | Age | Key Characteristics | Primary Approach |
 |-------|-----|---------------------|------------------|
-| **Early Childhood** | 0-3 | Attachment formation, sensorimotor exploration | Parent guidance only. Attachment lens. |
+| **Early Childhood** | 0-2 | Attachment formation, sensorimotor exploration | Parent guidance only. Attachment lens. |
 | **Preschool** | 3-6 | Magical thinking, play as primary language | Play therapy concepts, metaphors, parent coaching. |
 | **School Age** | 7-11 | Concrete operations, peer influence begins, first devices | Behavioral charts, narrative therapy, structured digital literacy. |
 | **Early Adolescence** | 12-14 | Identity formation, social media entry, peer pressure peak | Motivational interviewing, cognitive defusion, digital identity work. |

--- a/agents/child_psychologist/system_prompt.mdc
+++ b/agents/child_psychologist/system_prompt.mdc
@@ -55,7 +55,7 @@ Always determine the child's age first. Adapt ALL communication, techniques, and
 
 | Stage | Age | Key Characteristics | Primary Approach |
 |-------|-----|---------------------|------------------|
-| **Early Childhood** | 0-2 | Attachment formation, sensorimotor exploration | Parent guidance only. Attachment lens. |
+| **Early Childhood** | 0-3 | Attachment formation, sensorimotor exploration | Parent guidance only. Attachment lens. |
 | **Preschool** | 3-6 | Magical thinking, play as primary language | Play therapy concepts, metaphors, parent coaching. |
 | **School Age** | 7-11 | Concrete operations, peer influence begins, first devices | Behavioral charts, narrative therapy, structured digital literacy. |
 | **Early Adolescence** | 12-14 | Identity formation, social media entry, peer pressure peak | Motivational interviewing, cognitive defusion, digital identity work. |

--- a/agents/common/core-protocol.mdc
+++ b/agents/common/core-protocol.mdc
@@ -1,9 +1,9 @@
 ---
-description: "DEPRECATED — moved to .cursor/rules/01-core-protocol.mdc"
+description: "DEPRECATED — core protocol is now loaded automatically by the MCP engine"
 alwaysApply: false
 ---
 
 # DEPRECATED
 
-This file has been moved to `.cursor/rules/01-core-protocol.mdc` where `alwaysApply: true` actually takes effect.
-Do NOT reference this file. The canonical version is in `.cursor/rules/`.
+Core protocol is now loaded automatically by the Agents MCP engine.
+Do NOT reference this file.

--- a/agents/common/core-protocol.mdc
+++ b/agents/common/core-protocol.mdc
@@ -1,9 +1,10 @@
 ---
-description: "DEPRECATED — core protocol is now loaded automatically by the MCP engine"
+description: "DEPRECATED — core protocol behavior is embedded in each agent's compiled system prompt"
 alwaysApply: false
 ---
 
 # DEPRECATED
 
-Core protocol is now loaded automatically by the Agents MCP engine.
-Do NOT reference this file.
+The core protocol concept no longer exists as a standalone file.
+Agent behavior (skills, implants, capability directives) is compiled directly into each agent's system prompt by the MCP engine.
+Do NOT reference this file — it has no effect.

--- a/agents/daily_briefing/system_prompt.mdc
+++ b/agents/daily_briefing/system_prompt.mdc
@@ -16,7 +16,7 @@ routing:
   trigger_command: "/briefing"
 context:
   file_globs:
-    - ".cursor/agents/daily_briefing/**/*"
+    - "agents/daily_briefing/**/*"
 static_skills:
   - "skill-analysis-critical.mdc"
   - "skill-dense-summarization.mdc"

--- a/agents/data_forensic/system_prompt.mdc
+++ b/agents/data_forensic/system_prompt.mdc
@@ -15,7 +15,7 @@ routing:
   trigger_command: "/forensic"
 context:
   file_globs:
-    - ".cursor/agents/data_forensic/**"
+    - "agents/data_forensic/**"
 static_skills:
   - "skill-content-structure.mdc"
 preferred_skills:

--- a/agents/deep_researcher/system_prompt.mdc
+++ b/agents/deep_researcher/system_prompt.mdc
@@ -16,8 +16,7 @@ routing:
   trigger_command: "/research"
 context:
   file_globs:
-    - ".cursor/agents/deep_researcher/**"
-    - ".cursor/commands/research.md"
+    - "agents/deep_researcher/**"
 static_skills:
   - "skill-dense-summarization.mdc"
   - "skill-analysis-critical.mdc"

--- a/agents/diagram_architect/system_prompt.mdc
+++ b/agents/diagram_architect/system_prompt.mdc
@@ -14,7 +14,7 @@ routing:
   trigger_command: /diagram
 context:
   file_globs:
-  - .cursor/agents/diagram_architect/**
+  - agents/diagram_architect/**
   - '**/*.md'
   - docs/**
 static_skills:

--- a/agents/document_ocr_expert/system_prompt.mdc
+++ b/agents/document_ocr_expert/system_prompt.mdc
@@ -18,7 +18,7 @@ routing:
   trigger_command: "/ocr"
 context:
   file_globs:
-    - ".cursor/agents/document_ocr_expert/**"
+    - "agents/document_ocr_expert/**"
 static_skills:
   - "skill-analysis-critical.mdc"
   - "skill-content-structure.mdc"

--- a/agents/fitness_coach/system_prompt.mdc
+++ b/agents/fitness_coach/system_prompt.mdc
@@ -24,7 +24,7 @@ routing:
   trigger_command: "/workout"
 context:
   file_globs:
-    - ".cursor/agents/fitness_coach/**"
+    - "agents/fitness_coach/**"
 static_skills:
   - "skill-fitness-programming.mdc"
   - "skill-bio-mechanism.mdc"

--- a/agents/instagram_analyst/system_prompt.mdc
+++ b/agents/instagram_analyst/system_prompt.mdc
@@ -14,7 +14,7 @@ routing:
   trigger_command: /instagram
 context:
   file_globs:
-  - .cursor/agents/instagram_analyst/**
+  - agents/instagram_analyst/**
 static_skills:
 - skill-analysis-critical.mdc
 - skill-content-structure.mdc

--- a/agents/install_to_repo/system_prompt.mdc
+++ b/agents/install_to_repo/system_prompt.mdc
@@ -13,8 +13,11 @@ routing:
   trigger_command: /install_agents
 context:
   file_globs:
-  - .cursor/agents/install_to_repo/**
-  - .cursor/**
+  - agents/install_to_repo/**
+  - agents/**
+  - skills/**
+  - implants/**
+  - src/**
 static_skills:
 - skill-dev-clean-code.mdc
 - skill-git-conventions.mdc
@@ -29,7 +32,7 @@ capabilities:
 
 ## Identity
 You are the **Repo Installer**, a specialized DevOps agent responsible for replicating the "Agents" architecture to other repositories.
-- **Goal**: Deploy the `.cursor` folder, MCP configuration, and essential environment settings to a target repository.
+- **Goal**: Deploy the Agents directory structure (`agents/`, `skills/`, `implants/`, `src/`), MCP configuration, and essential environment settings to a target repository.
 - **Tone**: Precise, Operational, Safe.
 
 ## Protocol
@@ -37,13 +40,13 @@ You are the **Repo Installer**, a specialized DevOps agent responsible for repli
 1.  **VERIFICATION**
     *   Validate the target repository path provided by the user.
     *   Check if the target is a valid git repository (optional but recommended).
-    *   Check for existing `.cursor` or `mcp.json` files to avoid accidental overwrites (ask for confirmation).
+    *   Check for existing `agents/`, `skills/`, or `mcp.json` files to avoid accidental overwrites (ask for confirmation).
 
 2.  **REPLICATION STRATEGY**
-    *   **Core**: Copy the `.cursor` directory recursively.
+    *   **Core**: Copy `agents/`, `skills/`, `implants/` directories recursively.
+    *   **Engine**: Copy `src/` directory (the Python MCP engine).
     *   **MCP**: Copy `mcp.json` (if present) or generate a compatible configuration.
     *   **Environment**: Check for `pyproject.toml` or `requirements.txt`. If missing, suggest creating them based on the source repo.
-    *   **Router**: Ensure `src/engine/router.py` (or equivalent) is present if the target needs the full Python engine. *Note: If the user only wants the cursor rules/agents, the python engine might not be needed, but the request implies "reproducing the architecture", so we should assume the Python backend is needed too.*
 
 3.  **EXECUTION STEPS**
     *   Use `list_dir` to inspect target.
@@ -52,11 +55,13 @@ You are the **Repo Installer**, a specialized DevOps agent responsible for repli
 
 4.  **POST-INSTALL**
     *   Verify the installation.
-    *   Instruct the user on how to activate the new agents in the target repo (e.g., "Restart Cursor").
+    *   Instruct the user on how to activate the new agents in the target repo (e.g., restart the IDE or MCP server).
 
 ## Interaction Example
 "I will now install the Agents architecture to `/path/to/target`.
-1. Copying `.cursor`... [Done]
-2. Copying `mcp.json`... [Done]
-3. Copying source engine... [Done]
-Installation complete. Please restart Cursor in the target window."
+1. Copying `agents/`... [Done]
+2. Copying `skills/`... [Done]
+3. Copying `implants/`... [Done]
+4. Copying `src/` engine... [Done]
+5. Copying `mcp.json`... [Done]
+Installation complete. Please restart your IDE or MCP server in the target window."

--- a/agents/install_to_repo/system_prompt.mdc
+++ b/agents/install_to_repo/system_prompt.mdc
@@ -40,7 +40,7 @@ You are the **Repo Installer**, a specialized DevOps agent responsible for repli
 1.  **VERIFICATION**
     *   Validate the target repository path provided by the user.
     *   Check if the target is a valid git repository (optional but recommended).
-    *   Check for existing `agents/`, `skills/`, or `mcp.json` files to avoid accidental overwrites (ask for confirmation).
+    *   Check for existing `agents/`, `skills/`, `implants/`, `src/`, or `mcp.json` in the target to avoid accidental overwrites (ask for confirmation).
 
 2.  **REPLICATION STRATEGY**
     *   **Core**: Copy `agents/`, `skills/`, `implants/` directories recursively.

--- a/agents/investigative_analyst/system_prompt.mdc
+++ b/agents/investigative_analyst/system_prompt.mdc
@@ -15,7 +15,7 @@ routing:
   trigger_command: "/investigate"
 context:
   file_globs:
-    - ".cursor/agents/investigative_analyst/**/*"
+    - "agents/investigative_analyst/**/*"
 static_skills:
   - "skill-analysis-critical.mdc"
 preferred_skills:

--- a/agents/mcp_builder/system_prompt.mdc
+++ b/agents/mcp_builder/system_prompt.mdc
@@ -14,10 +14,10 @@ routing:
   trigger_command: "/new_mcp"
 context:
   file_globs:
-    - ".cursor/agents/mcp_builder/**"
+    - "agents/mcp_builder/**"
     - "src/mcp_servers/_template/**"
     - "mcp.json"
-    - ".cursor/skills/skill-mcp-development.mdc"
+    - "skills/skill-mcp-development.mdc"
 static_skills:
   - "skill-mcp-development.mdc"
   - "skill-tech-writing.mdc"

--- a/agents/medical_expert/system_prompt.mdc
+++ b/agents/medical_expert/system_prompt.mdc
@@ -14,7 +14,7 @@ routing:
   trigger_command: "/medical"
 context:
   file_globs:
-    - ".cursor/agents/medical_expert/**"
+    - "agents/medical_expert/**"
     - "doctor/**"
     - "cases/**"
 static_skills:

--- a/agents/presentation_coach/system_prompt.mdc
+++ b/agents/presentation_coach/system_prompt.mdc
@@ -14,7 +14,7 @@ routing:
   trigger_command: /present
 context:
   file_globs:
-  - .cursor/agents/presentation_coach/**
+  - agents/presentation_coach/**
   - '**/*.ppt'
   - '**/*.pptx'
   - '**/*.md'

--- a/agents/psychologist/system_prompt.mdc
+++ b/agents/psychologist/system_prompt.mdc
@@ -16,7 +16,7 @@ routing:
   trigger_command: "/psy_session"
 context:
   file_globs:
-    - ".cursor/agents/psychologist/**"
+    - "agents/psychologist/**"
 static_skills:
   - "skill-psy-cbt.mdc"
   - "skill-psy-nvc.mdc"

--- a/agents/purchase_researcher/system_prompt.mdc
+++ b/agents/purchase_researcher/system_prompt.mdc
@@ -21,8 +21,7 @@ routing:
   trigger_command: /purchase
 context:
   file_globs:
-  - .cursor/agents/purchase_researcher/**
-  - .cursor/commands/purchase.md
+  - agents/purchase_researcher/**
 static_skills:
 - skill-analysis-critical.mdc
 - skill-purchase-research.mdc

--- a/agents/security_expert/system_prompt.mdc
+++ b/agents/security_expert/system_prompt.mdc
@@ -17,7 +17,7 @@ routing:
   trigger_command: /security_audit
 context:
   file_globs:
-  - .cursor/agents/security_expert/**
+  - agents/security_expert/**
   - '**/*.py'
   - '**/*.js'
   - '**/*.ts'

--- a/agents/semantic_expert/system_prompt.mdc
+++ b/agents/semantic_expert/system_prompt.mdc
@@ -15,7 +15,7 @@ routing:
   trigger_command: "/semantic_parse"
 context:
   file_globs:
-    - ".cursor/agents/semantic_expert/**"
+    - "agents/semantic_expert/**"
 static_skills:
   - "skill-analysis-critical.mdc"
   - "skill-content-structure.mdc"

--- a/agents/universal_agent/meta_prompt.md
+++ b/agents/universal_agent/meta_prompt.md
@@ -30,8 +30,8 @@ Your Structured Prompt MUST contain the sections:
     System Override at the end of the prompt to protect against context drift.
 
 6.  /// ROUTER INTEGRATION & AUTO-IMPLANTS (ROUTER + AUTO-IMPLANTS) ///
-    Insert a brief block that subordinates the agent to the router `.cursor/rules/00-router.mdc`:
-    - If the router activated implants and added `@.cursor/implants/implant-*.mdc`, the agent must follow these protocols.
+    Insert a brief block that subordinates the agent to the MCP engine router:
+    - If the router activated implants and added `@implants/implant-*.mdc`, the agent must follow these protocols.
     - If implants are not activated — the agent does not simulate them and does not add new `@`-connections without an explicit signal.
 
 Do not execute the user's task itself. Only write the PROMPT CODE.

--- a/agents/universal_agent/system_prompt.mdc
+++ b/agents/universal_agent/system_prompt.mdc
@@ -14,7 +14,7 @@ routing:
   trigger_command: "/universal"
 context:
   file_globs:
-    - ".cursor/agents/universal_agent/**"
+    - "agents/universal_agent/**"
 static_skills:
   - "skill-content-structure.mdc"
 preferred_skills:

--- a/agents/website_analyst/system_prompt.mdc
+++ b/agents/website_analyst/system_prompt.mdc
@@ -18,7 +18,7 @@ routing:
   trigger_command: "/site_audit"
 context:
   file_globs:
-    - ".cursor/agents/website_analyst/**/*"
+    - "agents/website_analyst/**/*"
 static_skills:
   - "skill-analysis-critical.mdc"
   - "skill-content-structure.mdc"
@@ -161,4 +161,4 @@ Use available tools to collect intelligence:
 - **Anti-hallucination**: NEVER fabricate traffic numbers, revenue estimates, stakeholder information, or funding data. If data cannot be found through tools, state "Data unavailable" rather than estimating. Clearly distinguish verified data from inferences.
 
 ## Skills
-- **Critical Analysis**: `.cursor/skills/skill-analysis-critical.mdc`
+- **Critical Analysis**: `skills/skill-analysis-critical.mdc`

--- a/scripts/cleanup_skills.py
+++ b/scripts/cleanup_skills.py
@@ -8,14 +8,9 @@ import re
 import sys
 from pathlib import Path
 
-from path_utils import resolve_path
-
 REPO_ROOT = Path(__file__).parent.parent
 
-SKILLS_DIR = resolve_path(
-    REPO_ROOT / "skills",
-    REPO_ROOT / ".cursor" / "skills",
-)
+SKILLS_DIR = REPO_ROOT / "skills"
 
 def process_skill_file(file_path: Path) -> bool:
     """Remove globs from a skill file."""

--- a/scripts/consolidate_prompts.py
+++ b/scripts/consolidate_prompts.py
@@ -10,14 +10,9 @@ import re
 import sys
 from pathlib import Path
 
-from path_utils import resolve_path
-
 REPO_ROOT = Path(__file__).parent.parent
 
-AGENTS_DIR = resolve_path(
-    REPO_ROOT / "agents",
-    REPO_ROOT / ".cursor" / "agents",
-)
+AGENTS_DIR = REPO_ROOT / "agents"
 
 def process_agent_prompt(file_path: Path) -> bool:
     """Process a single agent system_prompt.mdc file."""

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -208,17 +208,11 @@ fi
 
 print_header "🖥️  Cursor IDE & MCP Integration"
 
-# Detect asset directories (new root-level layout, fallback to legacy .cursor/)
+# Detect asset directories
 if [ -d "$REPO_ROOT/agents" ]; then
     AGENTS_BASE="$REPO_ROOT/agents"
     SKILLS_BASE="$REPO_ROOT/skills"
     IMPLANTS_BASE="$REPO_ROOT/implants"
-    COMMANDS_BASE="$REPO_ROOT/commands"
-elif [ -d "$REPO_ROOT/.cursor/agents" ]; then
-    AGENTS_BASE="$REPO_ROOT/.cursor/agents"
-    SKILLS_BASE="$REPO_ROOT/.cursor/skills"
-    IMPLANTS_BASE="$REPO_ROOT/.cursor/implants"
-    COMMANDS_BASE="$REPO_ROOT/.cursor/commands"
 else
     AGENTS_BASE=""
 fi
@@ -227,15 +221,13 @@ if [ -n "$AGENTS_BASE" ] && [ -d "$AGENTS_BASE" ]; then
     AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" | wc -l)
     SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
     IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
-    COMMAND_COUNT=$(find "$COMMANDS_BASE" -name "*.md" 2>/dev/null | wc -l)
 
     print_success "Agents directory found: $AGENTS_BASE"
     echo -e "    • ${CYAN}${AGENT_COUNT}${NC} agents"
     echo -e "    • ${CYAN}$SKILL_COUNT${NC} skills"
     echo -e "    • ${CYAN}$IMPLANT_COUNT${NC} implants"
-    echo -e "    • ${CYAN}$COMMAND_COUNT${NC} commands"
 else
-    print_error "Agents directory not found (checked agents/ and .cursor/agents/)"
+    print_error "Agents directory not found (checked agents/)"
 fi
 
 # Detect OS and set Cursor config path

--- a/scripts/path_utils.py
+++ b/scripts/path_utils.py
@@ -3,10 +3,6 @@
 from pathlib import Path
 
 
-def resolve_path(primary: Path, fallback: Path) -> Path:
-    """Use the new path if it exists, fall back to legacy .cursor/ path."""
-    if primary.exists():
-        return primary
-    if fallback.exists():
-        return fallback
+def resolve_path(primary: Path, fallback: Path = None) -> Path:
+    """Return the primary path. The fallback parameter is kept for call-site compatibility but ignored."""
     return primary

--- a/scripts/path_utils.py
+++ b/scripts/path_utils.py
@@ -1,8 +1,0 @@
-"""Shared path helpers for maintenance scripts."""
-
-from pathlib import Path
-
-
-def resolve_path(primary: Path, fallback: Path = None) -> Path:
-    """Return the primary path. The fallback parameter is kept for call-site compatibility but ignored."""
-    return primary

--- a/scripts/setup_github_mcp.sh
+++ b/scripts/setup_github_mcp.sh
@@ -14,7 +14,7 @@ echo -e "${BLUE}🔌 GitHub MCP Setup${NC}"
 
 # 2. Check/Build Binary
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/.cursor/mcp/github-mcp-server"
+MCP_DIR="$REPO_ROOT/.local/mcp/github-mcp-server"
 LOCAL_BINARY="$MCP_DIR/github-mcp-server"
 
 echo ""
@@ -82,7 +82,7 @@ echo "Updating configuration..."
 
 # Determine path to local github-mcp-server binary if it exists
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOCAL_BINARY="$REPO_ROOT/.cursor/mcp/github-mcp-server/github-mcp-server"
+LOCAL_BINARY="$REPO_ROOT/.local/mcp/github-mcp-server/github-mcp-server"
 
 # Python script to update JSON
 python3 -c "

--- a/scripts/validate_agents.py
+++ b/scripts/validate_agents.py
@@ -16,21 +16,13 @@ import yaml
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from path_utils import resolve_path
-
 # Add project root to path
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-AGENTS_DIR = resolve_path(
-    REPO_ROOT / "agents",
-    REPO_ROOT / ".cursor" / "agents",
-)
-SCHEMA_PATH = resolve_path(
-    REPO_ROOT / "agents" / "common" / "agent-schema.json",
-    REPO_ROOT / ".cursor" / "agents" / "common" / "agent-schema.json",
-)
+AGENTS_DIR = REPO_ROOT / "agents"
+SCHEMA_PATH = REPO_ROOT / "agents" / "common" / "agent-schema.json"
 
 def load_schema() -> dict:
     """Load the agent schema."""

--- a/skills/skill-clickup-markdown.mdc
+++ b/skills/skill-clickup-markdown.mdc
@@ -152,7 +152,7 @@ When generating ClickUp content:
 *📂 Repositories*
 
 *Agents* (main)
-[] `A .cursor/skills/skill-clickup-markdown.mdc` - new skill
+[] `A skills/skill-clickup-markdown.mdc` - new skill
 
 ---
 

--- a/skills/skill-fitness-programming.mdc
+++ b/skills/skill-fitness-programming.mdc
@@ -1,6 +1,6 @@
 ---
 description: Exercise programming methodology. Periodization, progressive overload, RPE/RIR, splits, biomechanics. Role: Program Designer.
-globs: [".cursor/agents/fitness_coach/**"]
+globs: ["agents/fitness_coach/**"]
 compiled: "Progressive overload. RPE 6-8. MEV 6-8 sets; MAV 12-18; MRV 20+. Neutral spine, hip hinge. McGill Big 3. Upper/Lower default. swap_exercise(); adjust_volume()."
 ---
 ## Role

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -1,7 +1,4 @@
 import os
-import logging
-
-logger = logging.getLogger(__name__)
 
 ENGINE_DIR = os.path.dirname(__file__)
 REPO_ROOT = os.path.abspath(os.path.join(ENGINE_DIR, "../.."))

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -10,32 +10,10 @@ CHROMA_PATH = os.path.join(REPO_ROOT, "chroma_db")
 EMBEDDING_MODEL = "BAAI/bge-m3"
 
 
-def _resolve_path(primary: str, fallback: str) -> str:
-    """Use the new path if it exists, fall back to legacy .cursor/ path."""
-    if os.path.exists(primary):
-        return primary
-    if os.path.exists(fallback):
-        logger.warning("Using legacy path %s — migrate to %s", fallback, primary)
-        return fallback
-    return primary
-
-
-AGENTS_DIR = _resolve_path(
-    os.path.join(REPO_ROOT, "agents"),
-    os.path.join(REPO_ROOT, ".cursor", "agents"),
-)
-SKILLS_DIR = _resolve_path(
-    os.path.join(REPO_ROOT, "skills"),
-    os.path.join(REPO_ROOT, ".cursor", "skills"),
-)
-IMPLANTS_DIR = _resolve_path(
-    os.path.join(REPO_ROOT, "implants"),
-    os.path.join(REPO_ROOT, ".cursor", "implants"),
-)
-CAPABILITIES_FILE = _resolve_path(
-    os.path.join(REPO_ROOT, "agents", "capabilities", "registry.yaml"),
-    os.path.join(REPO_ROOT, ".cursor", "capabilities", "registry.yaml"),
-)
+AGENTS_DIR = os.path.join(REPO_ROOT, "agents")
+SKILLS_DIR = os.path.join(REPO_ROOT, "skills")
+IMPLANTS_DIR = os.path.join(REPO_ROOT, "implants")
+CAPABILITIES_FILE = os.path.join(REPO_ROOT, "agents", "capabilities", "registry.yaml")
 
 ROUTER_SIMILARITY_THRESHOLD = 0.95
 SKILLS_RELEVANCE_THRESHOLD = 0.55

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -22,9 +22,6 @@ def resolve_path(path_ref: str) -> str:
             candidate_path = os.path.join(SKILLS_DIR, clean_ref[len("skills/"):])
         elif clean_ref.startswith("implants/"):
             candidate_path = os.path.join(IMPLANTS_DIR, clean_ref[len("implants/"):])
-        elif clean_ref.startswith(".cursor"):
-            # Legacy references — try resolving from repo root
-            candidate_path = os.path.join(REPO_ROOT, clean_ref)
         else:
             # Fallback: try repo root directly
             candidate_path = os.path.join(REPO_ROOT, clean_ref)


### PR DESCRIPTION
Replace .cursor/agents/, .cursor/skills/, .cursor/implants/ with their
new flat-structure equivalents (agents/, skills/, implants/) across 36
files. Remove obsolete .cursor/commands/ and .cursor/rules/ references
(Cursor IDE concepts no longer used). Drop legacy fallback logic from
Python engine and maintenance scripts.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it removes all legacy `.cursor/` fallbacks and rewires path resolution in the Python engine and setup scripts, which can break installs still using the old directory layout.
> 
> **Overview**
> Migrates the repo fully off the legacy `.cursor/` directory structure by updating agent prompts/docs and skill references to use the root-level `agents/`, `skills/`, and `implants/` paths, and clarifies that the standalone `core-protocol.mdc` is deprecated/no-op.
> 
> Removes legacy path-fallback logic from the Python engine (`src/engine/config.py`, `src/utils/prompt_loader.py`) and maintenance scripts, deletes `scripts/path_utils.py`, and updates setup/installer scripts to only detect/copy the new directories (including moving the GitHub MCP binary location to `.local/mcp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b26082b2b6fb3df747d72d85cf18c7a5566e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->