### PR TITLE
docs: translate agent catalog to English, add routing flowchart, fix inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ANTHROPIC_API_KEY=sk-ant-...  # Optional: for document OCR
 AGENTS_DEBUG=0                # Set to 1 for JSON debug logging in logs/
 ```
 
-> **Note**: Embeddings are handled locally by `sentence-transformers` (all-MiniLM-L6-v2). No external API key is required for core routing.
+> **Note**: Embeddings are handled locally by `sentence-transformers` (`BAAI/bge-m3`). No external API key is required for core routing.
 
 ---
 
@@ -87,7 +87,7 @@ The server exposes MCP tools that any compatible client can call:
 
 ```
 Agents/
-├── agents/               # Agent personas (system prompts, 31 agents)
+├── agents/               # Agent personas (system prompts, 36 agents)
 │   ├── ai_debugger/
 │   │   └── system_prompt.mdc
 │   ├── software_engineer/
@@ -202,7 +202,7 @@ Instead of listing skills per agent, you can declare high-level capabilities:
 capabilities: [development, dev-security]
 ```
 
-The enrichment pipeline resolves capabilities to skill bundles via `agents/capabilities/registry.yaml`. Available capabilities: `critical-analysis`, `content-structure`, `development`, `dense-summary`, `trust-weighted-research`, `bio-health`, `tech-documentation`, `dev-security`, `consultative-intake`, `creative-writing`, `psychology`, `3d-printing`, `data-investigation`, `epistemic-analysis`.
+The enrichment pipeline resolves capabilities to skill bundles via `agents/capabilities/registry.yaml`. Available capabilities: `critical-analysis`, `content-structure`, `development`, `dense-summary`, `trust-weighted-research`, `bio-health`, `tech-documentation`, `dev-security`, `consultative-intake`, `creative-writing`, `psychology`, `3d-printing`, `data-investigation`, `epistemic-analysis`, `code-review`, `decision-making`, `product-thinking`, `temporal-research`, `performance-engineering`, `prompt-design`, `prompt-security`, `roblox-development`, `dev-tools`, `blender-scripting`, `health-optimization`, `consumer-research`, `visualization`, `child-psychology`.
 
 ---
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,14 +1,14 @@
-# Каталог агентов
+# Agent Catalog
 
-Справочник всех доступных агентов для ручной маршрутизации (fallback Path B).
-Также доступен программно через MCP-инструмент `list_agents`.
+Reference of all available agents for manual routing (fallback Path B).
+Also available programmatically via the MCP tool `list_agents`.
 
-> **Автоматическая маршрутизация**: `route_and_load(query)` — предпочтительный способ.
-> Этот каталог нужен, когда MCP недоступен или маршрутизация упала.
+> **Automatic routing**: `route_and_load(query)` is the preferred method.
+> This catalog is needed when MCP is unavailable or routing fails.
 
-## Исследование и аналитика
+## Research & Analytics
 
-| Агент | Trigger | Роль |
+| Agent | Trigger | Role |
 |---|---|---|
 | `deep_researcher` | `/research` | High-density Information Analyst |
 | `investigative_analyst` | `/investigate` | OSINT & Fact-Checking Expert |
@@ -18,9 +18,9 @@
 | `website_analyst` | `/site_audit` | Web Project Analyst: business models, traffic, monetization |
 | `instagram_analyst` | `/instagram` | Social Media Profile Auditor |
 
-## Разработка и инженерия
+## Development & Engineering
 
-| Агент | Trigger | Роль |
+| Agent | Trigger | Role |
 |---|---|---|
 | `software_engineer` | `/dev` | Senior Full Stack Engineer |
 | `code_reviewer` | `/review` | Code Review & PR Analyst |
@@ -32,9 +32,9 @@
 | `roblox_studio_expert` | `/roblox` | Full-Cycle Roblox Game Development |
 | `blender_scripter` | `/blender` | Python (bpy) scripts for 3D-printable objects |
 
-## Документация и контент
+## Documentation & Content
 
-| Агент | Trigger | Роль |
+| Agent | Trigger | Role |
 |---|---|---|
 | `tech_writer` | `/docs` | Technical Writer & Documentation Expert |
 | `literary_writer` | `/literary` | Master of artistic prose |
@@ -42,18 +42,19 @@
 | `presentation_coach` | `/present` | Presentation Structure and Psychology Expert |
 | `diagram_architect` | `/diagram` | Mermaid.js Visualization Specialist |
 
-## Здоровье и психология
+## Health & Psychology
 
-| Агент | Trigger | Роль |
+| Agent | Trigger | Role |
 |---|---|---|
 | `medical_expert` | `/medical` | Lead Medical Analyst and Consultant |
 | `psychologist` | `/psy_session` | Cognitive Systems Architect (Neuro-Structure) |
+| `child_psychologist` | `/child_psy` | Child & Adolescent Psychologist (digital generation) |
 | `bio_hacker` | `/bio_protocol` | Systems Biologist / Productivity Coach |
 | `fitness_coach` | `/workout` | Scientific Fitness Coach (spine rehabilitation) |
 
-## AI и стратегия
+## AI & Strategy
 
-| Агент | Trigger | Роль |
+| Agent | Trigger | Role |
 |---|---|---|
 | `ai_senior_engineer` | `/ai_architect` | AI Interaction Architect & Human-AI Symbiosis |
 | `universal_agent` | `/universal` | Chief of Staff / Strategic Partner |
@@ -61,9 +62,9 @@
 | `product_manager` | `/pm` | Product Thinking & Requirements Analyst |
 | `debate_moderator` | `/debate` | Devil's Advocate & Decision Facilitator |
 
-## Утилиты и операции
+## Utilities & Operations
 
-| Агент | Trigger | Роль |
+| Agent | Trigger | Role |
 |---|---|---|
 | `document_ocr_expert` | `/ocr` | PDF/image text extraction (incl. handwriting) |
 | `alerts_describer` | `/alerts_describer` | Infrastructure Alert Documentation |
@@ -73,5 +74,5 @@
 
 ---
 
-**Всего агентов**: 35
-**Обновлено**: 2026-04-04
+**Total agents**: 36
+**Updated**: 2026-04-05

--- a/docs/routing_flow.md
+++ b/docs/routing_flow.md
@@ -28,9 +28,11 @@ graph TD
     SessionCache -->|Hit| CachedPrompt[Return cached<br/>enriched prompt]
     SessionCache -->|Miss| LoadMeta[Load agent metadata<br/>preferred_skills, capabilities]
 
-    LoadMeta --> TierPromo{Tier = lite AND<br/>agent has skills<br/>or capabilities?}
+    LoadMeta --> TierExplicit{Tier set<br/>explicitly?}
+    TierExplicit -->|Yes| KeepTier[Keep explicit tier<br/>e.g. meta-query lite]
+    TierExplicit -->|No| TierPromo{Inferred lite AND<br/>agent has skills<br/>or capabilities?}
     TierPromo -->|Yes| Promote[Promote to standard]
-    TierPromo -->|No| KeepTier[Keep inferred tier]
+    TierPromo -->|No| KeepTier
 
     Promote --> Enrich
     KeepTier --> Enrich
@@ -76,7 +78,7 @@ graph TD
 | Signal | Tier | Enrichment |
 |--------|------|------------|
 | Query < 50 chars, no complex keywords | **lite** | Base prompt only |
-| Default / moderate complexity | **standard** | Up to 2 skills + 2 implants (preferred by ID when declared, RAG otherwise) |
+| Default / moderate complexity | **standard** | 2 skills via RAG + 2 implants; if preferred/capability skills declared, all loaded by ID (no cap) |
 | Query > 300 chars OR complex keywords (`debug`, `investigate`, `compare`, `design`, `review`, `audit`, `deep dive`, plus Russian equivalents) | **deep** | 4+ skills + 3 implants (preferred by ID + RAG fallback) |
 
 > **Tier Promotion**: If the inferred tier is `lite` but the target agent declares `preferred_skills` or `capabilities`, the tier is automatically promoted to `standard` to ensure skills are loaded.

--- a/docs/routing_flow.md
+++ b/docs/routing_flow.md
@@ -38,8 +38,8 @@ graph TD
     Enrich{Enrichment<br/>by Tier}
 
     Enrich -->|lite| Lite[Base prompt only<br/>No skills / No implants]
-    Enrich -->|standard| Standard[Base prompt<br/>+ 2 skills via RAG<br/>+ 2 implants via RAG]
-    Enrich -->|deep| Deep[Base prompt<br/>+ 4+ skills — all preferred + RAG<br/>+ 3 implants via RAG]
+    Enrich -->|standard| Standard[Base prompt<br/>+ up to 2 skills + 2 implants<br/>preferred/capability skills loaded by ID]
+    Enrich -->|deep| Deep[Base prompt<br/>+ 4+ skills + 3 implants<br/>all preferred/capability skills loaded by ID]
 
     Lite --> ResolveCaps
     Standard --> ResolveCaps
@@ -47,7 +47,7 @@ graph TD
 
     ResolveCaps[Resolve capabilities<br/>registry.yaml → skill bundles + directives]
 
-    ResolveCaps --> ComputeHash[Compute context_hash<br/>SHA-256 of enriched prompt]
+    ResolveCaps --> ComputeHash[Compute context_hash<br/>SHA-256 truncated to 16 hex chars]
     CachedPrompt --> ComputeHash
 
     ComputeHash --> HashCompare{context_hash<br/>matches previous?}
@@ -76,8 +76,8 @@ graph TD
 | Signal | Tier | Enrichment |
 |--------|------|------------|
 | Query < 50 chars, no complex keywords | **lite** | Base prompt only |
-| Default / moderate complexity | **standard** | 2 skills + 2 implants (RAG) |
-| Query > 300 chars OR complex keywords (`debug`, `architecture`, `review`, `analyze`, etc.) | **deep** | 4+ skills + 3 implants (RAG + preferred) |
+| Default / moderate complexity | **standard** | Up to 2 skills + 2 implants (preferred by ID when declared, RAG otherwise) |
+| Query > 300 chars OR complex keywords (`debug`, `investigate`, `compare`, `design`, `review`, `audit`, `deep dive`, plus Russian equivalents) | **deep** | 4+ skills + 3 implants (preferred by ID + RAG fallback) |
 
 > **Tier Promotion**: If the inferred tier is `lite` but the target agent declares `preferred_skills` or `capabilities`, the tier is automatically promoted to `standard` to ensure skills are loaded.
 
@@ -145,7 +145,7 @@ sequenceDiagram
 3. **ROUTE_REQUIRED**: On cache miss, the system returns a list of agent candidates with metadata (`display_name`, `role`, `trigger_command`), allowing the client LLM to select the best match via `get_agent_context()`.
 4. **Tier Inference**: Determines enrichment depth based on query complexity signals (length, keywords). Automatic promotion from `lite` to `standard` when agents declare skills or capabilities.
 5. **Enrichment Pipeline**:
-    * **Skills**: Domain-specific knowledge modules retrieved via ChromaDB semantic search (threshold: 0.55 distance).
+    * **Skills**: Domain-specific knowledge modules. When an agent declares `preferred_skills` or `capabilities`, those skills are loaded by exact ID (no vector search, no count limit). Otherwise, skills are retrieved via ChromaDB semantic search (threshold: 0.55 distance).
     * **Implants**: Cognitive reasoning strategies retrieved via semantic search (threshold: 0.73 distance). Agents can request more at runtime via `load_implants()`.
     * **Capabilities**: High-level compositions from `registry.yaml` mapping to skill bundles + behavioral directives.
 6. **Session Cache**: TTLCache (max 128 entries, 600s TTL) storing enriched prompts keyed by `{agent_name}:{query_hash}:{tier}`. Supports `context_hash` for multi-turn delta optimization.

--- a/docs/routing_flow.md
+++ b/docs/routing_flow.md
@@ -40,8 +40,8 @@ graph TD
     Enrich{Enrichment<br/>by Tier}
 
     Enrich -->|lite| Lite[Base prompt only<br/>No skills / No implants]
-    Enrich -->|standard| Standard[Base prompt<br/>+ up to 2 skills + 2 implants<br/>preferred/capability skills loaded by ID]
-    Enrich -->|deep| Deep[Base prompt<br/>+ 4+ skills + 3 implants<br/>all preferred/capability skills loaded by ID]
+    Enrich -->|standard| Standard[Base prompt<br/>+ up to 2 skills via RAG OR all declared by ID<br/>+ up to 2 implants via RAG]
+    Enrich -->|deep| Deep[Base prompt<br/>+ up to 4 skills via RAG OR all declared by ID<br/>+ up to 3 implants via RAG]
 
     Lite --> ResolveCaps
     Standard --> ResolveCaps
@@ -78,8 +78,8 @@ graph TD
 | Signal | Tier | Enrichment |
 |--------|------|------------|
 | Query < 50 chars, no complex keywords | **lite** | Base prompt only |
-| Default / moderate complexity | **standard** | 2 skills via RAG + 2 implants; if preferred/capability skills declared, all loaded by ID (no cap) |
-| Query > 300 chars OR complex keywords (`debug`, `investigate`, `compare`, `design`, `review`, `audit`, `deep dive`, plus Russian equivalents) | **deep** | 4+ skills + 3 implants (preferred by ID + RAG fallback) |
+| Default / moderate complexity | **standard** | Up to 2 skills + 2 implants (RAG, filtered by relevance threshold). If agent declares preferred skills or capabilities — all loaded by exact ID instead, no count limit. |
+| Query > 300 chars OR complex keywords (`debug`, `investigate`, `compare`, `design`, `review`, `audit`, `deep dive`, plus Russian equivalents) | **deep** | Up to max(4, len(declared)) skills + 3 implants (RAG, filtered by threshold). If agent declares preferred skills or capabilities — all loaded by exact ID instead. |
 
 > **Tier Promotion**: If the inferred tier is `lite` but the target agent declares `preferred_skills` or `capabilities`, the tier is automatically promoted to `standard` to ensure skills are loaded.
 

--- a/docs/routing_flow.md
+++ b/docs/routing_flow.md
@@ -1,8 +1,87 @@
 # Request Routing Flow
 
-This diagram illustrates the decision-making process for routing user requests to the appropriate agent via `route_and_load()`.
+This document describes the routing and enrichment pipeline for the Agents-Core MCP server.
 
-## Routing Flow Sequence
+## Architecture Overview
+
+```mermaid
+graph TD
+    Start([User Query]) --> Normalize[Normalize chat_history<br/>Generate request_id]
+    Normalize --> InferTier[Infer tier from query]
+    InferTier --> CacheLookup{ChromaDB<br/>Semantic Cache<br/>Similarity > 0.95?}
+
+    CacheLookup -->|Hit| AgentFound[Agent identified<br/>from cache]
+    CacheLookup -->|Miss| MetaCheck{Meta-query?<br/>greeting / len < 10}
+
+    MetaCheck -->|Yes| Universal[Route to universal_agent<br/>Force tier = lite]
+    MetaCheck -->|No| RouteRequired[/"ROUTE_REQUIRED<br/>Return candidates list"/]
+
+    RouteRequired --> ClientPicks([Client LLM picks agent])
+    ClientPicks --> GetAgent[get_agent_context<br/>agent_name, query]
+
+    AgentFound --> LoadEnrich
+    Universal --> LoadEnrich
+    GetAgent --> LoadEnrich
+
+    LoadEnrich[_load_and_enrich] --> SessionCache{Session TTLCache<br/>128 items / 600s TTL}
+
+    SessionCache -->|Hit| CachedPrompt[Return cached<br/>enriched prompt]
+    SessionCache -->|Miss| LoadMeta[Load agent metadata<br/>preferred_skills, capabilities]
+
+    LoadMeta --> TierPromo{Tier = lite AND<br/>agent has skills<br/>or capabilities?}
+    TierPromo -->|Yes| Promote[Promote to standard]
+    TierPromo -->|No| KeepTier[Keep inferred tier]
+
+    Promote --> Enrich
+    KeepTier --> Enrich
+
+    Enrich{Enrichment<br/>by Tier}
+
+    Enrich -->|lite| Lite[Base prompt only<br/>No skills / No implants]
+    Enrich -->|standard| Standard[Base prompt<br/>+ 2 skills via RAG<br/>+ 2 implants via RAG]
+    Enrich -->|deep| Deep[Base prompt<br/>+ 4+ skills — all preferred + RAG<br/>+ 3 implants via RAG]
+
+    Lite --> ResolveCaps
+    Standard --> ResolveCaps
+    Deep --> ResolveCaps
+
+    ResolveCaps[Resolve capabilities<br/>registry.yaml → skill bundles + directives]
+
+    ResolveCaps --> ComputeHash[Compute context_hash<br/>SHA-256 of enriched prompt]
+    CachedPrompt --> ComputeHash
+
+    ComputeHash --> HashCompare{context_hash<br/>matches previous?}
+
+    HashCompare -->|Yes| NoChange[/"NO_CHANGE<br/>Reuse prior context"/]
+    HashCompare -->|No| UpdateCache[Update ChromaDB<br/>router cache]
+
+    UpdateCache --> Sampling{MCP Sampling<br/>supported?}
+
+    Sampling -->|Yes| Sampled[/"SUCCESS_SAMPLED<br/>Ready-made response"/]
+    Sampling -->|No / Error| Success[/"SUCCESS<br/>Return system_prompt"/]
+
+    style Start fill:#4A90D9,color:#fff
+    style RouteRequired fill:#E6A23C,color:#fff
+    style NoChange fill:#909399,color:#fff
+    style Sampled fill:#67C23A,color:#fff
+    style Success fill:#67C23A,color:#fff
+    style Enrich fill:#F56C6C,color:#fff
+    style CacheLookup fill:#B37FEB,color:#fff
+    style SessionCache fill:#B37FEB,color:#fff
+    style HashCompare fill:#B37FEB,color:#fff
+```
+
+## Tier Inference Rules
+
+| Signal | Tier | Enrichment |
+|--------|------|------------|
+| Query < 50 chars, no complex keywords | **lite** | Base prompt only |
+| Default / moderate complexity | **standard** | 2 skills + 2 implants (RAG) |
+| Query > 300 chars OR complex keywords (`debug`, `architecture`, `review`, `analyze`, etc.) | **deep** | 4+ skills + 3 implants (RAG + preferred) |
+
+> **Tier Promotion**: If the inferred tier is `lite` but the target agent declares `preferred_skills` or `capabilities`, the tier is automatically promoted to `standard` to ensure skills are loaded.
+
+## Routing Sequence (Detailed)
 
 ```mermaid
 sequenceDiagram
@@ -61,15 +140,13 @@ sequenceDiagram
 
 ## Key Components
 
-1. **Semantic Cache**: Uses ChromaDB to store and retrieve previous routing decisions. A match occurs if the cosine distance is less than 0.05 (Similarity > 0.95).
+1. **Semantic Cache**: Uses ChromaDB with `BAAI/bge-m3` embeddings to store and retrieve previous routing decisions. A match occurs if the cosine similarity exceeds 0.95 (distance < 0.05).
 2. **Meta-Query Detection**: Regex-based detection of greetings and short queries (English + Russian) for auto-routing to `universal_agent`.
-3. **ROUTE_REQUIRED**: On cache miss, the system returns a list of agent candidates with descriptions, allowing the client LLM to select the best match via `get_agent_context()`.
-4. **Tier Inference**: Determines enrichment depth based on query complexity:
-    * **lite**: Short/simple queries — no skills or implants loaded.
-    * **standard**: Default — 2 skills + 2 implants selected via RAG.
-    * **deep**: Complex/architecture queries — 4+ skills + 3 implants with full capability resolution.
+3. **ROUTE_REQUIRED**: On cache miss, the system returns a list of agent candidates with metadata (`display_name`, `role`, `trigger_command`), allowing the client LLM to select the best match via `get_agent_context()`.
+4. **Tier Inference**: Determines enrichment depth based on query complexity signals (length, keywords). Automatic promotion from `lite` to `standard` when agents declare skills or capabilities.
 5. **Enrichment Pipeline**:
-    * **Skills**: Domain-specific knowledge modules retrieved via ChromaDB.
-    * **Implants**: Cognitive reasoning strategies (e.g., chain-of-code, reflexion).
-    * **Capabilities**: High-level compositions from `registry.yaml` mapping to skill stacks + directives.
-6. **Session Cache**: TTLCache (max 128 entries, 600s TTL) storing enriched prompts keyed by agent name. Supports `context_hash` for multi-turn delta optimization.
+    * **Skills**: Domain-specific knowledge modules retrieved via ChromaDB semantic search (threshold: 0.55 distance).
+    * **Implants**: Cognitive reasoning strategies retrieved via semantic search (threshold: 0.73 distance). Agents can request more at runtime via `load_implants()`.
+    * **Capabilities**: High-level compositions from `registry.yaml` mapping to skill bundles + behavioral directives.
+6. **Session Cache**: TTLCache (max 128 entries, 600s TTL) storing enriched prompts keyed by `{agent_name}:{query_hash}:{tier}`. Supports `context_hash` for multi-turn delta optimization.
+7. **MCP Sampling**: When the client supports MCP sampling, the server generates a response directly (`SUCCESS_SAMPLED`). Otherwise, it returns the enriched system prompt for the client to use (`SUCCESS`).


### PR DESCRIPTION
- Translate agents/README.md from Russian to English
- Add missing child_psychologist agent to the catalog (36 total)
- Create Mermaid flowchart diagram showing full routing + enrichment flow
- Fix embedding model name (all-MiniLM-L6-v2 → BAAI/bge-m3)
- Update agent count from 31 to 36
- Complete capabilities list (14 → 28)
- Add tier inference rules table and tier promotion docs
- Update key components with accurate thresholds and cache key format

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; main risk is minor confusion if the described routing thresholds/behavior diverge from implementation.
> 
> **Overview**
> Updates docs to match current system behavior and metadata: corrects the embedding model reference to `BAAI/bge-m3`, updates the documented agent count to **36**, and expands the listed capabilities.
> 
> Translates `agents/README.md` to English, adds the missing `child_psychologist` entry, and refreshes totals/dates.
> 
> Reworks `docs/routing_flow.md` into a detailed routing/enrichment spec with a new Mermaid architecture flowchart, tier inference rules (including *lite → standard promotion*), and more precise descriptions of cache keys, thresholds, and `SUCCESS` vs `SUCCESS_SAMPLED` outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e492fe7577f700c5b141a94d9272e01cede2b199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->