### PR TITLE
feat: add sticky agent routing to preserve active agent across turns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ python-dotenv
 PyYAML>=6.0
 cachetools>=5.3
 mcp>=0.1.0
+# Test dependencies
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
 # Document OCR dependencies
 pdf2image>=1.16.0
 Pillow>=10.0.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,7 +14,7 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
-echo -e "${GREEN}🧪 Running Language Detection Tests${NC}"
+echo -e "${GREEN}🧪 Running Tests${NC}"
 echo "================================================"
 
 # Detect and activate virtual environment
@@ -67,10 +67,10 @@ fi
 
 # Run tests with any additional arguments passed to script
 echo ""
-echo -e "${GREEN}Running: $PYTHON_BIN -m pytest tests/test_language.py -v $@${NC}"
+echo -e "${GREEN}Running: $PYTHON_BIN -m pytest tests/ -v $@${NC}"
 echo ""
 
-$PYTHON_BIN -m pytest tests/test_language.py -v "$@"
+$PYTHON_BIN -m pytest tests/ -v "$@"
 
 # Capture exit code
 TEST_EXIT_CODE=$?

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -70,10 +70,10 @@ echo ""
 echo -e "${GREEN}Running: $PYTHON_BIN -m pytest tests/ -v $@${NC}"
 echo ""
 
+set +e  # Allow pytest to fail without aborting — we handle exit code below
 $PYTHON_BIN -m pytest tests/ -v "$@"
-
-# Capture exit code
 TEST_EXIT_CODE=$?
+set -e
 
 echo ""
 if [ $TEST_EXIT_CODE -eq 0 ]; then

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -13,6 +13,11 @@ IMPLANTS_DIR = os.path.join(REPO_ROOT, "implants")
 CAPABILITIES_FILE = os.path.join(REPO_ROOT, "agents", "capabilities", "registry.yaml")
 
 ROUTER_SIMILARITY_THRESHOLD = 0.95
+# Sticky agent: auto-switch to a different agent without LLM if cosine distance
+# is below this value. Intentionally tighter than ROUTER_SIMILARITY_THRESHOLD
+# (0.05) — only near-duplicate queries trigger an auto-switch; ambiguous cases
+# keep the current agent for stability. Tune empirically if switches are too rare.
+STICKY_SWITCH_THRESHOLD = 0.02
 SKILLS_RELEVANCE_THRESHOLD = 0.55
 IMPLANTS_RELEVANCE_THRESHOLD = 0.73
 

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -14,9 +14,10 @@ CAPABILITIES_FILE = os.path.join(REPO_ROOT, "agents", "capabilities", "registry.
 
 ROUTER_SIMILARITY_THRESHOLD = 0.95
 # Sticky agent: auto-switch to a different agent without LLM if cosine distance
-# is below this value. Intentionally tighter than ROUTER_SIMILARITY_THRESHOLD
-# (0.05) — only near-duplicate queries trigger an auto-switch; ambiguous cases
-# keep the current agent for stability. Tune empirically if switches are too rare.
+# is below this value. Intentionally tighter than the router's distance cutoff
+# (1 - ROUTER_SIMILARITY_THRESHOLD) — only near-duplicate queries trigger an
+# auto-switch; ambiguous cases keep the current agent for stability.
+# Tune empirically if switches are too rare.
 STICKY_SWITCH_THRESHOLD = 0.02
 SKILLS_RELEVANCE_THRESHOLD = 0.55
 IMPLANTS_RELEVANCE_THRESHOLD = 0.73

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -87,7 +87,7 @@ class SemanticRouter:
 
     async def lookup_cache_with_distance(
         self, query: str, context: Dict[str, Any] = None
-    ) -> Optional[tuple["RouterDecision", float]]:
+    ) -> Optional[tuple[RouterDecision, float]]:
         """
         Checks the semantic cache. Returns (decision, distance) on hit, None on miss.
         """

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -85,29 +85,28 @@ class SemanticRouter:
             for name in self.available_agents
         ]
 
-    async def _query_nearest(
+    async def query_nearest(
         self, query: str, context: Dict[str, Any] = None
     ) -> Optional[tuple[RouterDecision, float]]:
         """
         Returns the nearest cached entry as (decision, distance), or None if
-        the cache is completely empty. No threshold is applied — the caller
-        decides what to do with the distance.
+        the cache has no entries. No threshold is applied — the caller decides
+        what to do with the distance.
+
+        Raises on ChromaDB errors so callers can distinguish empty cache from
+        lookup failure and handle each appropriately.
         """
         history_text = context.get("history_text", "") if context else ""
         semantic_query = f"{history_text[-200:]}\n{query}" if history_text else query
 
         loop = asyncio.get_running_loop()
-        try:
-            results = await loop.run_in_executor(
-                None,
-                lambda: self.collection.query(
-                    query_texts=[semantic_query],
-                    n_results=1,
-                ),
-            )
-        except Exception as e:
-            logger.error(f"ChromaDB lookup failed: {e}")
-            return None
+        results = await loop.run_in_executor(
+            None,
+            lambda: self.collection.query(
+                query_texts=[semantic_query],
+                n_results=1,
+            ),
+        )
 
         if results["ids"] and results["distances"] and len(results["distances"][0]) > 0:
             distance = results["distances"][0][0]
@@ -125,7 +124,11 @@ class SemanticRouter:
         self, query: str, context: Dict[str, Any] = None
     ) -> Optional[tuple[RouterDecision, float]]:
         """Returns (decision, distance) only if distance passes the similarity threshold."""
-        result = await self._query_nearest(query, context)
+        try:
+            result = await self.query_nearest(query, context)
+        except Exception as e:
+            logger.error(f"ChromaDB lookup failed: {e}")
+            return None
         if result and result[1] < (1 - ROUTER_SIMILARITY_THRESHOLD):
             return result
         return None

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -85,43 +85,45 @@ class SemanticRouter:
             for name in self.available_agents
         ]
 
-    async def lookup_cache(self, query: str, context: Dict[str, Any] = None) -> Optional[RouterDecision]:
+    async def lookup_cache_with_distance(
+        self, query: str, context: Dict[str, Any] = None
+    ) -> Optional[tuple["RouterDecision", float]]:
         """
-        Only checks the cache. Returns None if miss.
+        Checks the semantic cache. Returns (decision, distance) on hit, None on miss.
         """
         history_text = context.get("history_text", "") if context else ""
+        semantic_query = f"{history_text[-200:]}\n{query}" if history_text else query
 
-        if history_text:
-             # Create a context-aware query for semantic search
-             semantic_query = f"{history_text[-200:]}\n{query}" # Last 200 chars of context
-        else:
-             semantic_query = query
-
-        # ChromaDB query is blocking, run in executor
         loop = asyncio.get_running_loop()
         try:
             results = await loop.run_in_executor(
                 None,
                 lambda: self.collection.query(
                     query_texts=[semantic_query],
-                    n_results=1
-                )
+                    n_results=1,
+                ),
             )
         except Exception as e:
             logger.error(f"ChromaDB lookup failed: {e}")
             return None
 
-        if results['ids'] and results['distances'] and len(results['distances'][0]) > 0:
-            distance = results['distances'][0][0]
+        if results["ids"] and results["distances"] and len(results["distances"][0]) > 0:
+            distance = results["distances"][0][0]
             if distance < (1 - ROUTER_SIMILARITY_THRESHOLD):
-                metadata = results['metadatas'][0][0]
-                return RouterDecision(
-                    target_agent=metadata['target_agent'],
+                metadata = results["metadatas"][0][0]
+                decision = RouterDecision(
+                    target_agent=metadata["target_agent"],
                     confidence=1.0,
                     reasoning=f"Cached result (distance: {distance:.4f})",
-                    is_cached=True
+                    is_cached=True,
                 )
+                return decision, distance
         return None
+
+    async def lookup_cache(self, query: str, context: Dict[str, Any] = None) -> Optional[RouterDecision]:
+        """Only checks the cache. Returns None if miss."""
+        result = await self.lookup_cache_with_distance(query, context)
+        return result[0] if result else None
 
     async def update_cache(self, query: str, agent_name: str, reasoning: str, request_id: str):
         """

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -85,11 +85,13 @@ class SemanticRouter:
             for name in self.available_agents
         ]
 
-    async def lookup_cache_with_distance(
+    async def _query_nearest(
         self, query: str, context: Dict[str, Any] = None
     ) -> Optional[tuple[RouterDecision, float]]:
         """
-        Checks the semantic cache. Returns (decision, distance) on hit, None on miss.
+        Returns the nearest cached entry as (decision, distance), or None if
+        the cache is completely empty. No threshold is applied — the caller
+        decides what to do with the distance.
         """
         history_text = context.get("history_text", "") if context else ""
         semantic_query = f"{history_text[-200:]}\n{query}" if history_text else query
@@ -109,19 +111,27 @@ class SemanticRouter:
 
         if results["ids"] and results["distances"] and len(results["distances"][0]) > 0:
             distance = results["distances"][0][0]
-            if distance < (1 - ROUTER_SIMILARITY_THRESHOLD):
-                metadata = results["metadatas"][0][0]
-                decision = RouterDecision(
-                    target_agent=metadata["target_agent"],
-                    confidence=1.0,
-                    reasoning=f"Cached result (distance: {distance:.4f})",
-                    is_cached=True,
-                )
-                return decision, distance
+            metadata = results["metadatas"][0][0]
+            decision = RouterDecision(
+                target_agent=metadata["target_agent"],
+                confidence=1.0,
+                reasoning=f"Cached result (distance: {distance:.4f})",
+                is_cached=True,
+            )
+            return decision, distance
+        return None
+
+    async def lookup_cache_with_distance(
+        self, query: str, context: Dict[str, Any] = None
+    ) -> Optional[tuple[RouterDecision, float]]:
+        """Returns (decision, distance) only if distance passes the similarity threshold."""
+        result = await self._query_nearest(query, context)
+        if result and result[1] < (1 - ROUTER_SIMILARITY_THRESHOLD):
+            return result
         return None
 
     async def lookup_cache(self, query: str, context: Dict[str, Any] = None) -> Optional[RouterDecision]:
-        """Only checks the cache. Returns None if miss."""
+        """Only checks the cache with threshold. Returns None if miss."""
         result = await self.lookup_cache_with_distance(query, context)
         return result[0] if result else None
 

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -126,6 +126,8 @@ class SemanticRouter:
         """Returns (decision, distance) only if distance passes the similarity threshold."""
         try:
             result = await self.query_nearest(query, context)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.error(f"ChromaDB lookup failed: {e}")
             return None

--- a/src/server.py
+++ b/src/server.py
@@ -110,6 +110,27 @@ CONTEXT_HASH_CACHE: TTLCache = TTLCache(maxsize=SESSION_CACHE_MAX_SIZE, ttl=SESS
 def _compute_context_hash(prompt: str) -> str:
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
 
+_ROUTE_REQUIRED_INSTRUCTION = (
+    "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
+    "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
+    "Do NOT explore the codebase. Do NOT answer the user. "
+    "FIRST pick the single best agent from candidates, THEN call ONLY: "
+    "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
+    "Wait for its response. Only THEN proceed with the user's request."
+)
+
+def _build_route_required(request_id: str, tier: str, candidates: list) -> str:
+    """Build a ROUTE_REQUIRED JSON response. Single source of truth for this payload."""
+    result = {
+        "status": "ROUTE_REQUIRED",
+        "request_id": request_id,
+        "tier": tier,
+        "candidates": candidates,
+        "instruction": _ROUTE_REQUIRED_INSTRUCTION,
+    }
+    debug_log("route_and_load", "res", result)
+    return json.dumps(result, ensure_ascii=False)
+
 async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[str], tier: str | None = None) -> tuple[str, str, list[str], list[str], str]:
     """Shared helper: load prompt, enrich with skills/implants/capabilities.
     Returns (final_prompt, context_hash, skills_loaded, implants_loaded, effective_tier).
@@ -255,23 +276,7 @@ async def route_and_load(
 
                 if lookup_failed:
                     # DB error — release to ROUTE_REQUIRED so LLM can decide
-                    candidates = router.get_agent_catalog()
-                    result = {
-                        "status": "ROUTE_REQUIRED",
-                        "request_id": request_id,
-                        "tier": tier,
-                        "candidates": candidates,
-                        "instruction": (
-                            "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
-                            "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
-                            "Do NOT explore the codebase. Do NOT answer the user. "
-                            "FIRST pick the single best agent from candidates, THEN call ONLY: "
-                            "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
-                            "Wait for its response. Only THEN proceed with the user's request."
-                        ),
-                    }
-                    debug_log("route_and_load", "res", result)
-                    return json.dumps(result, ensure_ascii=False)
+                    return _build_route_required(request_id, tier, router.get_agent_catalog())
                 elif nearest is None:
                     # Cache is genuinely empty — keep current agent, don't cache
                     agent_name = sticky_agent
@@ -292,26 +297,8 @@ async def route_and_load(
                 elif nearest[1] >= similarity_threshold:
                     # Query is far from anything cached — likely a topic change.
                     # Go straight to ROUTE_REQUIRED so the LLM can pick the right agent.
-                    # No need to call lookup_cache (same query would yield the same far result)
-                    # or _is_meta_query (already checked before entering sticky branch).
                     debug_log("route_and_load", "sticky", {"action": "release", "reason": "topic_change", "from": sticky_agent, "distance": nearest[1]})
-                    candidates = router.get_agent_catalog()
-                    result = {
-                        "status": "ROUTE_REQUIRED",
-                        "request_id": request_id,
-                        "tier": tier,
-                        "candidates": candidates,
-                        "instruction": (
-                            "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
-                            "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
-                            "Do NOT explore the codebase. Do NOT answer the user. "
-                            "FIRST pick the single best agent from candidates, THEN call ONLY: "
-                            "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
-                            "Wait for its response. Only THEN proceed with the user's request."
-                        ),
-                    }
-                    debug_log("route_and_load", "res", result)
-                    return json.dumps(result, ensure_ascii=False)
+                    return _build_route_required(request_id, tier, router.get_agent_catalog())
                 else:
                     # Close match for a different agent, but not strong enough to auto-switch.
                     # Keep sticky agent for stability, don't cache.
@@ -331,23 +318,7 @@ async def route_and_load(
                 explicit_tier = "lite"
             else:
                 # 3. Cache miss — return candidates for the calling LLM to decide
-                candidates = router.get_agent_catalog()
-                result = {
-                    "status": "ROUTE_REQUIRED",
-                    "request_id": request_id,
-                    "tier": tier,
-                    "candidates": candidates,
-                    "instruction": (
-                        "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
-                        "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
-                        "Do NOT explore the codebase. Do NOT answer the user. "
-                        "FIRST pick the single best agent from candidates, THEN call ONLY: "
-                        "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
-                        "Wait for its response. Only THEN proceed with the user's request."
-                    ),
-                }
-                debug_log("route_and_load", "res", result)
-                return json.dumps(result, ensure_ascii=False)
+                return _build_route_required(request_id, tier, router.get_agent_catalog())
 
         # 3. Cache hit or meta-query — load enriched prompt
         # Pass explicit_tier only for meta-queries (preserves "lite"); None lets _load_and_enrich infer + promote

--- a/src/server.py
+++ b/src/server.py
@@ -69,10 +69,10 @@ atexit.register(langfuse.flush)
 
 @mcp.tool()
 async def clear_session_cache() -> str:
-    """Clears the session cache. Use when switching contexts."""
+    """Clears the session cache and sticky agent mappings. Use when switching contexts."""
     SESSION_CACHE.clear()
     CONTEXT_HASH_CACHE.clear()
-    return "Session cache cleared"
+    return "Session cache and sticky agent mappings cleared"
 
 _META_QUERY_RE = re.compile(
     r"^("
@@ -240,12 +240,40 @@ async def route_and_load(
                 reasoning = "Auto-fallback: meta-query overrides sticky agent"
                 explicit_tier = "lite"
             else:
-                # Use unfiltered nearest match to distinguish "empty cache" from "topic change"
-                nearest = await router._query_nearest(query, {"history_text": history_text})
+                # Use unfiltered nearest match to distinguish "empty cache" from "topic change".
+                # query_nearest raises on ChromaDB errors — release to ROUTE_REQUIRED on failure.
+                lookup_failed = False
+                try:
+                    nearest = await router.query_nearest(query, {"history_text": history_text})
+                except Exception as e:
+                    logger.error(f"Sticky lookup failed, releasing to standard routing: {e}")
+                    debug_log("route_and_load", "sticky", {"action": "release", "reason": "lookup_error", "from": sticky_agent, "error": str(e)})
+                    nearest = None
+                    lookup_failed = True
+
                 similarity_threshold = 1 - ROUTER_SIMILARITY_THRESHOLD  # 0.05
 
-                if nearest is None:
-                    # Cache is empty — keep current agent, don't cache
+                if lookup_failed:
+                    # DB error — release to ROUTE_REQUIRED so LLM can decide
+                    candidates = router.get_agent_catalog()
+                    result = {
+                        "status": "ROUTE_REQUIRED",
+                        "request_id": request_id,
+                        "tier": tier,
+                        "candidates": candidates,
+                        "instruction": (
+                            "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
+                            "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
+                            "Do NOT explore the codebase. Do NOT answer the user. "
+                            "FIRST pick the single best agent from candidates, THEN call ONLY: "
+                            "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
+                            "Wait for its response. Only THEN proceed with the user's request."
+                        ),
+                    }
+                    debug_log("route_and_load", "res", result)
+                    return json.dumps(result, ensure_ascii=False)
+                elif nearest is None:
+                    # Cache is genuinely empty — keep current agent, don't cache
                     agent_name = sticky_agent
                     reasoning = "Sticky: cache empty, keeping current agent"
                     should_cache = False

--- a/src/server.py
+++ b/src/server.py
@@ -266,13 +266,15 @@ async def route_and_load(
                 lookup_failed = False
                 try:
                     nearest = await router.query_nearest(query, {"history_text": history_text})
+                except asyncio.CancelledError:
+                    raise
                 except Exception as e:
-                    logger.error(f"Sticky lookup failed, releasing to standard routing: {e}")
+                    logger.error(f"Sticky lookup failed, releasing to ROUTE_REQUIRED: {e}")
                     debug_log("route_and_load", "sticky", {"action": "release", "reason": "lookup_error", "from": sticky_agent, "error": str(e)})
                     nearest = None
                     lookup_failed = True
 
-                similarity_threshold = 1 - ROUTER_SIMILARITY_THRESHOLD  # 0.05
+                similarity_threshold = 1 - ROUTER_SIMILARITY_THRESHOLD
 
                 if lookup_failed:
                     # DB error — release to ROUTE_REQUIRED so LLM can decide

--- a/src/server.py
+++ b/src/server.py
@@ -263,34 +263,27 @@ async def route_and_load(
                     debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": nearest[1]})
                 elif nearest[1] >= similarity_threshold:
                     # Query is far from anything cached — likely a topic change.
-                    # Fall back to standard routing so the LLM can pick the right agent.
+                    # Go straight to ROUTE_REQUIRED so the LLM can pick the right agent.
+                    # No need to call lookup_cache (same query would yield the same far result)
+                    # or _is_meta_query (already checked before entering sticky branch).
                     debug_log("route_and_load", "sticky", {"action": "release", "reason": "topic_change", "from": sticky_agent, "distance": nearest[1]})
-                    cached_decision = await router.lookup_cache(query, {"history_text": history_text})
-                    if cached_decision:
-                        agent_name = cached_decision.target_agent
-                        reasoning = cached_decision.reasoning
-                    elif _is_meta_query(query):
-                        agent_name = "universal_agent"
-                        reasoning = "Auto-fallback: meta-query detected"
-                        explicit_tier = "lite"
-                    else:
-                        candidates = router.get_agent_catalog()
-                        result = {
-                            "status": "ROUTE_REQUIRED",
-                            "request_id": request_id,
-                            "tier": tier,
-                            "candidates": candidates,
-                            "instruction": (
-                                "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
-                                "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
-                                "Do NOT explore the codebase. Do NOT answer the user. "
-                                "FIRST pick the single best agent from candidates, THEN call ONLY: "
-                                "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
-                                "Wait for its response. Only THEN proceed with the user's request."
-                            ),
-                        }
-                        debug_log("route_and_load", "res", result)
-                        return json.dumps(result, ensure_ascii=False)
+                    candidates = router.get_agent_catalog()
+                    result = {
+                        "status": "ROUTE_REQUIRED",
+                        "request_id": request_id,
+                        "tier": tier,
+                        "candidates": candidates,
+                        "instruction": (
+                            "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
+                            "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
+                            "Do NOT explore the codebase. Do NOT answer the user. "
+                            "FIRST pick the single best agent from candidates, THEN call ONLY: "
+                            "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
+                            "Wait for its response. Only THEN proceed with the user's request."
+                        ),
+                    }
+                    debug_log("route_and_load", "res", result)
+                    return json.dumps(result, ensure_ascii=False)
                 else:
                     # Close match for a different agent, but not strong enough to auto-switch.
                     # Keep sticky agent for stability, don't cache.

--- a/src/server.py
+++ b/src/server.py
@@ -71,6 +71,7 @@ atexit.register(langfuse.flush)
 async def clear_session_cache() -> str:
     """Clears the session cache. Use when switching contexts."""
     SESSION_CACHE.clear()
+    CONTEXT_HASH_CACHE.clear()
     return "Session cache cleared"
 
 _META_QUERY_RE = re.compile(
@@ -104,7 +105,7 @@ def _normalize_chat_history(chat_history: Optional[List[str] | str]) -> List[str
 
     return [entry for entry in chat_history if isinstance(entry, str)]
 
-CONTEXT_HASH_CACHE: TTLCache = TTLCache(maxsize=64, ttl=SESSION_CACHE_TTL_SECONDS)
+CONTEXT_HASH_CACHE: TTLCache = TTLCache(maxsize=SESSION_CACHE_MAX_SIZE, ttl=SESSION_CACHE_TTL_SECONDS)
 
 def _compute_context_hash(prompt: str) -> str:
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
@@ -225,50 +226,54 @@ async def route_and_load(
 
         # 1. Sticky agent: if we already have an active agent, prefer keeping it
         explicit_tier = None  # only set for intentional overrides (e.g. meta-query)
-        sticky_agent = None
         should_cache = True  # skip caching for unvalidated sticky decisions
-        if context_hash and context_hash in CONTEXT_HASH_CACHE:
-            sticky_agent = CONTEXT_HASH_CACHE[context_hash]
+        sticky_agent = CONTEXT_HASH_CACHE.get(context_hash) if context_hash else None
+        if sticky_agent:
             logger.info(f"Sticky agent active: {sticky_agent} (hash={context_hash})")
 
-        # Meta-queries always go to universal_agent regardless of sticky state
-        if _is_meta_query(query):
-            agent_name = "universal_agent"
-            reasoning = "Auto-fallback: meta-query detected"
-            explicit_tier = "lite"
-        elif sticky_agent:
-            # Check if semantic cache suggests a different agent
-            cache_result = await router.lookup_cache_with_distance(query, {"history_text": history_text})
-            if cache_result is None:
-                # No similar query seen before — keep current agent, but don't cache
-                # (LLM never validated this routing, avoid polluting cache)
-                agent_name = sticky_agent
-                reasoning = "Sticky: no competing route found"
-                should_cache = False
-                debug_log("route_and_load", "sticky", {"action": "keep", "reason": "no_cache_hit", "agent": agent_name})
-            elif cache_result[0].target_agent == sticky_agent:
-                # Cache confirms the same agent
-                agent_name = sticky_agent
-                reasoning = f"Sticky: confirmed by cache (d={cache_result[1]:.4f})"
-                debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": cache_result[1]})
-            elif cache_result[1] < STICKY_SWITCH_THRESHOLD:
-                # Very strong signal for a different agent — auto-switch
-                agent_name = cache_result[0].target_agent
-                reasoning = f"Auto-switch from {sticky_agent}: strong signal (d={cache_result[1]:.4f})"
-                logger.info(f"Sticky override: {sticky_agent} → {agent_name} (d={cache_result[1]:.4f})")
-                debug_log("route_and_load", "sticky", {"action": "switch", "from": sticky_agent, "to": agent_name, "distance": cache_result[1]})
+        if sticky_agent:
+            # Meta-queries always override sticky state
+            if _is_meta_query(query):
+                agent_name = "universal_agent"
+                reasoning = "Auto-fallback: meta-query overrides sticky agent"
+                explicit_tier = "lite"
             else:
-                # Ambiguous — keep current agent (prefer stability), don't cache
-                agent_name = sticky_agent
-                reasoning = f"Sticky: kept despite weak competing signal for {cache_result[0].target_agent} (d={cache_result[1]:.4f})"
-                should_cache = False
-                debug_log("route_and_load", "sticky", {"action": "keep", "reason": "weak_signal", "agent": agent_name, "competing": cache_result[0].target_agent, "distance": cache_result[1]})
+                # Check if semantic cache suggests a different agent
+                cache_result = await router.lookup_cache_with_distance(query, {"history_text": history_text})
+                if cache_result is None:
+                    # No similar query seen before — keep current agent, but don't cache
+                    # (LLM never validated this routing, avoid polluting cache)
+                    agent_name = sticky_agent
+                    reasoning = "Sticky: no competing route found"
+                    should_cache = False
+                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "no_cache_hit", "agent": agent_name})
+                elif cache_result[0].target_agent == sticky_agent:
+                    # Cache confirms the same agent
+                    agent_name = sticky_agent
+                    reasoning = f"Sticky: confirmed by cache (d={cache_result[1]:.4f})"
+                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": cache_result[1]})
+                elif cache_result[1] < STICKY_SWITCH_THRESHOLD:
+                    # Very strong signal for a different agent — auto-switch
+                    agent_name = cache_result[0].target_agent
+                    reasoning = f"Auto-switch from {sticky_agent}: strong signal (d={cache_result[1]:.4f})"
+                    logger.info(f"Sticky override: {sticky_agent} → {agent_name} (d={cache_result[1]:.4f})")
+                    debug_log("route_and_load", "sticky", {"action": "switch", "from": sticky_agent, "to": agent_name, "distance": cache_result[1]})
+                else:
+                    # Ambiguous — keep current agent (prefer stability), don't cache
+                    agent_name = sticky_agent
+                    reasoning = f"Sticky: kept despite weak competing signal for {cache_result[0].target_agent} (d={cache_result[1]:.4f})"
+                    should_cache = False
+                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "weak_signal", "agent": agent_name, "competing": cache_result[0].target_agent, "distance": cache_result[1]})
         else:
-            # 2. No sticky agent — standard routing
+            # 2. No sticky agent — standard routing (cache → meta-query → ROUTE_REQUIRED)
             cached_decision = await router.lookup_cache(query, {"history_text": history_text})
             if cached_decision:
                 agent_name = cached_decision.target_agent
                 reasoning = cached_decision.reasoning
+            elif _is_meta_query(query):
+                agent_name = "universal_agent"
+                reasoning = "Auto-fallback: meta-query detected"
+                explicit_tier = "lite"
             else:
                 # 3. Cache miss — return candidates for the calling LLM to decide
                 candidates = router.get_agent_catalog()

--- a/src/server.py
+++ b/src/server.py
@@ -213,6 +213,9 @@ async def route_and_load(
     Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
     Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
     Pass `context_hash` from a previous response to enable delta mode.
+    When context_hash maps to a previously loaded agent, sticky routing is activated:
+    the router prefers keeping the current agent unless a very strong semantic signal
+    (distance < STICKY_SWITCH_THRESHOLD) suggests a different one.
     """
     try:
         chat_history_list = _normalize_chat_history(chat_history)
@@ -228,10 +231,9 @@ async def route_and_load(
         explicit_tier = None  # only set for intentional overrides (e.g. meta-query)
         should_cache = True  # skip caching for unvalidated sticky decisions
         sticky_agent = CONTEXT_HASH_CACHE.get(context_hash) if context_hash else None
-        if sticky_agent:
-            logger.info(f"Sticky agent active: {sticky_agent} (hash={context_hash})")
 
         if sticky_agent:
+            logger.info(f"Sticky agent active: {sticky_agent} (hash={context_hash})")
             # Meta-queries always override sticky state
             if _is_meta_query(query):
                 agent_name = "universal_agent"

--- a/src/server.py
+++ b/src/server.py
@@ -32,7 +32,7 @@ from src.engine.enrichment import (
     infer_tier,
     implant_retriever,
 )
-from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD
+from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD, ROUTER_SIMILARITY_THRESHOLD
 from src.utils.prompt_loader import load_agent_prompt, get_agent_metadata
 from src.utils.debug_logger import debug_log
 
@@ -240,32 +240,64 @@ async def route_and_load(
                 reasoning = "Auto-fallback: meta-query overrides sticky agent"
                 explicit_tier = "lite"
             else:
-                # Check if semantic cache suggests a different agent
-                cache_result = await router.lookup_cache_with_distance(query, {"history_text": history_text})
-                if cache_result is None:
-                    # No similar query seen before — keep current agent, but don't cache
-                    # (LLM never validated this routing, avoid polluting cache)
+                # Use unfiltered nearest match to distinguish "empty cache" from "topic change"
+                nearest = await router._query_nearest(query, {"history_text": history_text})
+                similarity_threshold = 1 - ROUTER_SIMILARITY_THRESHOLD  # 0.05
+
+                if nearest is None:
+                    # Cache is empty — keep current agent, don't cache
                     agent_name = sticky_agent
-                    reasoning = "Sticky: no competing route found"
+                    reasoning = "Sticky: cache empty, keeping current agent"
                     should_cache = False
-                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "no_cache_hit", "agent": agent_name})
-                elif cache_result[0].target_agent == sticky_agent:
+                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "empty_cache", "agent": agent_name})
+                elif nearest[1] < STICKY_SWITCH_THRESHOLD and nearest[0].target_agent != sticky_agent:
+                    # Very strong signal for a different agent — auto-switch
+                    agent_name = nearest[0].target_agent
+                    reasoning = f"Auto-switch from {sticky_agent}: strong signal (d={nearest[1]:.4f})"
+                    logger.info(f"Sticky override: {sticky_agent} → {agent_name} (d={nearest[1]:.4f})")
+                    debug_log("route_and_load", "sticky", {"action": "switch", "from": sticky_agent, "to": agent_name, "distance": nearest[1]})
+                elif nearest[1] < similarity_threshold and nearest[0].target_agent == sticky_agent:
                     # Cache confirms the same agent
                     agent_name = sticky_agent
-                    reasoning = f"Sticky: confirmed by cache (d={cache_result[1]:.4f})"
-                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": cache_result[1]})
-                elif cache_result[1] < STICKY_SWITCH_THRESHOLD:
-                    # Very strong signal for a different agent — auto-switch
-                    agent_name = cache_result[0].target_agent
-                    reasoning = f"Auto-switch from {sticky_agent}: strong signal (d={cache_result[1]:.4f})"
-                    logger.info(f"Sticky override: {sticky_agent} → {agent_name} (d={cache_result[1]:.4f})")
-                    debug_log("route_and_load", "sticky", {"action": "switch", "from": sticky_agent, "to": agent_name, "distance": cache_result[1]})
+                    reasoning = f"Sticky: confirmed by cache (d={nearest[1]:.4f})"
+                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": nearest[1]})
+                elif nearest[1] >= similarity_threshold:
+                    # Query is far from anything cached — likely a topic change.
+                    # Fall back to standard routing so the LLM can pick the right agent.
+                    debug_log("route_and_load", "sticky", {"action": "release", "reason": "topic_change", "from": sticky_agent, "distance": nearest[1]})
+                    cached_decision = await router.lookup_cache(query, {"history_text": history_text})
+                    if cached_decision:
+                        agent_name = cached_decision.target_agent
+                        reasoning = cached_decision.reasoning
+                    elif _is_meta_query(query):
+                        agent_name = "universal_agent"
+                        reasoning = "Auto-fallback: meta-query detected"
+                        explicit_tier = "lite"
+                    else:
+                        candidates = router.get_agent_catalog()
+                        result = {
+                            "status": "ROUTE_REQUIRED",
+                            "request_id": request_id,
+                            "tier": tier,
+                            "candidates": candidates,
+                            "instruction": (
+                                "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
+                                "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
+                                "Do NOT explore the codebase. Do NOT answer the user. "
+                                "FIRST pick the single best agent from candidates, THEN call ONLY: "
+                                "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
+                                "Wait for its response. Only THEN proceed with the user's request."
+                            ),
+                        }
+                        debug_log("route_and_load", "res", result)
+                        return json.dumps(result, ensure_ascii=False)
                 else:
-                    # Ambiguous — keep current agent (prefer stability), don't cache
+                    # Close match for a different agent, but not strong enough to auto-switch.
+                    # Keep sticky agent for stability, don't cache.
                     agent_name = sticky_agent
-                    reasoning = f"Sticky: kept despite weak competing signal for {cache_result[0].target_agent} (d={cache_result[1]:.4f})"
+                    reasoning = f"Sticky: kept despite competing signal for {nearest[0].target_agent} (d={nearest[1]:.4f})"
                     should_cache = False
-                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "weak_signal", "agent": agent_name, "competing": cache_result[0].target_agent, "distance": cache_result[1]})
+                    debug_log("route_and_load", "sticky", {"action": "keep", "reason": "weak_signal", "agent": agent_name, "competing": nearest[0].target_agent, "distance": nearest[1]})
         else:
             # 2. No sticky agent — standard routing (cache → meta-query → ROUTE_REQUIRED)
             cached_decision = await router.lookup_cache(query, {"history_text": history_text})

--- a/src/server.py
+++ b/src/server.py
@@ -32,7 +32,7 @@ from src.engine.enrichment import (
     infer_tier,
     implant_retriever,
 )
-from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS
+from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD
 from src.utils.prompt_loader import load_agent_prompt, get_agent_metadata
 from src.utils.debug_logger import debug_log
 
@@ -223,35 +223,71 @@ async def route_and_load(
             "history_len": len(chat_history_list), "request_id": request_id,
         })
 
-        # 1. Try semantic cache
+        # 1. Sticky agent: if we already have an active agent, prefer keeping it
         explicit_tier = None  # only set for intentional overrides (e.g. meta-query)
-        cached_decision = await router.lookup_cache(query, {"history_text": history_text})
-        if cached_decision:
-            agent_name = cached_decision.target_agent
-            reasoning = cached_decision.reasoning
-        elif _is_meta_query(query):
+        sticky_agent = None
+        should_cache = True  # skip caching for unvalidated sticky decisions
+        if context_hash and context_hash in CONTEXT_HASH_CACHE:
+            sticky_agent = CONTEXT_HASH_CACHE[context_hash]
+            logger.info(f"Sticky agent active: {sticky_agent} (hash={context_hash})")
+
+        # Meta-queries always go to universal_agent regardless of sticky state
+        if _is_meta_query(query):
             agent_name = "universal_agent"
             reasoning = "Auto-fallback: meta-query detected"
             explicit_tier = "lite"
+        elif sticky_agent:
+            # Check if semantic cache suggests a different agent
+            cache_result = await router.lookup_cache_with_distance(query, {"history_text": history_text})
+            if cache_result is None:
+                # No similar query seen before — keep current agent, but don't cache
+                # (LLM never validated this routing, avoid polluting cache)
+                agent_name = sticky_agent
+                reasoning = "Sticky: no competing route found"
+                should_cache = False
+                debug_log("route_and_load", "sticky", {"action": "keep", "reason": "no_cache_hit", "agent": agent_name})
+            elif cache_result[0].target_agent == sticky_agent:
+                # Cache confirms the same agent
+                agent_name = sticky_agent
+                reasoning = f"Sticky: confirmed by cache (d={cache_result[1]:.4f})"
+                debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": cache_result[1]})
+            elif cache_result[1] < STICKY_SWITCH_THRESHOLD:
+                # Very strong signal for a different agent — auto-switch
+                agent_name = cache_result[0].target_agent
+                reasoning = f"Auto-switch from {sticky_agent}: strong signal (d={cache_result[1]:.4f})"
+                logger.info(f"Sticky override: {sticky_agent} → {agent_name} (d={cache_result[1]:.4f})")
+                debug_log("route_and_load", "sticky", {"action": "switch", "from": sticky_agent, "to": agent_name, "distance": cache_result[1]})
+            else:
+                # Ambiguous — keep current agent (prefer stability), don't cache
+                agent_name = sticky_agent
+                reasoning = f"Sticky: kept despite weak competing signal for {cache_result[0].target_agent} (d={cache_result[1]:.4f})"
+                should_cache = False
+                debug_log("route_and_load", "sticky", {"action": "keep", "reason": "weak_signal", "agent": agent_name, "competing": cache_result[0].target_agent, "distance": cache_result[1]})
         else:
-            # 2. Cache miss — return candidates for the calling LLM to decide
-            candidates = router.get_agent_catalog()
-            result = {
-                "status": "ROUTE_REQUIRED",
-                "request_id": request_id,
-                "tier": tier,
-                "candidates": candidates,
-                "instruction": (
-                    "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
-                    "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
-                    "Do NOT explore the codebase. Do NOT answer the user. "
-                    "FIRST pick the single best agent from candidates, THEN call ONLY: "
-                    "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
-                    "Wait for its response. Only THEN proceed with the user's request."
-                ),
-            }
-            debug_log("route_and_load", "res", result)
-            return json.dumps(result, ensure_ascii=False)
+            # 2. No sticky agent — standard routing
+            cached_decision = await router.lookup_cache(query, {"history_text": history_text})
+            if cached_decision:
+                agent_name = cached_decision.target_agent
+                reasoning = cached_decision.reasoning
+            else:
+                # 3. Cache miss — return candidates for the calling LLM to decide
+                candidates = router.get_agent_catalog()
+                result = {
+                    "status": "ROUTE_REQUIRED",
+                    "request_id": request_id,
+                    "tier": tier,
+                    "candidates": candidates,
+                    "instruction": (
+                        "CRITICAL: You MUST call get_agent_context(agent_name, query) RIGHT NOW as your ONLY next action. "
+                        "Do NOT call any other tools. Do NOT use Agent, Bash, Read, Grep, or any tool in parallel. "
+                        "Do NOT explore the codebase. Do NOT answer the user. "
+                        "FIRST pick the single best agent from candidates, THEN call ONLY: "
+                        "get_agent_context(agent_name=\"<chosen>\", query=\"<original query>\"). "
+                        "Wait for its response. Only THEN proceed with the user's request."
+                    ),
+                }
+                debug_log("route_and_load", "res", result)
+                return json.dumps(result, ensure_ascii=False)
 
         # 3. Cache hit or meta-query — load enriched prompt
         # Pass explicit_tier only for meta-queries (preserves "lite"); None lets _load_and_enrich infer + promote
@@ -270,7 +306,8 @@ async def route_and_load(
             debug_log("route_and_load", "res", result)
             return json.dumps(result, ensure_ascii=False)
 
-        await router.update_cache(query, agent_name, reasoning, request_id)
+        if should_cache:
+            await router.update_cache(query, agent_name, reasoning, request_id)
 
         # Try sampling: generate response with agent's system prompt via client LLM
         if ctx:

--- a/src/server.py
+++ b/src/server.py
@@ -274,7 +274,7 @@ async def route_and_load(
                     nearest = None
                     lookup_failed = True
 
-                similarity_threshold = 1 - ROUTER_SIMILARITY_THRESHOLD
+                distance_threshold = 1 - ROUTER_SIMILARITY_THRESHOLD
 
                 if lookup_failed:
                     # DB error — release to ROUTE_REQUIRED so LLM can decide
@@ -291,12 +291,12 @@ async def route_and_load(
                     reasoning = f"Auto-switch from {sticky_agent}: strong signal (d={nearest[1]:.4f})"
                     logger.info(f"Sticky override: {sticky_agent} → {agent_name} (d={nearest[1]:.4f})")
                     debug_log("route_and_load", "sticky", {"action": "switch", "from": sticky_agent, "to": agent_name, "distance": nearest[1]})
-                elif nearest[1] < similarity_threshold and nearest[0].target_agent == sticky_agent:
+                elif nearest[1] < distance_threshold and nearest[0].target_agent == sticky_agent:
                     # Cache confirms the same agent
                     agent_name = sticky_agent
                     reasoning = f"Sticky: confirmed by cache (d={nearest[1]:.4f})"
                     debug_log("route_and_load", "sticky", {"action": "keep", "reason": "same_agent", "agent": agent_name, "distance": nearest[1]})
-                elif nearest[1] >= similarity_threshold:
+                elif nearest[1] >= distance_threshold:
                     # Query is far from anything cached — likely a topic change.
                     # Go straight to ROUTE_REQUIRED so the LLM can pick the right agent.
                     debug_log("route_and_load", "sticky", {"action": "release", "reason": "topic_change", "from": sticky_agent, "distance": nearest[1]})

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7,7 +7,7 @@ Queries are multilingual (EN, RU, DE, ES, FR) and depersonalized.
 
 import json
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from cachetools import TTLCache
 
 from src.server import _is_meta_query, _normalize_chat_history
@@ -236,7 +236,7 @@ class TestStickyRouting:
         """With sticky agent and completely empty cache, keep current agent."""
         self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "medical_expert"
 
-        with patch.object(self.srv.router, "_query_nearest",
+        with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=None), \
              patch("src.server._load_and_enrich", new_callable=AsyncMock,
                    return_value=self._make_enrich_result("medical_expert")), \
@@ -258,7 +258,7 @@ class TestStickyRouting:
         cached = RouterDecision(target_agent="sysadmin", confidence=1.0,
                                 reasoning="Cached", is_cached=True)
 
-        with patch.object(self.srv.router, "_query_nearest",
+        with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=(cached, 0.01)), \
              patch("src.server._load_and_enrich", new_callable=AsyncMock,
                    return_value=self._make_enrich_result("sysadmin")), \
@@ -278,7 +278,7 @@ class TestStickyRouting:
         cached = RouterDecision(target_agent="daily_briefing", confidence=1.0,
                                 reasoning="Cached", is_cached=True)
 
-        with patch.object(self.srv.router, "_query_nearest",
+        with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=(cached, 0.005)), \
              patch("src.server._load_and_enrich", new_callable=AsyncMock,
                    return_value=self._make_enrich_result("daily_briefing")), \
@@ -297,7 +297,7 @@ class TestStickyRouting:
         cached = RouterDecision(target_agent="daily_briefing", confidence=1.0,
                                 reasoning="Cached", is_cached=True)
 
-        with patch.object(self.srv.router, "_query_nearest",
+        with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=(cached, 0.04)), \
              patch("src.server._load_and_enrich", new_callable=AsyncMock,
                    return_value=self._make_enrich_result("software_engineer")), \
@@ -317,7 +317,7 @@ class TestStickyRouting:
         far_match = RouterDecision(target_agent="daily_briefing", confidence=1.0,
                                    reasoning="Cached", is_cached=True)
 
-        with patch.object(self.srv.router, "_query_nearest",
+        with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=(far_match, 0.15)), \
              patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=None), \
              patch.object(self.srv.router, "get_agent_catalog", return_value=[{"name": "universal_agent"}]):
@@ -342,6 +342,20 @@ class TestStickyRouting:
             assert result["agent"] == "universal_agent"
 
     @pytest.mark.asyncio
+    async def test_sticky_releases_on_lookup_error(self):
+        """When ChromaDB query fails, release to ROUTE_REQUIRED instead of keeping sticky."""
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
+
+        with patch.object(self.srv.router, "query_nearest",
+                          new_callable=AsyncMock, side_effect=RuntimeError("ChromaDB connection lost")), \
+             patch.object(self.srv.router, "get_agent_catalog", return_value=[{"name": "universal_agent"}]):
+            result = json.loads(await self.srv.route_and_load(
+                "Wie kann ich die Leistung meiner Datenbank optimieren?",
+                context_hash="prev_hash",
+            ))
+            assert result["status"] == "ROUTE_REQUIRED"
+
+    @pytest.mark.asyncio
     async def test_expired_context_hash_falls_through(self):
         """If context_hash is not in cache (expired), treat as non-sticky."""
         with patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=None), \
@@ -357,7 +371,7 @@ class TestStickyRouting:
         """If enriched prompt produces the same hash, return NO_CHANGE."""
         self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
 
-        with patch.object(self.srv.router, "_query_nearest",
+        with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=None), \
              patch("src.server._load_and_enrich", new_callable=AsyncMock,
                    return_value=("prompt", "prev_hash", ["s"], ["i"], "standard")), \

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 from cachetools import TTLCache
 
 from src.server import _is_meta_query, _normalize_chat_history
+from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -180,8 +181,8 @@ class TestStickyRouting:
         self.original_ctx_cache = srv.CONTEXT_HASH_CACHE
         self.original_session_cache = srv.SESSION_CACHE
 
-        srv.CONTEXT_HASH_CACHE = TTLCache(maxsize=128, ttl=600)
-        srv.SESSION_CACHE = TTLCache(maxsize=128, ttl=600)
+        srv.CONTEXT_HASH_CACHE = TTLCache(maxsize=SESSION_CACHE_MAX_SIZE, ttl=SESSION_CACHE_TTL_SECONDS)
+        srv.SESSION_CACHE = TTLCache(maxsize=SESSION_CACHE_MAX_SIZE, ttl=SESSION_CACHE_TTL_SECONDS)
 
         yield
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,388 @@
+"""
+Tests for routing logic: _is_meta_query, _normalize_chat_history,
+and sticky agent routing in route_and_load.
+
+Queries are multilingual (EN, RU, DE, ES, FR) and depersonalized.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from cachetools import TTLCache
+
+from src.server import _is_meta_query, _normalize_chat_history
+
+
+# ---------------------------------------------------------------------------
+# _is_meta_query
+# ---------------------------------------------------------------------------
+
+class TestIsMetaQuery:
+    """Verify meta-query detection across languages."""
+
+    # --- Should be detected as meta ---
+
+    @pytest.mark.parametrize("query", [
+        # English
+        "hi",
+        "hey",
+        "hello",
+        "test",
+        "what can you do?",
+        "What tools do you have?",
+        "help me",
+        "introduce yourself",
+        "who are you",
+        "what are you",
+        # Russian
+        "привет",
+        "Привет!",
+        "здравствуй",
+        "кто ты",
+        "кто ты?",
+        "помоги",
+        "что ты умеешь",
+        "какие у тебя инструменты",
+        "какие есть агенты",
+    ])
+    def test_meta_queries_detected(self, query):
+        assert _is_meta_query(query) is True
+
+    # Short queries (< 10 chars) are always meta regardless of language
+    @pytest.mark.parametrize("query", [
+        "ok",
+        "да",
+        "yes",
+        "??",
+        "ок",
+        "oui",
+        "ja",
+        "sí",
+    ])
+    def test_short_queries_are_meta(self, query):
+        assert _is_meta_query(query) is True
+
+    # --- Should NOT be detected as meta ---
+
+    @pytest.mark.parametrize("query", [
+        # English — technical
+        "Review and fix linter warnings in the authentication module",
+        "Thorough code review: clean up unused imports and check test coverage",
+        "Fix validation logic for user registration endpoint",
+        "One-liner to archive only intact files from a storage pool preserving permissions",
+        "Database corruption root cause analysis — what information to collect for a bug report",
+        "Translate project documentation to English and create an architecture diagram",
+        "Set up a split tunnel VPN configuration on a mobile device",
+        # Russian — news/analysis
+        "Какие главные новости сегодня в мире?",
+        "Расскажи про последние события в регионе",
+        # Russian — medical
+        "У пациента 35 лет после физической нагрузки болит поясница уже неделю",
+        # Russian — creative
+        "Написать короткий рассказ про кота и его приключения",
+        # Russian — parenting
+        "Ребёнок 7 лет рассказывает всем семейные секреты, как с этим справиться",
+        "Как объяснить ребёнку сложную тему простыми словами?",
+        # Russian — technical
+        "Проверь почему сервер перестал отвечать на запросы через API",
+        "Оптимизация роутинга: кэширование решений по контексту запроса",
+        "Проведи ревью изменений кода на текущей ветке",
+        # Russian — travel
+        "Как лучше всего провести отпуск с семьёй на побережье?",
+        # Russian — health
+        "Расскажи, как улучшить качество сна?",
+        # Russian — philosophy
+        "Что появилось первое — курица или яйцо?",
+        # German — various topics
+        "Wie kann ich die Leistung meiner Datenbank optimieren?",
+        "Erkläre den Unterschied zwischen REST und GraphQL",
+        "Schreibe eine kurze Geschichte über einen Roboter, der träumen lernt",
+        "Welche Sehenswürdigkeiten sollte man in der Hauptstadt besuchen?",
+        # Spanish — various topics
+        "¿Cómo puedo mejorar el rendimiento de mi aplicación web?",
+        "Explica la diferencia entre microservicios y monolitos",
+        "Escribe un cuento corto sobre un viaje en el tiempo",
+        "¿Cuáles son las mejores prácticas para la seguridad de APIs?",
+        # French — various topics
+        "Comment optimiser les requêtes SQL dans une base de données relationnelle?",
+        "Explique la différence entre Docker et Kubernetes",
+        "Écris une courte histoire sur un chat qui explore une ville abandonnée",
+        "Quelles sont les meilleures pratiques pour le déploiement continu?",
+    ])
+    def test_real_queries_not_meta(self, query):
+        assert _is_meta_query(query) is False
+
+    # --- Known false positive: "help me with X" is caught by ^help\b ---
+    def test_help_with_topic_is_meta_false_positive(self):
+        # "help me with database optimization" SHOULD ideally NOT be meta,
+        # but ^help\b matches it. Documenting current behavior.
+        assert _is_meta_query("help me with database optimization") is True
+
+    # --- Edge cases ---
+    def test_question_about_project_not_meta(self):
+        assert _is_meta_query("Что здесь интересного? Обзор проекта") is False
+
+    def test_short_question_about_repo_not_meta(self):
+        # 18 chars, doesn't match meta regex
+        assert _is_meta_query("Что это за репо?") is False
+
+    def test_german_greeting_not_detected(self):
+        # German greetings are not in the regex — only EN/RU are supported
+        assert _is_meta_query("Hallo, wie geht es dir?") is False
+
+    def test_spanish_greeting_not_detected(self):
+        assert _is_meta_query("Hola, ¿qué puedes hacer?") is False
+
+    def test_french_greeting_not_detected(self):
+        assert _is_meta_query("Bonjour, qui es-tu?") is False
+
+
+# ---------------------------------------------------------------------------
+# _normalize_chat_history
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChatHistory:
+    def test_none_returns_empty(self):
+        assert _normalize_chat_history(None) == []
+
+    def test_empty_string_returns_empty(self):
+        assert _normalize_chat_history("") == []
+
+    def test_whitespace_string_returns_empty(self):
+        assert _normalize_chat_history("   ") == []
+
+    def test_single_string_wrapped(self):
+        assert _normalize_chat_history("hello") == ["hello"]
+
+    def test_list_passthrough(self):
+        assert _normalize_chat_history(["a", "b"]) == ["a", "b"]
+
+    def test_list_filters_non_strings(self):
+        assert _normalize_chat_history(["a", 42, None, "b"]) == ["a", "b"]
+
+    def test_list_keeps_empty_strings(self):
+        assert _normalize_chat_history(["a", "", "b"]) == ["a", "", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Sticky routing integration tests
+# ---------------------------------------------------------------------------
+
+class TestStickyRouting:
+    """Test sticky agent routing logic using mocked router and caches."""
+
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self):
+        """Patch router, caches, and enrichment for each test."""
+        import src.server as srv
+
+        self.srv = srv
+        self.original_ctx_cache = srv.CONTEXT_HASH_CACHE
+        self.original_session_cache = srv.SESSION_CACHE
+
+        srv.CONTEXT_HASH_CACHE = TTLCache(maxsize=128, ttl=600)
+        srv.SESSION_CACHE = TTLCache(maxsize=128, ttl=600)
+
+        yield
+
+        srv.CONTEXT_HASH_CACHE = self.original_ctx_cache
+        srv.SESSION_CACHE = self.original_session_cache
+
+    def _make_enrich_result(self, agent_name):
+        """Helper: return a fake _load_and_enrich result."""
+        prompt = f"system prompt for {agent_name}"
+        ctx_hash = f"hash_{agent_name}"
+        return (prompt, ctx_hash, ["skill-a"], ["implant-a"], "standard")
+
+    @pytest.mark.asyncio
+    async def test_no_sticky_cache_miss_returns_route_required(self):
+        """Without context_hash, a cache miss should return ROUTE_REQUIRED."""
+        with patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=None), \
+             patch.object(self.srv.router, "get_agent_catalog", return_value=[{"name": "universal_agent"}]):
+            result = json.loads(await self.srv.route_and_load(
+                "Erkläre den Unterschied zwischen REST und GraphQL"))
+            assert result["status"] == "ROUTE_REQUIRED"
+            assert "candidates" in result
+
+    @pytest.mark.asyncio
+    async def test_no_sticky_cache_hit_returns_success(self):
+        """Without context_hash, a cache hit should load the agent and return SUCCESS."""
+        from src.schemas.protocol import RouterDecision
+        cached = RouterDecision(target_agent="daily_briefing", confidence=1.0,
+                                reasoning="Cached", is_cached=True)
+
+        with patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=cached), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("daily_briefing")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock):
+            result = json.loads(await self.srv.route_and_load(
+                "Какие главные новости сегодня в мире?"))
+            assert result["status"] == "SUCCESS"
+            assert result["agent"] == "daily_briefing"
+
+    @pytest.mark.asyncio
+    async def test_no_sticky_meta_query_returns_universal(self):
+        """Meta-queries without sticky context should go to universal_agent."""
+        with patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=None), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("universal_agent")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock):
+            result = json.loads(await self.srv.route_and_load("привет"))
+            assert result["status"] == "SUCCESS"
+            assert result["agent"] == "universal_agent"
+
+    @pytest.mark.asyncio
+    async def test_sticky_keeps_agent_on_empty_cache(self):
+        """With sticky agent and completely empty cache, keep current agent."""
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "medical_expert"
+
+        with patch.object(self.srv.router, "_query_nearest",
+                          new_callable=AsyncMock, return_value=None), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("medical_expert")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock) as mock_cache:
+            result = json.loads(await self.srv.route_and_load(
+                "Le patient a des douleurs lombaires depuis une semaine après un exercice physique",
+                context_hash="prev_hash",
+            ))
+            assert result["status"] == "SUCCESS"
+            assert result["agent"] == "medical_expert"
+            # Should NOT cache unvalidated sticky decision
+            mock_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sticky_confirms_same_agent_from_cache(self):
+        """When cache confirms the same agent (close distance), keep it and allow caching."""
+        from src.schemas.protocol import RouterDecision
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "sysadmin"
+        cached = RouterDecision(target_agent="sysadmin", confidence=1.0,
+                                reasoning="Cached", is_cached=True)
+
+        with patch.object(self.srv.router, "_query_nearest",
+                          new_callable=AsyncMock, return_value=(cached, 0.01)), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("sysadmin")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock) as mock_cache:
+            result = json.loads(await self.srv.route_and_load(
+                "Filesystem corruption root cause analysis — what data to collect",
+                context_hash="prev_hash",
+            ))
+            assert result["agent"] == "sysadmin"
+            mock_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sticky_auto_switches_on_strong_signal(self):
+        """Very strong competing signal (distance < 0.02) triggers auto-switch."""
+        from src.schemas.protocol import RouterDecision
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
+        cached = RouterDecision(target_agent="daily_briefing", confidence=1.0,
+                                reasoning="Cached", is_cached=True)
+
+        with patch.object(self.srv.router, "_query_nearest",
+                          new_callable=AsyncMock, return_value=(cached, 0.005)), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("daily_briefing")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock):
+            result = json.loads(await self.srv.route_and_load(
+                "¿Cuáles son las noticias más importantes de hoy?",
+                context_hash="prev_hash",
+            ))
+            assert result["agent"] == "daily_briefing"
+
+    @pytest.mark.asyncio
+    async def test_sticky_keeps_on_weak_signal(self):
+        """Weak competing signal for different agent (distance 0.02-0.05) keeps sticky."""
+        from src.schemas.protocol import RouterDecision
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
+        cached = RouterDecision(target_agent="daily_briefing", confidence=1.0,
+                                reasoning="Cached", is_cached=True)
+
+        with patch.object(self.srv.router, "_query_nearest",
+                          new_callable=AsyncMock, return_value=(cached, 0.04)), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("software_engineer")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock) as mock_cache:
+            result = json.loads(await self.srv.route_and_load(
+                "Füge jetzt Tests für diese Funktion hinzu",
+                context_hash="prev_hash",
+            ))
+            assert result["agent"] == "software_engineer"
+            mock_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sticky_releases_on_topic_change(self):
+        """When nearest match is far (>= 0.05), sticky releases to ROUTE_REQUIRED."""
+        from src.schemas.protocol import RouterDecision
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
+        far_match = RouterDecision(target_agent="daily_briefing", confidence=1.0,
+                                   reasoning="Cached", is_cached=True)
+
+        with patch.object(self.srv.router, "_query_nearest",
+                          new_callable=AsyncMock, return_value=(far_match, 0.15)), \
+             patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=None), \
+             patch.object(self.srv.router, "get_agent_catalog", return_value=[{"name": "universal_agent"}]):
+            result = json.loads(await self.srv.route_and_load(
+                "Écris une courte histoire sur un chat qui explore une ville abandonnée",
+                context_hash="prev_hash",
+            ))
+            assert result["status"] == "ROUTE_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_sticky_meta_query_overrides_to_universal(self):
+        """Meta-query always overrides sticky agent to universal_agent."""
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
+
+        with patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=self._make_enrich_result("universal_agent")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock):
+            result = json.loads(await self.srv.route_and_load(
+                "hello",
+                context_hash="prev_hash",
+            ))
+            assert result["agent"] == "universal_agent"
+
+    @pytest.mark.asyncio
+    async def test_expired_context_hash_falls_through(self):
+        """If context_hash is not in cache (expired), treat as non-sticky."""
+        with patch.object(self.srv.router, "lookup_cache", new_callable=AsyncMock, return_value=None), \
+             patch.object(self.srv.router, "get_agent_catalog", return_value=[{"name": "universal_agent"}]):
+            result = json.loads(await self.srv.route_and_load(
+                "Review code changes on the current branch",
+                context_hash="expired_hash_not_in_cache",
+            ))
+            assert result["status"] == "ROUTE_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_no_change_on_same_context_hash(self):
+        """If enriched prompt produces the same hash, return NO_CHANGE."""
+        self.srv.CONTEXT_HASH_CACHE["prev_hash"] = "software_engineer"
+
+        with patch.object(self.srv.router, "_query_nearest",
+                          new_callable=AsyncMock, return_value=None), \
+             patch("src.server._load_and_enrich", new_callable=AsyncMock,
+                   return_value=("prompt", "prev_hash", ["s"], ["i"], "standard")), \
+             patch.object(self.srv.router, "update_cache", new_callable=AsyncMock):
+            result = json.loads(await self.srv.route_and_load(
+                "Comment optimiser ce code?",
+                context_hash="prev_hash",
+            ))
+            assert result["status"] == "NO_CHANGE"
+            assert result["agent"] == "software_engineer"
+
+
+# ---------------------------------------------------------------------------
+# clear_session_cache clears both caches
+# ---------------------------------------------------------------------------
+
+class TestClearSessionCache:
+    @pytest.mark.asyncio
+    async def test_clears_both_caches(self):
+        import src.server as srv
+        srv.SESSION_CACHE["key1"] = "val1"
+        srv.CONTEXT_HASH_CACHE["hash1"] = "agent1"
+
+        result = await srv.clear_session_cache()
+
+        assert len(srv.SESSION_CACHE) == 0
+        assert len(srv.CONTEXT_HASH_CACHE) == 0
+        assert "cleared" in result.lower()


### PR DESCRIPTION
When a context_hash is present from a previous turn, the router now prefers keeping the current agent instead of re-routing. Auto-switch only happens on very strong semantic signal (distance < 0.02).

Key decisions:
- Meta-queries always override sticky state (→ universal_agent)
- Unvalidated sticky decisions are not cached to prevent feedback loops
- lookup_cache is now a thin wrapper over lookup_cache_with_distance

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies core routing behavior and cache lookup semantics, which can change which agent answers multi-turn conversations and how often ROUTE_REQUIRED is triggered. Risk is mitigated by tight switch thresholds and comprehensive new tests covering sticky/override/error paths.
> 
> **Overview**
> Adds **sticky agent routing** to `route_and_load`: when a prior `context_hash` maps to an agent, the server prefers keeping that agent across turns, only auto-switching on a very strong semantic match (`STICKY_SWITCH_THRESHOLD`) and otherwise releasing to `ROUTE_REQUIRED` on topic changes or DB lookup errors.
> 
> Refactors router cache lookup by introducing `query_nearest()` (returns nearest decision + distance, raises on Chroma errors) and making `lookup_cache` a thin thresholded wrapper; also centralizes `ROUTE_REQUIRED` response construction, clears sticky mappings in `clear_session_cache`, expands test tooling/deps, and adds a new `tests/test_routing.py` suite plus updated `run_tests.sh` to run all tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c4cd8dce5485b5672066759648bf60689124cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->