### PR TITLE
fix: universal MCP setup, YAML frontmatter fixes, robust MDC parser

### DIFF
--- a/agents/agent_builder/system_prompt.mdc
+++ b/agents/agent_builder/system_prompt.mdc
@@ -53,6 +53,14 @@ You are the **Agent Builder**, a specialized architect responsible for expanding
         *   Routing is handled via `trigger_command` in frontmatter — no separate rule or command files needed.
     *   **Skills**: Create `skills/skill-<new-skill>.mdc` if needed (without `globs` field).
         *   **Recommended**: Add `compiled:` field to skill frontmatter — a dense ~1-line actionable summary used in token-saving mode. The engine falls back to `description` if omitted.
+        *   **CRITICAL**: Always wrap `description` and `compiled` values in double quotes in YAML frontmatter. Unquoted values containing colons (e.g. `Role: Architect`) break the YAML parser with "mapping values are not allowed here" error.
+            ```yaml
+            # ✗ WRONG — will break YAML parsing
+            description: Security practices. OWASP, CIA Triad. Role: Auditor.
+            # ✓ CORRECT — always quote
+            description: "Security practices. OWASP, CIA Triad. Role: Auditor."
+            compiled: "Trust no input. Sanitize. Parameterized SQL."
+            ```
     *   **Capabilities**: If the new agent's skill set maps to an existing capability in `registry.yaml`, reuse it. If not, consider adding a new capability entry.
 
 4.  **INTERACTION EXAMPLE**

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -322,7 +322,7 @@ if [ "$SKIP_INSTALL" = false ]; then
     set +e
     python -c "
 import sys, os
-sys.path.insert(0, os.getcwd())
+sys.path.insert(0, '$REPO_ROOT')
 
 # 1. Download/cache the embedding model
 from sentence_transformers import SentenceTransformer

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -319,12 +319,14 @@ fi
 # Without this, first startup takes 30-60s for embedding generation,
 # causing Claude Desktop to time out with "Request timed out" (-32001).
 # Runs regardless of SKIP_INSTALL — .mdc files may have changed even if deps are unchanged.
-print_header "🧠 Pre-downloading Embedding Model & Indexing ChromaDB"
+# Respects --skip-chroma flag since indexing writes to ChromaDB on disk.
+if [ "$SKIP_CHROMA" = false ]; then
+    print_header "🧠 Pre-downloading Embedding Model & Indexing ChromaDB"
 
-print_step "Downloading BAAI/bge-m3 and indexing skills/implants..."
-print_step "(this may take a few minutes on first run)"
-set +e
-python -c "
+    print_step "Downloading BAAI/bge-m3 and indexing skills/implants..."
+    print_step "(this may take a few minutes on first run)"
+    set +e
+    python -c "
 import sys, os
 sys.path.insert(0, '$REPO_ROOT')
 
@@ -344,13 +346,16 @@ from src.engine.implants import ImplantRetriever
 ir = ImplantRetriever()
 print(f'Implants indexed: {ir.collection.count()} entries', flush=True)
 " 2>&1
-INDEX_EXIT=$?
-set -e
+    INDEX_EXIT=$?
+    set -e
 
-if [ $INDEX_EXIT -eq 0 ]; then
-    print_success "Embedding model cached, skills & implants indexed"
+    if [ $INDEX_EXIT -eq 0 ]; then
+        print_success "Embedding model cached, skills & implants indexed"
+    else
+        print_warn "Pre-indexing failed — it will run on first MCP server start"
+    fi
 else
-    print_warn "Pre-indexing failed — it will run on first MCP server start"
+    print_step "Skipping ChromaDB pre-indexing (--skip-chroma)"
 fi
 
 # ============== MCP Environment Detection & Configuration ==============

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -5,11 +5,12 @@
 # This script sets up the development environment after cloning.
 #
 # Usage:
-#   ./scripts/init_repo.sh [--skip-env] [--skip-chroma]
+#   ./scripts/init_repo.sh [--skip-env] [--skip-chroma] [--skip-mcp]
 #
 # Flags:
 #   --skip-env     Skip .env file creation (useful if already configured)
 #   --skip-chroma  Skip ChromaDB initialization
+#   --skip-mcp     Skip MCP environment detection and configuration
 #   --help         Show this help message
 
 set -e
@@ -34,6 +35,7 @@ PYTHON_MAX_VERSION_MINOR="13" # 3.13 is the first unsafe version
 # ============== Parse Arguments ==============
 SKIP_ENV=false
 SKIP_CHROMA=false
+SKIP_MCP=false
 
 for arg in "$@"; do
     case $arg in
@@ -45,8 +47,12 @@ for arg in "$@"; do
             SKIP_CHROMA=true
             shift
             ;;
+        --skip-mcp)
+            SKIP_MCP=true
+            shift
+            ;;
         --help|-h)
-            head -20 "$0" | tail -n +2 | sed 's/^# //' | sed 's/^#//'
+            sed -n '2,/^$/{ s/^# //; s/^#//; p; }' "$0"
             exit 0
             ;;
     esac
@@ -97,6 +103,44 @@ version_gte() {
 version_lt() {
     # Returns 0 (true) if $1 < $2
     ! version_gte "$1" "$2"
+}
+
+# Inject Agents-Core MCP server entry into a JSON config file.
+# Usage: inject_mcp_config <config_path> <label>
+inject_mcp_config() {
+    local config_path="$1"
+    local label="$2"
+
+    CLAUDE_CONFIG_PATH="$config_path" \
+    MCP_PYTHON="$PYTHON_ABS" \
+    MCP_SERVER="$SERVER_ABS" \
+    python3 -c "
+import json, os
+
+config_path = os.environ['CLAUDE_CONFIG_PATH']
+python_abs  = os.environ['MCP_PYTHON']
+server_abs  = os.environ['MCP_SERVER']
+
+try:
+    with open(config_path) as f:
+        config = json.load(f)
+except (json.JSONDecodeError, FileNotFoundError):
+    config = {}
+
+if 'mcpServers' not in config:
+    config['mcpServers'] = {}
+
+config['mcpServers']['Agents-Core'] = {
+    'command': python_abs,
+    'args': [server_abs],
+}
+
+with open(config_path, 'w') as f:
+    json.dump(config, f, indent=2, ensure_ascii=False)
+
+print('OK')
+" && print_success "Agents-Core added to $label" \
+  || { print_error "Failed to update $label"; return 1; }
 }
 
 # ============== Pre-flight Checks & Python Selection ==============
@@ -204,155 +248,6 @@ else
     print_step "Skipping .env configuration (--skip-env)"
 fi
 
-# ============== Cursor Integration & MCP Settings ==============
-
-print_header "🖥️  Cursor IDE & MCP Integration"
-
-# Detect asset directories
-if [ -d "$REPO_ROOT/agents" ]; then
-    AGENTS_BASE="$REPO_ROOT/agents"
-    SKILLS_BASE="$REPO_ROOT/skills"
-    IMPLANTS_BASE="$REPO_ROOT/implants"
-else
-    AGENTS_BASE=""
-fi
-
-if [ -n "$AGENTS_BASE" ] && [ -d "$AGENTS_BASE" ]; then
-    AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" | wc -l)
-    SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
-    IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
-
-    print_success "Agents directory found: $AGENTS_BASE"
-    echo -e "    • ${CYAN}${AGENT_COUNT}${NC} agents"
-    echo -e "    • ${CYAN}$SKILL_COUNT${NC} skills"
-    echo -e "    • ${CYAN}$IMPLANT_COUNT${NC} implants"
-else
-    print_error "Agents directory not found (checked agents/)"
-fi
-
-# Detect OS and set Cursor config path
-# Cursor now uses a global mcp.json in ~/.cursor/mcp.json
-if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    CURSOR_GLOBAL_DIR="$HOME/.cursor"
-    MCP_SETTINGS_FILE="$CURSOR_GLOBAL_DIR/mcp.json"
-else
-    print_warn "Unsupported OS for automatic MCP configuration: $OSTYPE"
-    CURSOR_GLOBAL_DIR=""
-fi
-
-if [ -n "$CURSOR_GLOBAL_DIR" ]; then
-    # Ensure ~/.cursor directory exists
-    if [ ! -d "$CURSOR_GLOBAL_DIR" ]; then
-        print_step "Creating $CURSOR_GLOBAL_DIR directory..."
-        mkdir -p "$CURSOR_GLOBAL_DIR"
-    fi
-
-    # Create empty mcp.json if not exists
-    if [ ! -f "$MCP_SETTINGS_FILE" ]; then
-        print_step "Creating new global MCP config..."
-        echo '{ "mcpServers": {} }' > "$MCP_SETTINGS_FILE"
-    fi
-
-    if [ -f "$MCP_SETTINGS_FILE" ]; then
-        print_step "Found global Cursor MCP settings at ~/.cursor/mcp.json"
-
-        # Backup existing settings
-        BACKUP_FILE="${MCP_SETTINGS_FILE}.backup.$(date +%s)"
-        cp "$MCP_SETTINGS_FILE" "$BACKUP_FILE"
-
-        # Merge MCP configs using Python
-        print_step "Merging MCP server configs..."
-
-        # Validate mcp.json first
-        MCP_CONFIG="$REPO_ROOT/mcp.json"
-        if [ -f "$MCP_CONFIG" ] && python3 -c "import json; json.load(open('$MCP_CONFIG'))" 2>/dev/null; then
-
-            # Export variables for Python script
-            export REPO_ROOT
-            export MCP_SETTINGS_FILE
-
-            python3 << 'PYTHON_SCRIPT'
-import json
-import sys
-import os
-
-repo_root = os.environ['REPO_ROOT']
-mcp_settings_file = os.environ['MCP_SETTINGS_FILE']
-mcp_json_path = os.path.join(repo_root, 'mcp.json')
-
-# Load existing Cursor settings
-try:
-    with open(mcp_settings_file, 'r') as f:
-        cursor_settings = json.load(f)
-except json.JSONDecodeError:
-    cursor_settings = {"mcpServers": {}}
-
-# Load our mcp.json
-with open(mcp_json_path, 'r') as f:
-    our_mcp = json.load(f)
-
-# Ensure mcpServers exists
-if 'mcpServers' not in cursor_settings:
-    cursor_settings['mcpServers'] = {}
-
-# Merge servers (convert relative paths to absolute)
-for server_name, server_config in our_mcp.get('mcpServers', {}).items():
-    # Convert relative command path to absolute
-    if server_config['command'].startswith('.venv/'):
-        server_config['command'] = os.path.join(repo_root, server_config['command'])
-
-    # Convert relative args to absolute
-    updated_args = []
-    for arg in server_config.get('args', []):
-        if arg.startswith('src/'):
-            updated_args.append(os.path.join(repo_root, arg))
-        else:
-            updated_args.append(arg)
-    server_config['args'] = updated_args
-
-    # Add or update
-    cursor_settings['mcpServers'][server_name] = server_config
-    print(f"  ✓ Added/Updated: {server_name}", file=sys.stderr)
-
-# Write back
-with open(mcp_settings_file, 'w') as f:
-    json.dump(cursor_settings, f, indent=2)
-
-print("SUCCESS", file=sys.stderr)
-PYTHON_SCRIPT
-
-            if [ $? -eq 0 ]; then
-                print_success "MCP servers added to ~/.cursor/mcp.json"
-            else
-                print_error "Failed to merge MCP settings"
-            fi
-        else
-            print_error "mcp.json missing or invalid"
-        fi
-
-    else
-        print_error "Failed to create/access $MCP_SETTINGS_FILE"
-    fi
-else
-    print_step "Skipping MCP injection (OS detection failed)"
-fi
-
-# ============== ChromaDB Initialization ==============
-
-print_header "🗄️  ChromaDB Initialization"
-
-CHROMA_PATH="$REPO_ROOT/chroma_db"
-
-if [ "$SKIP_CHROMA" = false ]; then
-    if [ -d "$CHROMA_PATH" ] && [ "$(ls -A $CHROMA_PATH 2>/dev/null)" ]; then
-        print_success "ChromaDB already initialized at $CHROMA_PATH"
-    else
-        print_step "ChromaDB will be initialized on first server run"
-    fi
-else
-    print_step "Skipping ChromaDB check (--skip-chroma)"
-fi
-
 # ============== Virtual Environment & Dependencies ==============
 
 print_header "🐍 Virtual Environment & Dependencies"
@@ -439,20 +334,279 @@ else
     print_step "Skipping package installation"
 fi
 
+# ============== MCP Environment Detection & Configuration ==============
+
+print_header "🔌 MCP Environment Detection & Configuration"
+
+# Absolute paths for MCP config entries
+PYTHON_ABS="$VENV_PATH/bin/python"
+SERVER_ABS="$REPO_ROOT/src/server.py"
+
+# Detect asset directories
+if [ -d "$REPO_ROOT/agents" ]; then
+    AGENTS_BASE="$REPO_ROOT/agents"
+    SKILLS_BASE="$REPO_ROOT/skills"
+    IMPLANTS_BASE="$REPO_ROOT/implants"
+else
+    AGENTS_BASE=""
+fi
+
+if [ -n "$AGENTS_BASE" ] && [ -d "$AGENTS_BASE" ]; then
+    AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" | wc -l)
+    SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
+    IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
+
+    print_success "Agents directory found: $AGENTS_BASE"
+    echo -e "    • ${CYAN}${AGENT_COUNT}${NC} agents"
+    echo -e "    • ${CYAN}$SKILL_COUNT${NC} skills"
+    echo -e "    • ${CYAN}$IMPLANT_COUNT${NC} implants"
+else
+    print_error "Agents directory not found (checked agents/)"
+fi
+
+if [ "$SKIP_MCP" = true ]; then
+    print_step "Skipping MCP configuration (--skip-mcp)"
+else
+    # Track which environments were configured
+    CONFIGURED_ENVS=()
+
+    echo ""
+    print_step "Detecting IDE environments..."
+    echo ""
+
+    # --- Detect Cursor ---
+    CURSOR_DETECTED=false
+    CURSOR_GLOBAL_DIR="$HOME/.cursor"
+    if [ -d "$CURSOR_GLOBAL_DIR" ]; then
+        CURSOR_DETECTED=true
+        print_success "Cursor IDE detected (~/.cursor/ exists)"
+    else
+        print_step "Cursor IDE not detected"
+    fi
+
+    # --- Detect Claude Desktop ---
+    CLAUDE_DESKTOP_DETECTED=false
+    CLAUDE_DESKTOP_DIR=""
+    CLAUDE_DESKTOP_CONFIG=""
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        CLAUDE_DESKTOP_DIR="$HOME/Library/Application Support/Claude"
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        CLAUDE_DESKTOP_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/Claude"
+    fi
+
+    if [ -n "$CLAUDE_DESKTOP_DIR" ] && [ -d "$CLAUDE_DESKTOP_DIR" ]; then
+        CLAUDE_DESKTOP_DETECTED=true
+        CLAUDE_DESKTOP_CONFIG="$CLAUDE_DESKTOP_DIR/claude_desktop_config.json"
+        print_success "Claude Desktop detected ($CLAUDE_DESKTOP_DIR)"
+    else
+        print_step "Claude Desktop not detected"
+    fi
+
+    # --- Detect Claude Code ---
+    CLAUDE_CODE_DETECTED=false
+    if check_command claude || [ -f "$HOME/.claude.json" ]; then
+        CLAUDE_CODE_DETECTED=true
+        print_success "Claude Code detected"
+    else
+        print_step "Claude Code not detected"
+    fi
+
+    echo ""
+
+    # --- Configure Cursor ---
+    if [ "$CURSOR_DETECTED" = true ]; then
+        print_step "Configuring Cursor MCP (~/.cursor/mcp.json)..."
+        MCP_SETTINGS_FILE="$CURSOR_GLOBAL_DIR/mcp.json"
+
+        if [ ! -f "$MCP_SETTINGS_FILE" ]; then
+            echo '{ "mcpServers": {} }' > "$MCP_SETTINGS_FILE"
+        fi
+
+        # Backup before modifying
+        cp "$MCP_SETTINGS_FILE" "${MCP_SETTINGS_FILE}.backup.$(date +%s)"
+
+        inject_mcp_config "$MCP_SETTINGS_FILE" "~/.cursor/mcp.json"
+        CONFIGURED_ENVS+=("Cursor")
+    fi
+
+    # --- Configure Claude Desktop ---
+    if [ "$CLAUDE_DESKTOP_DETECTED" = true ]; then
+        print_step "Configuring Claude Desktop MCP..."
+
+        if [ ! -f "$CLAUDE_DESKTOP_CONFIG" ]; then
+            echo '{}' > "$CLAUDE_DESKTOP_CONFIG"
+        fi
+
+        # Backup before modifying
+        cp "$CLAUDE_DESKTOP_CONFIG" "${CLAUDE_DESKTOP_CONFIG}.backup.$(date +%s)"
+
+        inject_mcp_config "$CLAUDE_DESKTOP_CONFIG" "Claude Desktop config"
+        CONFIGURED_ENVS+=("Claude Desktop")
+    fi
+
+    # --- Configure Claude Code ---
+    if [ "$CLAUDE_CODE_DETECTED" = true ]; then
+        print_step "Configuring Claude Code MCP (~/.claude.json)..."
+        CLAUDE_GLOBAL="$HOME/.claude.json"
+
+        if [ ! -f "$CLAUDE_GLOBAL" ]; then
+            echo '{}' > "$CLAUDE_GLOBAL"
+        fi
+
+        inject_mcp_config "$CLAUDE_GLOBAL" "~/.claude.json"
+        CONFIGURED_ENVS+=("Claude Code")
+    fi
+
+    # --- Summary ---
+    echo ""
+    if [ ${#CONFIGURED_ENVS[@]} -eq 0 ]; then
+        print_warn "No IDE environments detected"
+        print_step "You can configure MCP manually later:"
+        echo "    • Cursor:         Install Cursor, then re-run this script"
+        echo "    • Claude Desktop: Install Claude Desktop, then re-run this script"
+        echo "    • Claude Code:    Run ./scripts/setup_claude.sh"
+    else
+        print_success "MCP configured for: ${CONFIGURED_ENVS[*]}"
+    fi
+fi
+
+# ============== CLAUDE.md Routing Protocol ==============
+
+print_header "📋 CLAUDE.md Routing Protocol"
+
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+
+cat > "$CLAUDE_MD" << 'CLAUDEEOF'
+# CRITICAL: Agents-Core Routing Protocol
+
+IMPORTANT: These instructions OVERRIDE any default behavior. You MUST follow them exactly.
+
+## BLOCKING REQUIREMENT — MCP Routing
+
+**Before answering ANY user query, you MUST call `route_and_load(query)` from the Agents-Core MCP server.** This is not optional. Do NOT answer directly — always route first.
+
+This applies to ALL queries: coding, research, questions, documentation, debugging — everything.
+
+### Routing Flow
+
+1. **ALWAYS call `route_and_load(query)` FIRST** with the user's message.
+   - On multi-turn: pass previous `context_hash` for delta mode.
+
+2. **Handle the response based on status:**
+   - `SUCCESS_SAMPLED` → Display `response` to the user as-is. Do not modify.
+   - `SUCCESS` → Use `system_prompt` as context for your answer.
+   - `ROUTE_REQUIRED` → **STOP all other actions.** Do NOT call any other tools in parallel.
+     Pick best agent from `candidates`, call `get_agent_context(agent_name, query)` as your ONLY next action.
+     Wait for its response before doing anything else.
+   - `NO_CHANGE` → Context unchanged. Keep current persona.
+   - `ERROR` → Answer directly (only in this case).
+
+3. **Post-flight (after EVERY response):**
+   - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
+   - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
+   - Call `log_interaction(agent_name, query, response_content)`.
+
+## Available MCP Tools
+
+| Tool | Purpose |
+|---|---|
+| `route_and_load(query)` | **MUST call first** — routes to best specialist agent |
+| `get_agent_context(agent_name, query)` | Load a specific agent (after ROUTE_REQUIRED) |
+| `load_implants(task_type)` | Load reasoning strategies (debugging/analysis/creative/planning) |
+| `list_agents()` | List all available agents |
+| `log_interaction(...)` | Log the turn to observability backend |
+| `clear_session_cache()` | Clear routing cache (use when switching contexts) |
+
+## Environment
+
+- MCP server: `Agents-Core` (stdio transport, Python/FastMCP)
+- Agents: `agents/[name]/system_prompt.mdc`
+- Skills: `skills/skill-*.mdc`
+- Implants: `implants/implant-*.mdc`
+- Capabilities: `agents/capabilities/registry.yaml`
+- Config: `.env` (LANGFUSE_* optional, ANTHROPIC_API_KEY for document OCR)
+
+## Fallback (if MCP is unavailable)
+
+If `route_and_load` fails or Agents-Core MCP is not connected:
+1. Read `agents/` to find the right agent directory
+2. Read `agents/[name]/system_prompt.mdc`
+3. Follow the prompt manually
+CLAUDEEOF
+
+print_success "Created: CLAUDE.md"
+
+# ============== ChromaDB Initialization ==============
+
+print_header "🗄️  ChromaDB Initialization"
+
+CHROMA_PATH="$REPO_ROOT/chroma_db"
+
+if [ "$SKIP_CHROMA" = false ]; then
+    if [ -d "$CHROMA_PATH" ] && [ "$(ls -A $CHROMA_PATH 2>/dev/null)" ]; then
+        print_success "ChromaDB already initialized at $CHROMA_PATH"
+    else
+        print_step "ChromaDB will be initialized on first server run"
+    fi
+else
+    print_step "Skipping ChromaDB check (--skip-chroma)"
+fi
+
 # ============== Final Summary ==============
 
 print_header "✅ Initialization Complete!"
 
 echo ""
+echo -e "  ${GREEN}What was configured:${NC}"
+
+if [ "$SKIP_MCP" = false ] && [ ${#CONFIGURED_ENVS[@]} -gt 0 ]; then
+    for env in "${CONFIGURED_ENVS[@]}"; do
+        echo -e "    ${GREEN}✓${NC} $env — MCP server registered"
+    done
+elif [ "$SKIP_MCP" = true ]; then
+    echo -e "    ${YELLOW}⚠${NC} MCP configuration skipped (--skip-mcp)"
+else
+    echo -e "    ${YELLOW}⚠${NC} No IDE environments were detected"
+fi
+echo -e "    ${GREEN}✓${NC} CLAUDE.md — routing protocol for Claude agents"
+
+echo ""
 echo -e "  ${GREEN}Next steps:${NC}"
 echo ""
-echo "  1. Configure API keys in .env (if you haven't yet):"
+
+STEP=1
+
+echo "  $STEP. Configure API keys in .env (if you haven't yet):"
 echo -e "     ${CYAN}nano $ENV_FILE${NC}"
 echo ""
-echo "  2. Restart Cursor IDE to activate new MCP servers"
-echo ""
-echo "  3. Test with a command:"
-echo -e "     ${CYAN}/route${NC} - check available agents"
+STEP=$((STEP + 1))
+
+# Dynamic restart/start instructions per environment
+if [ "$SKIP_MCP" = false ] && [ ${#CONFIGURED_ENVS[@]} -gt 0 ]; then
+    for env in "${CONFIGURED_ENVS[@]}"; do
+        case "$env" in
+            "Cursor")
+                echo "  $STEP. Restart Cursor IDE to activate MCP servers"
+                echo ""
+                STEP=$((STEP + 1))
+                ;;
+            "Claude Desktop")
+                echo "  $STEP. Restart Claude Desktop to activate MCP servers"
+                echo ""
+                STEP=$((STEP + 1))
+                ;;
+            "Claude Code")
+                echo "  $STEP. Start Claude Code in this directory:"
+                echo -e "     ${CYAN}cd $REPO_ROOT && claude${NC}"
+                echo ""
+                STEP=$((STEP + 1))
+                ;;
+        esac
+    done
+fi
+
+echo "  $STEP. Test with a command:"
+echo -e "     ${CYAN}/route${NC} — check available agents"
 echo ""
 
 # ============== Health Check ==============
@@ -460,7 +614,7 @@ echo ""
 if [ -f "$ENV_FILE" ]; then
     source "$ENV_FILE" 2>/dev/null || true
     if [ -z "$ANTHROPIC_API_KEY" ] || [ "$ANTHROPIC_API_KEY" = "sk-ant-..." ]; then
-        print_warn "ANTHROPIC_API_KEY not configured - document OCR will be unavailable"
+        print_warn "ANTHROPIC_API_KEY not configured — document OCR will be unavailable"
     fi
 fi
 

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -312,23 +312,40 @@ if [ "$SKIP_INSTALL" = false ]; then
 
     print_success "All dependencies installed"
 
-    # Pre-download embedding model so MCP server starts instantly
-    print_header "🧠 Pre-downloading Embedding Model"
+    # Pre-download embedding model AND pre-index ChromaDB so MCP server starts instantly.
+    # Without this, first startup takes 30-60s for embedding generation,
+    # causing Claude Desktop to time out with "Request timed out" (-32001).
+    print_header "🧠 Pre-downloading Embedding Model & Indexing ChromaDB"
 
-    print_step "Downloading BAAI/bge-m3 (this may take a few minutes on first run)..."
+    print_step "Downloading BAAI/bge-m3 and indexing skills/implants..."
+    print_step "(this may take a few minutes on first run)"
     set +e
     python -c "
+import sys, os
+sys.path.insert(0, os.getcwd())
+
+# 1. Download/cache the embedding model
 from sentence_transformers import SentenceTransformer
 model = SentenceTransformer('BAAI/bge-m3')
-print('Model ready')
+print('Embedding model ready')
+
+# 2. Pre-index skills and implants into ChromaDB
+from src.engine.skills import SkillRetriever
+from src.engine.implants import ImplantRetriever
+
+sr = SkillRetriever()
+print(f'Skills indexed: {sr.collection.count()} entries')
+
+ir = ImplantRetriever()
+print(f'Implants indexed: {ir.collection.count()} entries')
 " 2>&1
-    MODEL_EXIT=$?
+    INDEX_EXIT=$?
     set -e
 
-    if [ $MODEL_EXIT -eq 0 ]; then
-        print_success "Embedding model cached and ready"
+    if [ $INDEX_EXIT -eq 0 ]; then
+        print_success "Embedding model cached, skills & implants indexed"
     else
-        print_warn "Model download failed — it will be downloaded on first MCP server start"
+        print_warn "Pre-indexing failed — it will run on first MCP server start"
     fi
 else
     print_step "Skipping package installation"

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -114,7 +114,7 @@ inject_mcp_config() {
     CLAUDE_CONFIG_PATH="$config_path" \
     MCP_PYTHON="$PYTHON_ABS" \
     MCP_SERVER="$SERVER_ABS" \
-    python3 -c "
+    python -c "
 import json, os
 
 config_path = os.environ['CLAUDE_CONFIG_PATH']
@@ -442,8 +442,9 @@ else
         # Backup before modifying
         cp "$MCP_SETTINGS_FILE" "${MCP_SETTINGS_FILE}.backup.$(date +%s)"
 
-        inject_mcp_config "$MCP_SETTINGS_FILE" "~/.cursor/mcp.json"
-        CONFIGURED_ENVS+=("Cursor")
+        if inject_mcp_config "$MCP_SETTINGS_FILE" "~/.cursor/mcp.json"; then
+            CONFIGURED_ENVS+=("Cursor")
+        fi
     fi
 
     # --- Configure Claude Desktop ---
@@ -457,8 +458,9 @@ else
         # Backup before modifying
         cp "$CLAUDE_DESKTOP_CONFIG" "${CLAUDE_DESKTOP_CONFIG}.backup.$(date +%s)"
 
-        inject_mcp_config "$CLAUDE_DESKTOP_CONFIG" "Claude Desktop config"
-        CONFIGURED_ENVS+=("Claude Desktop")
+        if inject_mcp_config "$CLAUDE_DESKTOP_CONFIG" "Claude Desktop config"; then
+            CONFIGURED_ENVS+=("Claude Desktop")
+        fi
     fi
 
     # --- Configure Claude Code ---
@@ -470,8 +472,12 @@ else
             echo '{}' > "$CLAUDE_GLOBAL"
         fi
 
-        inject_mcp_config "$CLAUDE_GLOBAL" "~/.claude.json"
-        CONFIGURED_ENVS+=("Claude Code")
+        # Backup before modifying
+        cp "$CLAUDE_GLOBAL" "${CLAUDE_GLOBAL}.backup.$(date +%s)"
+
+        if inject_mcp_config "$CLAUDE_GLOBAL" "~/.claude.json"; then
+            CONFIGURED_ENVS+=("Claude Code")
+        fi
     fi
 
     # --- Summary ---

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -311,44 +311,46 @@ if [ "$SKIP_INSTALL" = false ]; then
     echo ""
 
     print_success "All dependencies installed"
+else
+    print_step "Skipping package installation"
+fi
 
-    # Pre-download embedding model AND pre-index ChromaDB so MCP server starts instantly.
-    # Without this, first startup takes 30-60s for embedding generation,
-    # causing Claude Desktop to time out with "Request timed out" (-32001).
-    print_header "🧠 Pre-downloading Embedding Model & Indexing ChromaDB"
+# Pre-download embedding model AND pre-index ChromaDB so MCP server starts instantly.
+# Without this, first startup takes 30-60s for embedding generation,
+# causing Claude Desktop to time out with "Request timed out" (-32001).
+# Runs regardless of SKIP_INSTALL — .mdc files may have changed even if deps are unchanged.
+print_header "🧠 Pre-downloading Embedding Model & Indexing ChromaDB"
 
-    print_step "Downloading BAAI/bge-m3 and indexing skills/implants..."
-    print_step "(this may take a few minutes on first run)"
-    set +e
-    python -c "
+print_step "Downloading BAAI/bge-m3 and indexing skills/implants..."
+print_step "(this may take a few minutes on first run)"
+set +e
+python -c "
 import sys, os
 sys.path.insert(0, '$REPO_ROOT')
 
 # 1. Download/cache the embedding model
 from sentence_transformers import SentenceTransformer
 model = SentenceTransformer('BAAI/bge-m3')
-print('Embedding model ready')
+print('Embedding model ready', flush=True)
 
 # 2. Pre-index skills and implants into ChromaDB
+print('Indexing skills...', flush=True)
 from src.engine.skills import SkillRetriever
-from src.engine.implants import ImplantRetriever
-
 sr = SkillRetriever()
-print(f'Skills indexed: {sr.collection.count()} entries')
+print(f'Skills indexed: {sr.collection.count()} entries', flush=True)
 
+print('Indexing implants...', flush=True)
+from src.engine.implants import ImplantRetriever
 ir = ImplantRetriever()
-print(f'Implants indexed: {ir.collection.count()} entries')
+print(f'Implants indexed: {ir.collection.count()} entries', flush=True)
 " 2>&1
-    INDEX_EXIT=$?
-    set -e
+INDEX_EXIT=$?
+set -e
 
-    if [ $INDEX_EXIT -eq 0 ]; then
-        print_success "Embedding model cached, skills & implants indexed"
-    else
-        print_warn "Pre-indexing failed — it will run on first MCP server start"
-    fi
+if [ $INDEX_EXIT -eq 0 ]; then
+    print_success "Embedding model cached, skills & implants indexed"
 else
-    print_step "Skipping package installation"
+    print_warn "Pre-indexing failed — it will run on first MCP server start"
 fi
 
 # ============== MCP Environment Detection & Configuration ==============

--- a/skills/skill-3d-platforms.mdc
+++ b/skills/skill-3d-platforms.mdc
@@ -1,5 +1,5 @@
 ---
-description: Comprehensive registry of 3D printable model platforms with search strategies and quality indicators.
+description: "Comprehensive registry of 3D printable model platforms with search strategies and quality indicators."
 compiled: "Tier1: Printables, Thingiverse, Thangs, MyMiniFactory, Cults3D. PQRS: P40% Q30% R20% S10%. sort:most_makes. License check. CC-BY/CC0."
 ---
 # Skill: 3D Print Platforms

--- a/skills/skill-analysis-critical.mdc
+++ b/skills/skill-analysis-critical.mdc
@@ -1,5 +1,5 @@
 ---
-description: Critical analysis method selector. Maps validation needs to reasoning implants. Role: Logic Auditor.
+description: "Critical analysis method selector. Maps validation needs to reasoning implants. Role: Logic Auditor."
 compiled: "Factual claims→CoV. Argument→LoT. Complex problem→Step-Back. High-stakes→Reflexion. Trust but verify."
 alwaysApply: false
 ---

--- a/skills/skill-bio-mechanism.mdc
+++ b/skills/skill-bio-mechanism.mdc
@@ -1,5 +1,5 @@
 ---
-description: Systemic approach to biology requiring mechanistic explanations. Systems Biology, Homeostasis, Neurotransmitters. Role: Systems Biologist.
+description: "Systemic approach to biology requiring mechanistic explanations. Systems Biology, Homeostasis, Neurotransmitters. Role: Systems Biologist."
 compiled: "Mechanism first. Pathway before supplement. Correlation≠causation. Cite half-life. trace_pathway(); check_interactions()."
 ---
 ## Role

--- a/skills/skill-bio-protocols.mdc
+++ b/skills/skill-bio-protocols.mdc
@@ -1,5 +1,5 @@
 ---
-description: Standardized format for actionable health interventions. MED, Hormesis, Stacking. Role: Clinical Coach.
+description: "Standardized format for actionable health interventions. MED, Hormesis, Stacking. Role: Clinical Coach."
 compiled: "Dosage+Timing+Duration. Safety Stop always. MED. 'Not medical advice' disclaimer. JSON: Intervention, Dosage, Timing, Duration, Contraindications."
 ---
 ## Role

--- a/skills/skill-blender-scripting.mdc
+++ b/skills/skill-blender-scripting.mdc
@@ -1,5 +1,5 @@
 ---
-description: Blender Python (bpy) scripting patterns and 3D printing best practices for procedural object generation.
+description: "Blender Python (bpy) scripting patterns and 3D printing best practices for procedural object generation."
 compiled: "bmesh>bpy.ops in loops. Manifold: watertight, normals out, no self-intersect. Min wall: FDM 1.2mm, SLA 0.8mm. Apply modifiers before export. validate_printability()."
 globs: ["**/*blender*", "**/*bpy*", "**/*.blend"]
 ---

--- a/skills/skill-clickup-markdown.mdc
+++ b/skills/skill-clickup-markdown.mdc
@@ -1,5 +1,5 @@
 ---
-description: ClickUp-specific Markdown formatting rules and quirks. Use when generating content for ClickUp tasks/comments.
+description: "ClickUp-specific Markdown formatting rules and quirks. Use when generating content for ClickUp tasks/comments."
 compiled: "[] not -[ ]. *bold* not **bold**. *Header* not ##. Single newlines. --- with blank lines. Russian default. Inline backticks."
 ---
 # Skill: ClickUp Markdown

--- a/skills/skill-content-structure.mdc
+++ b/skills/skill-content-structure.mdc
@@ -1,5 +1,5 @@
 ---
-description: Principles of effective communication and text organization. Minto Pyramid, BLUF, MECE. Role: Editor.
+description: "Principles of effective communication and text organization. Minto Pyramid, BLUF, MECE. Role: Editor."
 compiled: "BLUF. Minto(answer→args→evidence). MECE. Atomic paragraphs. Skimmable headers+bullets+bold. compress()."
 ---
 ## Role

--- a/skills/skill-decision-frameworks.mdc
+++ b/skills/skill-decision-frameworks.mdc
@@ -1,5 +1,5 @@
 ---
-description: Decision Frameworks. Inversion, Eisenhower Matrix, Reversibility Test, Devil's Advocate. Role: Decision Architect.
+description: "Decision Frameworks. Inversion, Eisenhower Matrix, Reversibility Test, Devil's Advocate. Role: Decision Architect."
 compiled: "Inversion: what guarantees failure? Avoid that. Reversible=act fast. Irreversible=deliberate. Eisenhower: urgent≠important. Devil's Advocate: steel-man opposing view. For Pre-Mortem→implant-premortem. For 2nd-order→implant-second-order-thinking."
 ---
 ## Role

--- a/skills/skill-dev-api-design.mdc
+++ b/skills/skill-dev-api-design.mdc
@@ -1,5 +1,5 @@
 ---
-description: API Design Patterns. REST, GraphQL, gRPC. Schema design, versioning, error responses, pagination. Role: API Architect.
+description: "API Design Patterns. REST, GraphQL, gRPC. Schema design, versioning, error responses, pagination. Role: API Architect."
 compiled: "REST: nouns not verbs, plural resources, HTTP verbs=CRUD. Status codes matter. Pagination=cursor-based. Version in URL or header. Error={code,message,details}. HATEOAS for discoverability."
 globs: ["**/routes/**", "**/api/**", "**/controllers/**", "**/endpoints/**"]
 ---

--- a/skills/skill-dev-clean-code.mdc
+++ b/skills/skill-dev-clean-code.mdc
@@ -1,5 +1,5 @@
 ---
-description: Universal standards for maintainable code. Covers SOLID, DRY, KISS, YAGNI, Boy Scout Rule. Code smells and refactoring patterns. Role: Principal Engineer.
+description: "Universal standards for maintainable code. Covers SOLID, DRY, KISS, YAGNI, Boy Scout Rule. Code smells and refactoring patterns. Role: Principal Engineer."
 compiled: "SOLID, DRY, KISS, YAGNI. One function=one thing. Constants not magic. Descriptive names. No dead code. Smell→refactoring map. refactor(); document why."
 globs: ["**/*.py", "**/*.ts", "**/*.js", "**/*.go", "**/*.java", "**/*.rs"]
 ---

--- a/skills/skill-dev-debugging.mdc
+++ b/skills/skill-dev-debugging.mdc
@@ -1,5 +1,5 @@
 ---
-description: Structured approach to identifying and resolving software defects. Scientific Method, Root Cause Analysis, Binary Search. Role: Detective.
+description: "Structured approach to identifying and resolving software defects. Scientific Method, Root Cause Analysis, Binary Search. Role: Detective."
 compiled: "Hypothesis→test. Reproduce first. Full stack trace. One variable at a time. isolate(); log(); assert(). Binary search; 5 Whys."
 ---
 ## Role

--- a/skills/skill-dev-performance.mdc
+++ b/skills/skill-dev-performance.mdc
@@ -1,5 +1,5 @@
 ---
-description: Performance Engineering. Profiling, bottleneck identification, optimization patterns, benchmarking. Role: Performance Engineer.
+description: "Performance Engineering. Profiling, bottleneck identification, optimization patterns, benchmarking. Role: Performance Engineer."
 compiled: "Measure first. Profile before optimizing. Benchmark before/after. Amdahl's law: optimize the bottleneck. Premature optimization=root of evil. Cache hot paths. Batch I/O. Async where possible."
 ---
 ## Role

--- a/skills/skill-dev-security.mdc
+++ b/skills/skill-dev-security.mdc
@@ -1,5 +1,5 @@
 ---
-description: Fundamental security practices. OWASP, Input Validation, Secrets Management, CIA Triad. Role: Security Auditor.
+description: "Fundamental security practices. OWASP, Input Validation, Secrets Management, CIA Triad. Role: Security Auditor."
 compiled: "Trust no input. sanitize(); parameterized SQL; encode output. No secrets in repo. CIA: Confidentiality, Integrity, Availability. Least privilege."
 globs: ["**/*.py", "**/*.ts", "**/*.js", "**/*.go"]
 ---

--- a/skills/skill-dev-testing.mdc
+++ b/skills/skill-dev-testing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Testing Methodologies. Unit, Integration, E2E, Property-Based, TDD/BDD workflow. Role: Test Architect.
+description: "Testing Methodologies. Unit, Integration, E2E, Property-Based, TDD/BDD workflow. Role: Test Architect."
 compiled: "TDD: Red→Green→Refactor. Unit=isolated logic. Integration=boundaries. E2E=critical paths only. AAA pattern. No test interdependency. Mock at boundaries, not internals. Coverage≠quality."
 globs: ["**/*_test.*", "**/*.test.*", "**/*.spec.*", "**/__tests__/**", "**/tests/**", "**/test/**"]
 ---

--- a/skills/skill-error-recovery.mdc
+++ b/skills/skill-error-recovery.mdc
@@ -1,5 +1,5 @@
 ---
-description: Error Recovery Protocol. Universal error handling for all agents. Classify errors, apply recovery strategies, never silently fail.
+description: "Error Recovery Protocol. Universal error handling for all agents. Classify errors, apply recovery strategies, never silently fail."
 compiled: "Classify error (tool/input/knowledge/conflict). Tool fail→explain+alternative. Ambiguous input→ask clarification. Knowledge gap→say 'I don't know'. Conflict→present both sides. Never silently fail."
 ---
 ## Role

--- a/skills/skill-fact-verification.mdc
+++ b/skills/skill-fact-verification.mdc
@@ -1,5 +1,5 @@
 ---
-description: Fact Verification Protocol. Source Triangulation, Chain-of-Verification, Temporal Coherence, Anomaly Detection. Role: Fact Checker.
+description: "Fact Verification Protocol. Source Triangulation, Chain-of-Verification, Temporal Coherence, Anomaly Detection. Role: Fact Checker."
 compiled: "1 source=UNVERIFIED; 2=PROBABLE; 3+=VERIFIED. Independent sources only. >30% anomaly→triple verify. Failed→silent discard. triangulate(); verify_chain(); check_temporal()."
 ---
 ## Role

--- a/skills/skill-fitness-programming.mdc
+++ b/skills/skill-fitness-programming.mdc
@@ -1,5 +1,5 @@
 ---
-description: Exercise programming methodology. Periodization, progressive overload, RPE/RIR, splits, biomechanics. Role: Program Designer.
+description: "Exercise programming methodology. Periodization, progressive overload, RPE/RIR, splits, biomechanics. Role: Program Designer."
 globs: ["agents/fitness_coach/**"]
 compiled: "Progressive overload. RPE 6-8. MEV 6-8 sets; MAV 12-18; MRV 20+. Neutral spine, hip hinge. McGill Big 3. Upper/Lower default. swap_exercise(); adjust_volume()."
 ---

--- a/skills/skill-git-conventions.mdc
+++ b/skills/skill-git-conventions.mdc
@@ -1,5 +1,5 @@
 ---
-description: Git Commit Conventions. Conventional Commits, Atomic Commits.
+description: "Git Commit Conventions. Conventional Commits, Atomic Commits."
 compiled: "type(scope): subject. feat|fix|docs|style|refactor|perf|test|chore. Imperative. 72-char wrap. One change per commit."
 globs: ["**/CHANGELOG*", "**/.gitignore"]
 ---

--- a/skills/skill-mermaid-best-practices.mdc
+++ b/skills/skill-mermaid-best-practices.mdc
@@ -1,5 +1,5 @@
 ---
-description: Best practices for creating compact, human-readable Mermaid diagrams. Covers flowcharts, sequence, ER, Gantt, class diagrams. Role: Visualization Expert.
+description: "Best practices for creating compact, human-readable Mermaid diagrams. Covers flowcharts, sequence, ER, Gantt, class diagrams. Role: Visualization Expert."
 compiled: "graph TD/LR. subgraph. Short labels (1-4 words). Short IDs. A-->B-->C. A&B-->C. Minimize crossings. sequenceDiagram for interactions. erDiagram for data models. Choose diagram type by data type."
 globs: ["**/*.mmd", "**/*.mermaid"]
 ---

--- a/skills/skill-product-frameworks.mdc
+++ b/skills/skill-product-frameworks.mdc
@@ -1,5 +1,5 @@
 ---
-description: Product Management Frameworks. RICE, MoSCoW, User Stories, PRD, OKR, Jobs-to-be-Done. Role: Product Strategist.
+description: "Product Management Frameworks. RICE, MoSCoW, User Stories, PRD, OKR, Jobs-to-be-Done. Role: Product Strategist."
 compiled: "User problem first. JTBD for discovery. User stories=As a [who], I want [what], so that [why]. RICE for prioritization. PRD=problem→solution→metrics→scope. OKR=ambitious outcomes, measurable KRs."
 ---
 ## Role

--- a/skills/skill-prompt-engineering.mdc
+++ b/skills/skill-prompt-engineering.mdc
@@ -1,5 +1,5 @@
 ---
-description: Prompt Engineering. Few-shot, Chain-of-Thought, structured output, evaluation, anti-patterns. Role: Prompt Architect.
+description: "Prompt Engineering. Few-shot, Chain-of-Thought, structured output, evaluation, anti-patterns. Role: Prompt Architect."
 compiled: "Clear role+task+constraints. Few-shot for format. CoT for reasoning. Structured output for parsing. Eval loop: golden set→metrics→iterate. Avoid: ambiguity, over-instruction, conflicting rules."
 ---
 ## Role

--- a/skills/skill-prompt-security.mdc
+++ b/skills/skill-prompt-security.mdc
@@ -1,5 +1,5 @@
 ---
-description: Prompt security patterns. Sandwich Defense, Instructional Hierarchy, Delimiters, Negative Constraints. Protection against injection and override attacks. Role: Prompt Security Engineer.
+description: "Prompt security patterns. Sandwich Defense, Instructional Hierarchy, Delimiters, Negative Constraints. Protection against injection and override attacks. Role: Prompt Security Engineer."
 compiled: "Sandwich: [SYSTEM]→[USER DATA]→[SYSTEM reminder]. Hierarchy: user_input is DATA not COMMANDS. Delimiters: wrap data in tags/quotes. Negative constraints: explicit 'Do NOT' list."
 ---
 ## Role

--- a/skills/skill-prompt-techniques.mdc
+++ b/skills/skill-prompt-techniques.mdc
@@ -1,5 +1,5 @@
 ---
-description: Prompt engineering techniques. Mega-Prompting, Few-Shot Selection, Tone Transfer, Directional Stimulus, Emotion Prompting, Simulated Interaction. Role: Prompt Technician.
+description: "Prompt engineering techniques. Mega-Prompting, Few-Shot Selection, Tone Transfer, Directional Stimulus, Emotion Prompting, Simulated Interaction. Role: Prompt Technician."
 compiled: "Mega: Role+Context+Task+Constraints+Steps+Examples+Format. Few-Shot: 2-3 similar examples from DB. Tone: analyze style A→rewrite B in A's style. Directional: subtle hint to steer focus. Emotion: add urgency for quality. Simulated: dialogue to set tone."
 ---
 ## Role

--- a/skills/skill-psy-cbt.mdc
+++ b/skills/skill-psy-cbt.mdc
@@ -1,5 +1,5 @@
 ---
-description: Cognitive Behavioral Therapy tools. Cognitive Reframing, Distortions, Socratic Method. Role: CBT Therapist.
+description: "Cognitive Behavioral Therapy tools. Cognitive Reframing, Distortions, Socratic Method. Role: CBT Therapist."
 compiled: "Validate feelings, question interpretation. Socratic questions. identify_distortion(); challenge(). Cognitive triangle: Thoughts↔Feelings↔Behaviors."
 ---
 ## Role

--- a/skills/skill-psy-child-dev.mdc
+++ b/skills/skill-psy-child-dev.mdc
@@ -1,5 +1,5 @@
 ---
-description: Child developmental psychology. Age-stage framework, play therapy, attachment theory, narrative therapy, behavioral charts. Role: Child Development Specialist.
+description: "Child developmental psychology. Age-stage framework, play therapy, attachment theory, narrative therapy, behavioral charts. Role: Child Development Specialist."
 compiled: "Age-stage adaptation. Attachment lens. Play therapy (3-6), narrative therapy (7-11), MI+CBT (12-17). Normalize before pathologize. Behavioral charts for school age. Authoritative parenting."
 ---
 ## Role

--- a/skills/skill-psy-digital-wellbeing.mdc
+++ b/skills/skill-psy-digital-wellbeing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Digital environment psychology for children and adolescents. Screen time, social media, cyberbullying, gaming addiction, dopamine economy, parasocial relationships. Role: Digital Wellbeing Analyst.
+description: "Digital environment psychology for children and adolescents. Screen time, social media, cyberbullying, gaming addiction, dopamine economy, parasocial relationships. Role: Digital Wellbeing Analyst."
 compiled: "Screen quality > quantity. Dopamine loops: infinite scroll, notifications, loot boxes. Parasocial relationships. FOMO/social comparison. Cyberbullying intervention. Digital literacy by age. Co-viewing. Tech-free zones. No surveillance — transparent agreements."
 ---
 ## Role

--- a/skills/skill-psy-nvc.mdc
+++ b/skills/skill-psy-nvc.mdc
@@ -1,5 +1,5 @@
 ---
-description: Non-Violent Communication framework. OFNR, Empathy, Conflict Resolution. Role: Mediator.
+description: "Non-Violent Communication framework. OFNR, Empathy, Conflict Resolution. Role: Mediator."
 compiled: "I-statements. Observation≠Evaluation. Feelings→Needs. OFNR: Observation, Feeling, Need, Request. translate(): Judgment→NVC."
 ---
 ## Role

--- a/skills/skill-reasoning-logic.mdc
+++ b/skills/skill-reasoning-logic.mdc
@@ -1,5 +1,5 @@
 ---
-description: Logical reasoning and argumentation. Fallacy detection, argument strength rating, First Principles, Occam's Razor, Hanlon's Razor. Role: Logic Auditor.
+description: "Logical reasoning and argumentation. Fallacy detection, argument strength rating, First Principles, Occam's Razor, Hanlon's Razor. Role: Logic Auditor."
 compiled: "Attack argument not person. Find enthymemes. Fact vs opinion. First principles. Occam's Razor. Hanlon's Razor. 8 fallacies table. Strength 1-5. deconstruct(); falsify(); rate_strength()."
 alwaysApply: false
 ---

--- a/skills/skill-roblox-development.mdc
+++ b/skills/skill-roblox-development.mdc
@@ -1,5 +1,5 @@
 ---
-description: Roblox development best practices. Covers Luau patterns, Roblox API, anti-exploit, performance, DataStore, networking. Role: Roblox Game Developer. Competency: Expert.
+description: "Roblox development best practices. Covers Luau patterns, Roblox API, anti-exploit, performance, DataStore, networking. Role: Roblox Game Developer. Competency: Expert."
 compiled: "Server authority. Never trust client. pcall DataStore. Object pooling. Debounce. RemoteEvent vs RemoteFunction. WaitForChild; :Destroy() not Parent=nil."
 globs: ["**/*.lua", "**/*.luau", "**/*.rbxl", "**/*.rbxlx"]
 ---

--- a/skills/skill-tech-writing.mdc
+++ b/skills/skill-tech-writing.mdc
@@ -1,5 +1,5 @@
 ---
-description: Technical Writing and Documentation Best Practices. Clarity, Conciseness, Markdown, API docs, audience adaptation.
+description: "Technical Writing and Documentation Best Practices. Clarity, Conciseness, Markdown, API docs, audience adaptation."
 compiled: "Clarity; conciseness; consistency. Active voice. H1>H2>H3. Bullets for items; numbers for steps. Code: specify language. Audience-first: adapt depth."
 ---
 ## Principles

--- a/skills/skill-temporal-validation.mdc
+++ b/skills/skill-temporal-validation.mdc
@@ -1,5 +1,5 @@
 ---
-description: Temporal Validation Skill: Logic for validating timestamps and event freshness
+description: "Temporal Validation Skill: Logic for validating timestamps and event freshness"
 compiled: "Fresh ≤24h; Recent 24-48h; Stale >48h discard. Unknown→triple verify. UTC. No date on anomaly→assume old until proven."
 ---
 # Temporal Validation Skill

--- a/src/engine/implants.py
+++ b/src/engine/implants.py
@@ -5,6 +5,7 @@ import hashlib
 import yaml
 from src.utils.langfuse_compat import observe
 from typing import List, Dict, Any, Optional
+from src.utils.prompt_loader import split_frontmatter
 
 from src.engine.config import IMPLANTS_DIR, IMPLANTS_RELEVANCE_THRESHOLD, CHROMA_PATH
 from src.engine.chroma import get_chroma_client, get_embedding_fn
@@ -75,14 +76,13 @@ class ImplantRetriever:
                 frontmatter = {}
                 body = content
 
-                if content.startswith("---"):
-                    parts = content.split("---", 2)
-                    if len(parts) >= 3:
-                        try:
-                            frontmatter = yaml.safe_load(parts[1])
-                            body = parts[2].strip()
-                        except Exception as e:
-                            logger.error(f"Failed to parse frontmatter for {file_path}: {e}")
+                fm_str, parsed_body = split_frontmatter(content)
+                if fm_str is not None:
+                    try:
+                        frontmatter = yaml.safe_load(fm_str)
+                        body = parsed_body
+                    except Exception as e:
+                        logger.error(f"Failed to parse frontmatter for {file_path}: {e}")
 
                 # Prepare for indexing
                 description = frontmatter.get("description", "")

--- a/src/engine/implants.py
+++ b/src/engine/implants.py
@@ -35,7 +35,8 @@ class ImplantRetriever:
         h = hashlib.md5()
         for path in sorted(glob.glob(os.path.join(IMPLANTS_DIR, "*.mdc"))):
             h.update(path.encode())
-            h.update(str(os.path.getmtime(path)).encode())
+            with open(path, "rb") as f:
+                h.update(f.read())
         return h.hexdigest()
 
     def _needs_reindex(self) -> tuple[bool, str]:

--- a/src/engine/implants.py
+++ b/src/engine/implants.py
@@ -80,7 +80,7 @@ class ImplantRetriever:
                 fm_str, parsed_body = split_frontmatter(content)
                 if fm_str is not None:
                     try:
-                        frontmatter = yaml.safe_load(fm_str)
+                        frontmatter = yaml.safe_load(fm_str) or {}
                         body = parsed_body
                     except Exception as e:
                         logger.error(f"Failed to parse frontmatter for {file_path}: {e}")

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -6,6 +6,7 @@ from src.utils.langfuse_compat import observe
 
 logger = logging.getLogger(__name__)
 from typing import List, Optional, Dict, Any
+from src.utils.prompt_loader import split_frontmatter
 
 from src.schemas.protocol import RouterDecision, AgentRequest
 from src.engine.config import ROUTER_SIMILARITY_THRESHOLD, AGENTS_DIR
@@ -61,18 +62,17 @@ class SemanticRouter:
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     content = f.read()
-                if content.startswith("---"):
-                    parts = content.split("---", 2)
-                    if len(parts) >= 2:
-                        meta = yaml.safe_load(parts[1]) or {}
-                        identity = meta.get("identity", {})
-                        routing = meta.get("routing", {})
-                        descriptions[name] = {
-                            "display_name": identity.get("display_name", name),
-                            "role": identity.get("role", ""),
-                            "trigger_command": routing.get("trigger_command", ""),
-                        }
-                        continue
+                fm_str, _ = split_frontmatter(content)
+                if fm_str is not None:
+                    meta = yaml.safe_load(fm_str) or {}
+                    identity = meta.get("identity", {})
+                    routing = meta.get("routing", {})
+                    descriptions[name] = {
+                        "display_name": identity.get("display_name", name),
+                        "role": identity.get("role", ""),
+                        "trigger_command": routing.get("trigger_command", ""),
+                    }
+                    continue
             except Exception as e:
                 logger.warning(f"Failed to load metadata for {name}: {e}")
             descriptions[name] = {"display_name": name, "role": "", "trigger_command": ""}

--- a/src/engine/skills.py
+++ b/src/engine/skills.py
@@ -80,7 +80,7 @@ class SkillRetriever:
                 fm_str, parsed_body = split_frontmatter(content)
                 if fm_str is not None:
                     try:
-                        frontmatter = yaml.safe_load(fm_str)
+                        frontmatter = yaml.safe_load(fm_str) or {}
                         body = parsed_body
                     except Exception as e:
                         logger.error(f"Failed to parse frontmatter for {file_path}: {e}")

--- a/src/engine/skills.py
+++ b/src/engine/skills.py
@@ -5,6 +5,7 @@ import hashlib
 import yaml
 from src.utils.langfuse_compat import observe
 from typing import List, Dict, Any
+from src.utils.prompt_loader import split_frontmatter
 
 from src.engine.config import SKILLS_DIR, SKILLS_RELEVANCE_THRESHOLD, CHROMA_PATH
 from src.engine.chroma import get_chroma_client, get_embedding_fn
@@ -75,14 +76,13 @@ class SkillRetriever:
                 frontmatter = {}
                 body = content
 
-                if content.startswith("---"):
-                    parts = content.split("---", 2)
-                    if len(parts) >= 3:
-                        try:
-                            frontmatter = yaml.safe_load(parts[1])
-                            body = parts[2].strip()
-                        except Exception as e:
-                            logger.error(f"Failed to parse frontmatter for {file_path}: {e}")
+                fm_str, parsed_body = split_frontmatter(content)
+                if fm_str is not None:
+                    try:
+                        frontmatter = yaml.safe_load(fm_str)
+                        body = parsed_body
+                    except Exception as e:
+                        logger.error(f"Failed to parse frontmatter for {file_path}: {e}")
 
                 # Prepare for indexing
                 # We index the full content (description + body) for better retrieval

--- a/src/engine/skills.py
+++ b/src/engine/skills.py
@@ -35,7 +35,8 @@ class SkillRetriever:
         h = hashlib.md5()
         for path in sorted(glob.glob(os.path.join(SKILLS_DIR, "*.mdc"))):
             h.update(path.encode())
-            h.update(str(os.path.getmtime(path)).encode())
+            with open(path, "rb") as f:
+                h.update(f.read())
         return h.hexdigest()
 
     def _needs_reindex(self) -> tuple[bool, str]:

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -82,7 +82,7 @@ def load_file_content(path: str) -> str:
             content = f.read()
             # specific to MDC files with frontmatter: remove it if present
             _, body = split_frontmatter(content)
-            return body if body != content else content
+            return body
     except FileNotFoundError:
         return f"[MISSING FILE: {path}]"
     except Exception as e:

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -27,9 +27,9 @@ def split_frontmatter(content: str) -> Tuple[Optional[str], str]:
         return None, content
 
     # Everything between first and second --- markers
-    fm_start = matches[0].end()    # right after opening ---\n
+    fm_start = matches[0].end()    # right after opening --- (end of match, before newline)
     fm_end = matches[1].start()    # right before closing ---
-    body_start = matches[1].end()  # right after closing ---\n
+    body_start = matches[1].end()  # right after closing --- (end of match, before newline)
 
     frontmatter_str = content[fm_start:fm_end]
     body = content[body_start:].strip()

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -1,9 +1,40 @@
 import os
 import re
 import yaml
-from typing import Set
+from typing import Set, Tuple, Optional
 
 from src.engine.config import REPO_ROOT, SKILLS_DIR, IMPLANTS_DIR, AGENTS_DIR
+
+# Regex to find the closing --- of YAML frontmatter.
+# Matches --- only at the start of a line, avoiding --- inside quoted values.
+_FRONTMATTER_RE = re.compile(r'^---\s*$', re.MULTILINE)
+
+
+def split_frontmatter(content: str) -> Tuple[Optional[str], str]:
+    """Split MDC content into (frontmatter_yaml, body).
+
+    Returns (None, content) if no valid frontmatter block is found.
+    Uses regex to match ``---`` only at the start of a line, so ``---``
+    embedded inside quoted YAML values (e.g. ``compiled: "use --- for
+    separators"``) won't break the split.
+    """
+    if not content.startswith("---"):
+        return None, content
+
+    # Find all --- at start-of-line; first is the opening, second is the closing.
+    matches = list(_FRONTMATTER_RE.finditer(content))
+    if len(matches) < 2:
+        return None, content
+
+    # Everything between first and second --- markers
+    fm_start = matches[0].end()    # right after opening ---\n
+    fm_end = matches[1].start()    # right before closing ---
+    body_start = matches[1].end()  # right after closing ---\n
+
+    frontmatter_str = content[fm_start:fm_end]
+    body = content[body_start:].strip()
+
+    return frontmatter_str, body
 
 def resolve_path(path_ref: str) -> str:
     """
@@ -50,11 +81,8 @@ def load_file_content(path: str) -> str:
         with open(path, 'r', encoding='utf-8') as f:
             content = f.read()
             # specific to MDC files with frontmatter: remove it if present
-            if content.startswith("---"):
-                parts = content.split("---", 2)
-                if len(parts) >= 3:
-                    return parts[2].strip()
-            return content
+            _, body = split_frontmatter(content)
+            return body if body != content else content
     except FileNotFoundError:
         return f"[MISSING FILE: {path}]"
     except Exception as e:
@@ -87,12 +115,11 @@ def _compute_skip_inline(norm: str) -> bool:
         try:
             with open(norm, "r", encoding="utf-8") as f:
                 raw = f.read()
-            if raw.startswith("---"):
-                parts = raw.split("---", 2)
-                if len(parts) >= 2:
-                    fm = yaml.safe_load(parts[1]) or {}
-                    if fm.get("alwaysApply") is True:
-                        return True
+            fm_str, _ = split_frontmatter(raw)
+            if fm_str is not None:
+                fm = yaml.safe_load(fm_str) or {}
+                if fm.get("alwaysApply") is True:
+                    return True
         except Exception:
             pass
     return False
@@ -141,10 +168,9 @@ def get_agent_metadata(agent_name: str) -> dict:
     try:
         with open(base_path, 'r', encoding='utf-8') as f:
             content = f.read()
-            if content.startswith("---"):
-                parts = content.split("---", 2)
-                if len(parts) >= 2:
-                    return yaml.safe_load(parts[1]) or {}
+        fm_str, _ = split_frontmatter(content)
+        if fm_str is not None:
+            return yaml.safe_load(fm_str) or {}
     except Exception:
         pass
 


### PR DESCRIPTION
Universal IDE detection in init_repo.sh — the script was hardcoded to Cursor IDE (only configured ~/.cursor/mcp.json, final output said "Restart Cursor IDE"). Now it auto-detects three environments (Cursor, Claude Desktop, Claude Code), configures MCP for each one found, generates CLAUDE.md with the routing protocol, and shows dynamic next-steps per environment. Added --skip-mcp flag.
YAML frontmatter quoting in 31 skill .mdc files — unquoted description values containing colons (Role: Architect) caused YAML parsing errors ("mapping values are not allowed here"). Wrapped all description and compiled values in double quotes.
Robust frontmatter parser — replaced naive content.split("---", 2) (used in 6 places across skills.py, implants.py, router.py, prompt_loader.py) with a regex-based split_frontmatter() utility that matches ^---$ only at start-of-line. Fixes parsing of files like skill-clickup-markdown.mdc where --- appears inside quoted YAML values.
Agent builder docs — added explicit YAML quoting rule with examples to agent_builder system prompt, so new skills are generated with correct frontmatter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches repo init automation and indexing/routing frontmatter parsing; failures here can break IDE MCP registration or cause missing/incorrect skill/implant/agent metadata at runtime, but changes are localized and add more robust parsing.
> 
> **Overview**
> **Improves MDC/YAML frontmatter robustness and eliminates YAML parsing footguns.** Adds `split_frontmatter()` (regex-based) and switches skills/implants indexing, agent metadata loading, and prompt loading from naive `content.split('---', ...)` to the new parser; multiple skill `description` fields are now quoted to prevent YAML errors when values contain colons.
> 
> **Upgrades repo initialization to configure MCP across multiple environments and speed first start.** `init_repo.sh` gains `--skip-mcp`, auto-detects and writes an `Agents-Core` MCP server entry into Cursor/Claude Desktop/Claude Code configs (with backups), pre-downloads the embedding model and pre-indexes skills/implants into ChromaDB to avoid first-run timeouts, and prints environment-specific next steps.
> 
> **Updates agent-builder guidance.** The agent builder system prompt now explicitly instructs quoting `description`/`compiled` YAML values and includes an example to avoid broken generated skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc56027e76997165bbbc941132720cf856085aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->