### PR TITLE
Expands implant docs and adds new techniques

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ whisper_models/
 # Exceptions (keep these visible)
 !.gitignore
 !.git/
+
+agents_private.egg-info/
+
+uv.lock

--- a/implants/README.md
+++ b/implants/README.md
@@ -49,10 +49,21 @@ implant-{technique-name}.mdc
 description: "Brief description of the reasoning technique"
 globs: []              # File patterns for auto-activation (usually empty)
 alwaysApply: false     # Whether to always include this implant
+short_name: MyTechnique     # CamelCase short name for display
+one_liner: brief action phrase  # Lowercase, no period, describes what it does
 ---
 ## Pattern
-1. Step one of the technique
-2. Step two...
+1. **Step One**: Description of first step
+2. **Step Two**: Description of second step
+3. ...
+
+## When to Use
+- Scenario where this technique is most effective
+- Another appropriate use case
+
+## Limitations
+- Known failure mode or constraint
+- When NOT to use this technique
 ```
 
 ## Implant Categories
@@ -73,6 +84,7 @@ Techniques that structure sequential reasoning:
 | `self-harmonized-cot` | Multiple perspectives harmonized into one |
 | `reverse-cot` | Work backwards from conclusion to premises |
 | `take-a-deep-breath` | Zero-shot CoT trigger |
+| `dr-cot` | Dynamic Recursive CoT — recurse deeper only when needed |
 
 ### Meta-Cognition
 
@@ -126,7 +138,9 @@ Techniques for producing better outputs:
 |---------|-------------|
 | `analogical-prompting` | Reasoning by analogy to known cases |
 | `generated-knowledge` | Generate context before answering |
-| `role-play-expert` | Deep expertise via persona assignment |
+| `role-play-expert` | Expert persona for reasoning style (not facts — see Warning) |
+| `output-priming` | Provide answer opening to steer completion format |
+| `dynamic-few-shot` | Select task-relevant examples from a pool |
 
 > **Moved to skills**: prompt engineering techniques (mega-prompting, few-shot-selection, directional-stimulus, emotion-prompting, simulated-interaction, tone-transfer) → `skill-prompt-techniques`
 
@@ -183,17 +197,27 @@ load_implants(query="How do I debug this race condition?")
 
 1. **Create file**: `implants/implant-my-technique.mdc`
 
-2. **Add content**:
+2. **Add content** (all sections except Example are **required**):
    ```yaml
    ---
    description: "My Technique: brief explanation of when and why to use it"
    globs: []
    alwaysApply: false
+   short_name: MyTechnique
+   one_liner: brief action phrase describing what it does
    ---
    ## Pattern
-   1. First step of the technique
-   2. Second step
+   1. **Step One**: First step of the technique
+   2. **Step Two**: Second step
    3. ...
+
+   ## When to Use
+   - Scenario 1 where this technique excels
+   - Scenario 2...
+
+   ## Limitations
+   - Known failure mode or constraint
+   - When NOT to use this technique
 
    ## Example (optional)
    Input: "..."

--- a/implants/implant-active-prompting.mdc
+++ b/implants/implant-active-prompting.mdc
@@ -1,10 +1,29 @@
 ---
-description: Active Prompting. Active uncertainty check. If confidence is low, triggers deep CoT analysis.
+description: Active Prompting. Active uncertainty check. If confidence is low, triggers deep CoT analysis. Related to adaptive prompting.
 globs: []
 alwaysApply: false
 short_name: ActivePrompting
 one_liner: trigger full CoT when confidence is low
 ---
 ## Pattern
-1. Make a quick request.
-2. If confidence low/answers vary -> Trigger full CoT with detailed justification.
+1. **Quick Assessment**: Generate a rapid initial response with a confidence estimate (high/medium/low).
+2. **Confidence Check**: Evaluate uncertainty — do multiple quick attempts agree? Is the answer well-supported?
+3. **Branch on Confidence**:
+   - **High confidence**: Return the quick answer directly.
+   - **Low confidence**: Trigger full Chain-of-Thought with detailed step-by-step justification.
+4. **Output**: Deliver the answer with appropriate confidence framing.
+
+## Related Concept
+In production systems, this evolves into **adaptive prompting** — dynamically selecting the prompting strategy (zero-shot, few-shot, CoT) based on estimated task difficulty. Active Prompting is the simplest version of this pattern.
+
+## When to Use
+- Mixed-difficulty task batches (easy questions get fast answers, hard ones get deep reasoning)
+- Cost-sensitive applications where full CoT on every query is wasteful
+- Triage workflows that need to allocate compute dynamically
+- API pipelines optimizing latency vs. accuracy tradeoff
+
+## Limitations
+- Models are often overconfident — confidence calibration is unreliable
+- Threshold tuning is domain-specific and requires experimentation
+- Two-pass approach still incurs latency on hard questions
+- The "quick assessment" may lock in a wrong initial direction

--- a/implants/implant-analogical-prompting.mdc
+++ b/implants/implant-analogical-prompting.mdc
@@ -1,10 +1,28 @@
 ---
-description: Analogical Prompting. Self-generated Few-Shot examples. Model invents similar tasks to solve the current one.
+description: Analogical Prompting. Self-generated Few-Shot examples. Model invents similar tasks from different domains to solve the current one.
 globs: []
 alwaysApply: false
 short_name: AnalogicalPrompting
 one_liner: invent similar tasks as few-shot examples
 ---
 ## Pattern
-1. "Recall or invent 3 similar tasks with solutions."
-2. "Use these examples as a template to solve the original task."
+1. **Identify Problem Type**: Classify the structural type of the problem (optimization, classification, debugging, design, etc.).
+2. **Generate Analogies**: "Recall or invent 3 similar problems from **different domains** with their solutions." Cross-domain analogies are more powerful than same-domain.
+3. **Extract Strategy**: Identify the shared reasoning pattern across the analogies — what strategy did all solutions use?
+4. **Apply**: Use the extracted strategy as a template to solve the original problem.
+
+## Key Insight
+Research (2026, Nature Communications) shows analogies from different domains amplify performance up to 10x compared to same-domain examples. The structural transfer forces deeper understanding.
+
+## When to Use
+- Novel problems where standard approaches failed
+- Creative problem solving requiring lateral thinking
+- Cross-domain knowledge transfer (e.g., applying biological patterns to software design)
+- When no labeled examples are available for few-shot
+- Learning new concepts by connecting to known ones
+
+## Limitations
+- Analogies can mislead if structural similarity is superficial
+- Cross-domain analogies require broad knowledge to generate well
+- Not efficient for routine, well-understood problems
+- Model may generate poor analogies that distort rather than clarify

--- a/implants/implant-automatic-reasoning.mdc
+++ b/implants/implant-automatic-reasoning.mdc
@@ -1,12 +1,24 @@
 ---
-description: Automatic Reasoning & Tool-use. Alternates reasoning with tool calls (calc, search).
+description: Automatic Reasoning & Tool-use (ART). Alternates reasoning with tool calls (calc, search, code execution).
 globs: []
 alwaysApply: false
 short_name: AutoReasoning
 one_liner: alternate reasoning with tool calls
 ---
 ## Pattern
-1. Formulate reasoning step.
-2. **Call Tool** (if needed).
-3. Receive result.
-4. Continue reasoning.
+1. **Formulate**: Reason about the current state and what information/computation is needed.
+2. **Call Tool**: Invoke the appropriate tool (calculator, search, code interpreter, API).
+3. **Receive Result**: Incorporate the tool output into reasoning context.
+4. **Continue**: Repeat until the reasoning chain is complete.
+
+## When to Use
+- Tasks requiring factual grounding via search
+- Calculations that are error-prone with mental math
+- Multi-step tasks mixing reasoning with data retrieval
+- Any workflow where tools augment reasoning quality
+
+## Limitations
+- Conceptually similar to ReAct — choose ReAct for explicit Thought/Action/Observation structure, ART for lightweight tool interleaving
+- Tool call failures can break the reasoning chain
+- Over-reliance on tools for tasks the model can handle directly wastes latency
+- Requires tool availability — degrades gracefully but loses grounding

--- a/implants/implant-buffer-of-thoughts.mdc
+++ b/implants/implant-buffer-of-thoughts.mdc
@@ -28,3 +28,9 @@ Current instance: "TypeError in user service" → Instantiate template with spec
 - Batch processing similar items (reviewing 10 PRs, analyzing 5 datasets).
 - Repetitive professional tasks with consistent structure.
 - When consistency across similar outputs matters.
+
+## Limitations
+- Requires having solved similar tasks before — cold-start problem on novel task types
+- Abstracted templates can miss important specifics of the current instance
+- Template rigidity — may force a pattern that doesn't fit this particular variant
+- Meta-template refinement is only as good as the model's self-assessment

--- a/implants/implant-causal-reasoning.mdc
+++ b/implants/implant-causal-reasoning.mdc
@@ -28,3 +28,16 @@ one_liner: distinguish correlation from causation with systematic checks
 - Single study, especially with small N.
 - Ecological fallacy (group-level data applied to individuals).
 - Post hoc ergo propter hoc (after, therefore because of).
+
+## When to Use
+- Evaluating claims about cause and effect in research, reports, or arguments
+- Debugging — determining whether a code change actually caused a bug
+- Business decisions based on A/B tests or observational data
+- Medical/health claims requiring causal scrutiny
+- Any analysis where "X caused Y" is asserted without rigorous evidence
+
+## Limitations
+- Full causal analysis requires data that may not be available
+- Intervention tests (RCTs) are often impractical or unethical
+- Can lead to analysis paralysis — sometimes "probable causation" is sufficient for decisions
+- The framework is strongest for single-cause/single-effect; multi-causal systems are harder

--- a/implants/implant-chain-of-abstraction.mdc
+++ b/implants/implant-chain-of-abstraction.mdc
@@ -10,3 +10,14 @@ one_liner: abstract away details progressively to reveal core structure
 2. **Abstract**: Replace domain-specific details with placeholders (x, f, entity).
 3. **Reason**: Solve the abstract version of the problem.
 4. **Instantiate**: Map the abstract solution back to concrete details.
+
+## When to Use
+- Problems where domain details obscure the underlying logic
+- Transfer learning — applying a solution pattern from one domain to another
+- Mathematical word problems with distracting narrative
+- Architecture decisions where technology-specific details cloud structural reasoning
+
+## Limitations
+- Abstraction can lose relevant details that affect the solution
+- Some problems have domain-specific constraints that cannot be abstracted away
+- Adds overhead for problems that are already stated abstractly

--- a/implants/implant-chain-of-code.mdc
+++ b/implants/implant-chain-of-code.mdc
@@ -7,5 +7,17 @@ one_liner: pseudocode-driven reasoning for logic and math
 ---
 ## Pattern
 1. **Pseudocode**: Express the problem as pseudocode or algorithm.
-2. **Mental Simulation**: Trace execution step by step.
+2. **Mental Simulation**: Trace execution step by step, tracking variable states.
 3. **Answer**: Extract result from the trace.
+
+## When to Use
+- Multi-step math and arithmetic where tracking state helps
+- Logic puzzles with clear rules and conditions
+- Sorting, searching, or algorithmic reasoning
+- Problems where natural language reasoning leads to errors but code logic is precise
+
+## Limitations
+- Overkill for simple calculations or single-step reasoning
+- Mental simulation can accumulate errors on long traces
+- Not suitable for open-ended or creative reasoning
+- Some semantic reasoning tasks can't be expressed as code

--- a/implants/implant-chain-of-draft.mdc
+++ b/implants/implant-chain-of-draft.mdc
@@ -1,9 +1,27 @@
 ---
-description: Token efficiency implant. Uses thesis points and mini-steps (3-5 words) instead of full CoT.
+description: Chain of Draft (CoD). Token efficiency implant. Uses thesis points and mini-steps (3-5 words) instead of full CoT.
 globs: []
 alwaysApply: false
 short_name: ChainOfDraft
 one_liner: use thesis points instead of full CoT for tokens
 ---
 ## Pattern
-"Think in thesis points. Use mini-steps of 3–5 words instead of long explanations before the answer."
+1. **Compress Reasoning**: Think in thesis points — use mini-steps of 3-5 words instead of full sentences.
+2. **Skip Justification**: Only expand a step if the reasoning is non-obvious. Obvious steps get one phrase.
+3. **Answer Directly**: After the compressed chain, produce the final answer without restating the reasoning.
+
+## Example
+Instead of: "First, I need to calculate the total cost. The base price is $100. The tax rate is 8%. So the tax is $100 * 0.08 = $8. Therefore the total is $100 + $8 = $108."
+Use: "Base: $100 → Tax 8%: $8 → Total: $108."
+
+## When to Use
+- Token-constrained environments (limited context window)
+- Straightforward reasoning where full CoT is overkill
+- Batch processing where token cost matters at scale
+- Internal "scratchpad" reasoning before the final answer
+
+## Limitations
+- Loses nuance on complex, multi-step reasoning
+- Compressed steps may hide errors that full CoT would expose
+- Not suitable for tasks requiring detailed justification or audit trail
+- Harder for humans to verify compressed reasoning

--- a/implants/implant-chain-of-note.mdc
+++ b/implants/implant-chain-of-note.mdc
@@ -1,11 +1,23 @@
 ---
-description: RAG Source Annotation. Reads fragments, annotates relevance, synthesizes answer only from relevant notes. Reduces hallucinations.
+description: Chain of Note (CoN). RAG Source Annotation. Reads fragments, annotates relevance, synthesizes answer only from relevant notes. Reduces hallucinations.
 globs: []
 alwaysApply: false
 short_name: ChainOfNote
 one_liner: answer from annotated relevant notes only
 ---
 ## Pattern
-1. **Read**: Document X.
-2. **Annotate**: For each paragraph, is it relevant? (Yes/No). Extract key fact.
-3. **Synthesize**: Answer using ONLY facts from relevant notes.
+1. **Read**: Process each retrieved document/fragment.
+2. **Annotate**: For each paragraph, assess relevance (Relevant/Not Relevant). Extract key fact from relevant ones.
+3. **Synthesize**: Answer using ONLY facts from relevant notes. If no notes are relevant, say "insufficient information."
+
+## When to Use
+- RAG pipelines where retrieved documents may contain irrelevant content
+- Multi-document question answering requiring source grounding
+- Reducing hallucination by forcing answer to be grounded in sources
+- Research synthesis where not all sources are equally relevant
+
+## Limitations
+- Adds annotation overhead before answer generation
+- Relevance assessment can be wrong — may discard useful information
+- "Insufficient information" response may frustrate users when a partial answer would help
+- Not useful for tasks without source documents

--- a/implants/implant-chain-of-symbol.mdc
+++ b/implants/implant-chain-of-symbol.mdc
@@ -6,6 +6,17 @@ short_name: ChainOfSymbol
 one_liner: solve logic via symbolic abstraction
 ---
 ## Pattern
-1. **Encode**: Replace objects with symbols (A, B, C).
-2. **Manipulate**: Solve using symbols only.
+1. **Encode**: Replace objects with symbols (A, B, C) and relationships with operators (→, <, ∈).
+2. **Manipulate**: Solve using symbols only — apply logical rules, spatial reasoning, or set operations.
 3. **Decode**: Translate result back to real objects.
+
+## When to Use
+- Spatial reasoning tasks (directions, positions, layouts)
+- Relationship reasoning (A is taller than B, B is taller than C, who is tallest?)
+- Set operations and Venn diagram logic
+- Any task where natural language descriptions of relationships cause confusion
+
+## Limitations
+- Encoding step can introduce errors if relationships are complex
+- Not suitable for problems requiring semantic understanding (the meaning matters, not just structure)
+- Adds overhead for problems already stated in symbolic form

--- a/implants/implant-chain-of-table.mdc
+++ b/implants/implant-chain-of-table.mdc
@@ -6,6 +6,19 @@ short_name: ChainOfTable
 one_liner: structure data in table for comparisons
 ---
 ## Pattern
-1. Create a table: Rows=[Objects], Cols=[Characteristics].
-2. Fill with data.
-3. Answer the question using the table.
+1. **Design Table**: Create structure: Rows = [Objects/Options], Columns = [Characteristics/Criteria].
+2. **Fill**: Populate the table with data from the problem.
+3. **Analyze**: Answer the question using the table — compare rows, find patterns, identify gaps.
+
+## When to Use
+- Comparison tasks (products, options, candidates)
+- Multi-criteria decision making
+- Data scattered across text that needs organization
+- Pros/cons analysis and feature matrices
+- Any task where structured visual layout aids reasoning
+
+## Limitations
+- Overkill for simple single-variable questions
+- Table structure may not suit non-tabular relationships (hierarchies, graphs, timelines)
+- Filling the table adds token overhead
+- Can force flat structure on inherently nested data

--- a/implants/implant-chain-of-verification.mdc
+++ b/implants/implant-chain-of-verification.mdc
@@ -7,5 +7,23 @@ one_liner: fact-check claims via draft-verify-correct cycle
 ---
 ## Pattern
 1. **Draft**: Generate initial answer.
-2. **Verify**: Generate specific verification questions for each claim.
-3. **Correct**: Answer questions independently, rewrite draft fixing errors.
+2. **Plan Verification**: Generate specific verification questions for each factual claim. Questions must be answerable independently of the original reasoning (avoid confirmation bias).
+3. **Execute Verification**: Answer each verification question independently — do not reference the draft while answering.
+4. **Correct**: Compare verification answers with the draft. Rewrite the draft fixing any errors or unsupported claims.
+5. **Iterate**: If corrections are major, re-verify the corrected version.
+
+## Variant: CoV-RAG
+When applied to RAG-retrieved documents: verify that each claim in the generated answer is actually supported by the retrieved sources. Generate questions like "Does source X actually state Y?"
+
+## When to Use
+- Factual summaries where hallucination risk is high
+- RAG-generated answers that need grounding verification
+- Knowledge-intensive outputs (dates, numbers, names, specifications)
+- Any output that will be used as a basis for decisions
+- High-stakes content (medical, legal, financial information)
+
+## Limitations
+- Doubles token cost (draft + verification + correction)
+- Verification questions can themselves contain hallucinations
+- Not useful for creative or opinion-based outputs
+- Diminishing returns after 2 verification iterations

--- a/implants/implant-constitutional-critique.mdc
+++ b/implants/implant-constitutional-critique.mdc
@@ -1,11 +1,23 @@
 ---
-description: Constitutional Critique. Ethical Self-Correction based on principles (Safety, Helpfulness). Constitutional AI.
+description: Constitutional Critique. Ethical Self-Correction based on principles (Safety, Helpfulness, Honesty). Constitutional AI.
 globs: []
 alwaysApply: false
 short_name: ConstitutionalCritique
 one_liner: ethical self-correction via principle check
 ---
 ## Pattern
-1. Generate draft.
-2. "Does this violate principles [Safety/Ethics]?"
-3. Rewrite correcting violations.
+1. **Generate**: Produce initial draft response.
+2. **Critique Against Principles**: "Does this violate any of the following principles: [Safety, Helpfulness, Honesty, Harmlessness]?"
+3. **Rewrite**: Correct any violations while preserving useful content.
+
+## When to Use
+- Safety-critical outputs that must be reviewed before delivery
+- Content generation that could inadvertently include harmful information
+- Any task where ethical guardrails must be applied post-generation
+- Automated content moderation pipelines
+
+## Limitations
+- Principles must be explicitly defined — vague principles lead to inconsistent critique
+- Can be overly cautious, refusing or weakening useful content
+- Self-critique for safety is less reliable than external moderation
+- Adds a review pass that increases latency and token cost

--- a/implants/implant-contextual-compression.mdc
+++ b/implants/implant-contextual-compression.mdc
@@ -1,9 +1,24 @@
 ---
-description: Contextual Compression. Distills text to key facts/numbers. Token economy.
+description: Contextual Compression. Distills text to key facts/numbers. Token economy for input processing.
 globs: []
 alwaysApply: false
 short_name: ContextualCompression
 one_liner: compress text to key facts and numbers
 ---
 ## Pattern
-"Compress text. Keep ONLY facts, numbers, names, logic. Remove fluff. Format: bulleted list."
+1. **Identify Essentials**: Extract facts, numbers, names, dates, causal relationships, and logical conditions.
+2. **Remove Filler**: Strip conversational fillers, redundant phrasing, hedging language, and repeated information.
+3. **Format**: Output as a bulleted list of atomic facts. Each bullet = one verifiable claim.
+
+## When to Use
+- Long document processing before feeding into another prompt
+- RAG post-processing — compress retrieved chunks to maximize relevant information density
+- Preparing context for subsequent prompts with limited token budget
+- Summarizing meeting transcripts, reports, or verbose inputs
+- Multi-document synthesis where raw text exceeds context limits
+
+## Limitations
+- May lose important nuance, tone, or hedging (dangerous for legal/medical text)
+- Compression is lossy — "key" is a judgment call that can be wrong
+- Not suitable for creative or literary text where style matters
+- Aggressive compression can remove context needed for correct interpretation

--- a/implants/implant-contrastive-cot.mdc
+++ b/implants/implant-contrastive-cot.mdc
@@ -6,4 +6,23 @@ short_name: ContrastiveCoT
 one_liner: prevent mistakes via correct and incorrect examples
 ---
 ## Pattern
-"Example Correct: [Solution]. Example Incorrect: [Error] (Why: explanation). Now solve..."
+1. **Identify Error Type**: Determine the common mistake for this type of problem (e.g., off-by-one, sign error, logical fallacy).
+2. **Construct Incorrect Example**: Show a plausible but wrong solution with explicit explanation of **why** it fails.
+3. **Construct Correct Example**: Show the correct solution, highlighting where it diverges from the incorrect one.
+4. **Solve**: Present the actual problem with both examples as context: "Avoid the error shown above. Follow the correct reasoning pattern."
+
+## Variant: Auto-CCoT (2025)
+Automatically generates valid-invalid pairs from LLM outputs and dynamically selects the most informative pairs via retrieval. Produces incoherent examples that match real model errors, making them more effective than manually-crafted counterexamples.
+
+## When to Use
+- Math problems with common traps (sign errors, order of operations)
+- Logic puzzles where plausible-but-wrong paths exist
+- Classification tasks with known confusing categories
+- Any task with well-known error patterns
+- Teaching scenarios where understanding mistakes aids learning
+
+## Limitations
+- Requires knowing the common mistakes in advance
+- Showing incorrect examples can occasionally **prime** the model toward the error
+- Doubles the example token cost (correct + incorrect for each)
+- Less effective when errors are diverse and unpredictable

--- a/implants/implant-cumulative-reasoning.mdc
+++ b/implants/implant-cumulative-reasoning.mdc
@@ -7,6 +7,18 @@ one_liner: build conclusions by incrementally accumulating verified evidence
 ---
 ## Pattern
 1. **Seed**: State the initial known fact or observation.
-2. **Accumulate**: Add one new verified fact at a time, checking consistency with prior facts.
+2. **Accumulate**: Add one new verified fact at a time, checking consistency with all prior facts.
 3. **Synthesize**: After sufficient evidence, derive the conclusion.
 4. **Audit**: Review the chain — is every step warranted? Remove any unsupported leaps.
+
+## When to Use
+- Investigative analysis building a case from evidence
+- Scientific reasoning where each claim must be grounded
+- Legal argumentation constructing from facts to conclusion
+- Any reasoning where premature conclusions lead to errors
+
+## Limitations
+- Very slow for tasks that don't require incremental evidence building
+- Can over-constrain reasoning by refusing to speculate even when useful
+- The "verification" at each step is bounded by model capability
+- May miss big-picture patterns visible only when considering all evidence at once

--- a/implants/implant-decomposed-prompting.mdc
+++ b/implants/implant-decomposed-prompting.mdc
@@ -10,3 +10,15 @@ one_liner: break complex tasks into simpler sub-prompts and combine
 2. **Solve**: Address each sub-task with a focused, simple prompt.
 3. **Combine**: Merge sub-task results into the final answer.
 4. **Verify**: Check that combined result satisfies the original task.
+
+## When to Use
+- Complex tasks that can be split into independent parts
+- Multi-aspect analysis (e.g., technical + business + legal review)
+- Tasks exceeding a single prompt's reliable capability
+- Parallelizable work where sub-tasks don't depend on each other
+
+## Limitations
+- Sub-tasks must be genuinely independent — hidden dependencies cause wrong results
+- Combining step can introduce incoherence if sub-results conflict
+- Overhead of multiple prompts is wasteful for tasks that are naturally sequential
+- Decomposition itself can be done incorrectly, splitting at the wrong boundaries

--- a/implants/implant-dr-cot.mdc
+++ b/implants/implant-dr-cot.mdc
@@ -1,0 +1,29 @@
+---
+description: Dynamic Recursive CoT (DR-CoT). Dynamically decide when to recurse deeper vs. stop reasoning. Adaptive depth reasoning.
+globs: []
+alwaysApply: false
+short_name: DRCoT
+one_liner: recurse deeper only when needed during reasoning
+---
+## Pattern
+1. **Initial Reasoning**: Begin solving the problem with standard Chain-of-Thought.
+2. **Complexity Check**: At each reasoning step, assess: "Is this sub-problem simple enough to solve directly, or does it need further decomposition?"
+3. **Solve Directly**: If simple — produce the answer for this step and continue.
+4. **Recurse**: If complex — decompose into sub-problems and apply DR-CoT to each recursively.
+5. **Synthesize**: When all sub-problems are resolved, combine results into the final answer.
+
+## Key Insight
+Unlike fixed-depth approaches (Plan-and-Solve, Least-to-Most), DR-CoT allocates reasoning depth dynamically — simple parts get shallow treatment, complex parts get deep decomposition. This mirrors how humans allocate cognitive effort.
+
+## When to Use
+- Variable-depth complexity problems (some parts trivial, others hard)
+- Mathematical proofs with nested sub-proofs
+- Code generation with nested logic and conditionals
+- Multi-step analysis where some steps are routine and others require deep thought
+- Problems where fixed decomposition wastes tokens on simple sub-tasks
+
+## Limitations
+- Requires accurate self-assessment of sub-problem complexity (models can misjudge)
+- Recursive depth is bounded by context window
+- Over-recursion on simple problems wastes tokens
+- Harder to control and predict token usage than fixed-depth approaches

--- a/implants/implant-dynamic-few-shot.mdc
+++ b/implants/implant-dynamic-few-shot.mdc
@@ -1,0 +1,28 @@
+---
+description: Dynamic Few-Shot. Select task-relevant examples from a pool rather than using static examples. Adaptive example selection.
+globs: []
+alwaysApply: false
+short_name: DynamicFewShot
+one_liner: select relevant examples per task from a pool
+---
+## Pattern
+1. **Maintain Example Pool**: Curate a diverse set of labeled input/output examples covering different task variations.
+2. **Match**: For each new task, embed and match to find the 2-5 most similar examples from the pool (semantic similarity, keyword overlap, or category match).
+3. **Order**: Place examples in the prompt with the most similar example closest to the actual task (recency bias helps).
+4. **Generate**: Prompt the model with selected context + the actual task.
+
+## Key Insight
+Static few-shot (same examples for every query) underperforms on diverse inputs. Dynamic selection provides relevant context while avoiding noise from irrelevant examples. Research shows 80% efficiency improvement over zero-shot without requiring full few-shot overhead.
+
+## When to Use
+- Production systems handling diverse query types
+- Classification tasks with many categories
+- Any few-shot setup where fixed examples underperform on some inputs
+- RAG systems where examples can be retrieved alongside documents
+- Multi-language or multi-domain applications
+
+## Limitations
+- Requires a retrieval mechanism (not pure prompting — needs embedding search or similar)
+- Adds retrieval latency before generation
+- Example pool quality bounds overall performance — bad examples = bad outputs
+- Pool maintenance overhead — examples need updating as the task evolves

--- a/implants/implant-generated-knowledge.mdc
+++ b/implants/implant-generated-knowledge.mdc
@@ -1,10 +1,25 @@
 ---
-description: Generated Knowledge. Generate facts before answering. Memory augmentation.
+description: Generated Knowledge. Generate facts before answering. Self-augmented memory for knowledge-intensive tasks.
 globs: []
 alwaysApply: false
 short_name: GeneratedKnowledge
 one_liner: augment knowledge by generating facts before answering
 ---
 ## Pattern
-1. "Write 5 key facts about [Topic] that will help answer [Question]."
-2. "Using these facts, answer the question."
+1. **Identify Knowledge Gaps**: "What background knowledge is needed to answer [Question] correctly?"
+2. **Generate Facts**: "Write 5 key facts about [Topic] that are most relevant to answering [Question]."
+3. **Verify Plausibility**: Review generated facts — flag any that feel uncertain or potentially fabricated.
+4. **Answer**: "Using these facts as context, answer [Question]."
+
+## When to Use
+- Questions requiring background knowledge the model might not foreground automatically
+- Commonsense reasoning where making implicit knowledge explicit helps
+- Educational scenarios where building context before answering improves depth
+- Domain-specific tasks where self-generated context is more relevant than retrieved context
+- When external retrieval (RAG) is not available
+
+## Limitations
+- Generated "knowledge" can itself be hallucinated — pair with Chain-of-Verification for critical applications
+- Adds token overhead (knowledge generation + answer generation)
+- Less reliable than actual retrieval from verified sources
+- Model may generate plausible-sounding but factually wrong "facts"

--- a/implants/implant-graph-of-thoughts.mdc
+++ b/implants/implant-graph-of-thoughts.mdc
@@ -1,11 +1,32 @@
 ---
-description: Graph of Thoughts (GoT). Network reasoning. Generate nodes (ideas), score, branch, synthesize.
+description: Graph of Thoughts (GoT). Network reasoning where thoughts are nodes and dependencies are edges. Unlike ToT, allows merging partial solutions from different branches.
 globs: []
 alwaysApply: false
 short_name: GoT
-one_liner: network reasoning with branching and synthesis
+one_liner: network reasoning with branching, merging, and synthesis
 ---
 ## Pattern
-1. **Generate**: 3-5 alternative approaches.
-2. **Evaluation**: Score each.
-3. **Synthesis**: Combine best features.
+1. **Decompose**: Break the problem into sub-problems, each becoming a node in the graph.
+2. **Generate**: For each node, produce 2-3 candidate partial solutions.
+3. **Evaluate**: Score each candidate for correctness and progress.
+4. **Merge/Refine**: Combine strong candidates from different nodes into improved solutions — this is the key differentiator from ToT (tree = no merging; graph = merging allowed).
+5. **Synthesize**: Assemble the best merged partial solutions into the final answer.
+
+## Key Insight
+Unlike Tree-of-Thought (linear branching, no merging), GoT models reasoning as a **directed graph** where partial solutions from different branches can be combined. This captures the non-sequential nature of human thinking.
+
+## Variant: EGoT (Efficient GoT)
+Prunes low-scoring nodes early to reduce computational cost while maintaining quality.
+
+## When to Use
+- Multi-faceted problems where solutions have combinable components
+- Document writing (outline + sections can be developed and merged independently)
+- System design (different subsystems designed in parallel, then integrated)
+- Tasks where the best answer is a synthesis of multiple partial approaches
+- Sorting, optimization, and aggregation tasks
+
+## Limitations
+- Complex to orchestrate — requires explicit merge logic
+- Merging can introduce incoherence if partial solutions conflict
+- Higher token cost than linear reasoning
+- Overkill for problems with a single clean reasoning path

--- a/implants/implant-layer-of-thoughts.mdc
+++ b/implants/implant-layer-of-thoughts.mdc
@@ -1,11 +1,23 @@
 ---
-description: Layer of Thoughts. Hierarchical analysis for domains with rules (Law, Policy).
+description: Layer of Thoughts. Hierarchical analysis for domains with rules (Law, Policy, Compliance).
 globs: []
 alwaysApply: false
 short_name: LayerOfThoughts
 one_liner: hierarchical analysis for rules-based domains
 ---
 ## Pattern
-1. **Layer 1**: Process high-level rules/laws.
-2. **Layer 2**: Apply to specific facts.
-3. **Synthesis**: Conclude.
+1. **Layer 1 — Rules**: Identify and process high-level rules, laws, or policies that govern the domain.
+2. **Layer 2 — Facts**: Map specific facts of the case to the applicable rules.
+3. **Layer 3 — Synthesis**: Conclude by applying rules to facts, noting conflicts or ambiguities.
+
+## When to Use
+- Legal analysis (statute → case facts → ruling)
+- Policy compliance checks (policy → situation → compliance status)
+- Regulatory assessment (regulation → business activity → risk evaluation)
+- Any domain with hierarchical rules that must be applied to specific facts
+
+## Limitations
+- Assumes rules are clear and non-contradictory — fails with ambiguous regulations
+- Shallow when rules interact across multiple layers or jurisdictions
+- Not suitable for domains without formal rule structures
+- May oversimplify complex legal reasoning that requires precedent analysis

--- a/implants/implant-least-to-most-prompting.mdc
+++ b/implants/implant-least-to-most-prompting.mdc
@@ -1,9 +1,23 @@
 ---
-description: Least-to-Most Prompting. Decompose complex task, solve sequentially using previous answers.
+description: Least-to-Most Prompting. Decompose complex task, solve sequentially from simple to complex using previous answers.
 globs: []
 alwaysApply: false
 short_name: LeastToMost
 one_liner: solve simple to complex sequentially
 ---
 ## Pattern
-"Break this complex task into simple subtasks. Solve them sequentially from simple to complex, using results from previous steps."
+1. **Decompose**: Break the complex task into subtasks ordered from simplest to hardest.
+2. **Solve Sequentially**: Solve the simplest subtask first. Use its result as context for the next, harder subtask.
+3. **Build Up**: Each step uses all previous results, progressively building toward the full answer.
+
+## When to Use
+- Math word problems with nested dependencies
+- Multi-step reasoning where each step builds on the previous
+- Teaching/tutoring scenarios where scaffolding helps
+- Problems that overwhelm when presented all at once but are manageable in parts
+
+## Limitations
+- Errors in early steps propagate through all subsequent steps
+- Requires correct ordering from simple to complex (misordering derails the chain)
+- Slower than direct approaches for problems the model can solve in one pass
+- Not suitable for tasks with independent, non-sequential sub-problems (use Decomposed Prompting instead)

--- a/implants/implant-logic-of-thought.mdc
+++ b/implants/implant-logic-of-thought.mdc
@@ -1,11 +1,24 @@
 ---
-description: Logic of Thought (LoT). Formal logical reasoning. Propositions to inference to conclusion.
+description: Logic of Thought (LoT). Formal logical reasoning. Extract propositions, apply inference rules, derive conclusion.
 globs: []
 alwaysApply: false
 short_name: LoT
 one_liner: formal logical reasoning with propositions
 ---
 ## Pattern
-1. **Propositions**: Extract explicit premises from context.
-2. **Inference**: Apply logical rules (modus ponens, contrapositive, etc.).
-3. **Conclusion**: Derive result. Flag if premises are insufficient.
+1. **Propositions**: Extract explicit premises from context as formal statements (P, Q, R...).
+2. **Inference**: Apply logical rules — modus ponens, contrapositive, transitive law, disjunctive syllogism, etc.
+3. **Conclusion**: Derive the result. Flag if premises are insufficient or contradictory.
+
+## When to Use
+- Puzzles and logic problems requiring formal reasoning
+- Legal reasoning and rule interpretation with logical conditions
+- Standardized test questions (LSAT, GRE logic)
+- Tasks requiring logical consistency checking
+- Outperforms CoT on tasks requiring strict logical deduction
+
+## Limitations
+- Not all reasoning is reducible to formal logic — semantic nuance is lost
+- Extracting correct propositions from natural language is error-prone
+- Overkill for commonsense reasoning or creative tasks
+- Assumes premises are complete — missing information leads to wrong conclusions

--- a/implants/implant-maieutic-prompting.mdc
+++ b/implants/implant-maieutic-prompting.mdc
@@ -1,11 +1,23 @@
 ---
-description: Maieutic Prompting. Socratic method. Explanation tree to find logical contradictions.
+description: Maieutic Prompting. Socratic method. Explanation tree to find logical contradictions and select the consistent branch.
 globs: []
 alwaysApply: false
 short_name: MaieuticPrompting
 one_liner: find contradictions via Socratic explanation tree
 ---
 ## Pattern
-1. Generate explanations for True AND False answers.
-2. Check which explanation is logically consistent with facts.
-3. Select consistent branch.
+1. **Generate Both Sides**: Produce explanations for why the answer is True AND why it is False.
+2. **Check Consistency**: For each explanation, verify logical consistency with known facts and constraints.
+3. **Select**: Choose the branch whose explanation is internally consistent and supported by evidence.
+
+## When to Use
+- True/False or binary decision problems
+- Fact verification where the model's initial answer might be wrong
+- Controversial or ambiguous claims requiring rigorous evaluation
+- Reducing confident errors by forcing the model to argue both sides
+
+## Limitations
+- Only works for binary or few-option decisions — doesn't scale to open-ended questions
+- Both explanations may appear equally plausible, leaving the decision unresolved
+- Generating the "wrong" explanation can occasionally bias the model toward it
+- Token-expensive — doubles the reasoning cost for binary questions

--- a/implants/implant-metacognitive-prompting.mdc
+++ b/implants/implant-metacognitive-prompting.mdc
@@ -1,9 +1,24 @@
 ---
-description: Metacognitive Prompting. Self-evaluation of thinking process.
+description: Metacognitive Prompting. Self-evaluation of thinking process. Confidence calibration during reasoning.
 globs: []
 alwaysApply: false
 short_name: MetacognitivePrompting
 one_liner: self-evaluate confidence in each reasoning step
 ---
 ## Pattern
-"Provide reasoning, and then comment: do you have confidence in each step? Self-diagnose."
+1. **Reason**: Provide step-by-step reasoning for the problem.
+2. **Self-Evaluate**: For each step, rate confidence (high/medium/low) and explain why.
+3. **Diagnose**: Identify the weakest step — what assumption is most likely wrong?
+4. **Strengthen or Flag**: Either reinforce the weak step with additional reasoning, or flag it as uncertain.
+
+## When to Use
+- Complex reasoning where hidden assumptions can derail the answer
+- High-stakes outputs where knowing uncertainty matters
+- Calibrating model confidence before presenting results
+- Debugging reasoning chains that produce wrong answers
+
+## Limitations
+- Models tend to be overconfident in self-evaluation
+- Adds significant token overhead for the meta-commentary
+- Self-diagnosis quality is bounded by the model's own capability
+- Can produce false confidence when the model assigns high confidence to wrong steps

--- a/implants/implant-narrative-of-thought.mdc
+++ b/implants/implant-narrative-of-thought.mdc
@@ -1,9 +1,24 @@
 ---
-description: Narrative of Thought (NoT). Ordering chaotic events into a chronological story/timeline.
+description: Narrative of Thought (NoT). Ordering chaotic events into a chronological story/timeline for cause-effect analysis.
 globs: []
 alwaysApply: false
 short_name: NoT
 one_liner: order events chronologically for cause-effect
 ---
 ## Pattern
-"Imagine task conditions as a story. Arrange events chronologically. Describe cause-and-effect."
+1. **Collect**: Gather all events, facts, and actions from the input.
+2. **Order**: Arrange events chronologically into a narrative timeline.
+3. **Connect**: Describe cause-and-effect relationships between sequential events.
+4. **Answer**: Use the narrative to answer the question.
+
+## When to Use
+- Incident timelines and post-mortems
+- Understanding chaotic logs, chat histories, or event streams
+- Historical analysis requiring causal understanding
+- Debugging by reconstructing what happened in order
+
+## Limitations
+- Assumes chronological ordering is relevant — not all problems are temporal
+- Can impose false causality on coincidental sequential events (post hoc fallacy)
+- Token-expensive for events with many participants or parallel threads
+- Not suitable for non-temporal reasoning tasks

--- a/implants/implant-output-automata.mdc
+++ b/implants/implant-output-automata.mdc
@@ -69,3 +69,9 @@ Close:
 - Complex workflows with error recovery.
 - Processes that need deterministic, auditable behavior.
 - When you need to prevent state corruption (going back to invalid states).
+
+## Limitations
+- Overhead of defining full FSM is excessive for simple linear flows
+- State explosion — complex processes can have too many states to enumerate
+- Guards and transitions must be exhaustive — missing transitions cause undefined behavior
+- Rigid structure can't handle truly open-ended conversations

--- a/implants/implant-output-priming.mdc
+++ b/implants/implant-output-priming.mdc
@@ -1,0 +1,29 @@
+---
+description: Output Priming. Provide the beginning of the desired output to steer completion format, style, and content. Structural anchoring.
+globs: []
+alwaysApply: false
+short_name: OutputPriming
+one_liner: start the answer to steer model completion
+---
+## Pattern
+1. **Define Target Format**: Decide the exact structure of the desired output (JSON, table, bullet list, specific template).
+2. **Write the Opening**: Provide the first 1-3 lines of the desired output as a prefix for the model to complete.
+3. **Prompt Completion**: "Continue from where I left off, maintaining the same format and style."
+4. **Optional Closing**: Provide the closing structure to bookend the output (e.g., closing JSON brace, summary section).
+
+## Example
+Instead of: "Generate a JSON object with user data"
+Use: "Complete this JSON:\n```json\n{\n  \"user\": {\n    \"name\": "
+
+## When to Use
+- Enforcing strict output formats (JSON, XML, CSV, specific templates)
+- Reducing hallucination through structural anchoring
+- API response formatting where schema compliance is critical
+- Consistent output across repeated calls
+- When format instructions alone produce inconsistent results
+
+## Limitations
+- Can over-constrain creative tasks — the model follows the pattern too rigidly
+- Errors in the priming propagate through the entire output
+- Less useful with frontier models that already follow format instructions well
+- Requires knowing the exact output structure in advance

--- a/implants/implant-output-priming.mdc
+++ b/implants/implant-output-priming.mdc
@@ -13,7 +13,13 @@ one_liner: start the answer to steer model completion
 
 ## Example
 Instead of: "Generate a JSON object with user data"
-Use: "Complete this JSON:\n```json\n{\n  \"user\": {\n    \"name\": "
+Use: "Complete this JSON:" followed by the opening fragment:
+```json
+{
+  "user": {
+    "name":
+```
+The model continues from the primed structure, maintaining the JSON format.
 
 ## When to Use
 - Enforcing strict output formats (JSON, XML, CSV, specific templates)

--- a/implants/implant-plan-and-solve-plus.mdc
+++ b/implants/implant-plan-and-solve-plus.mdc
@@ -1,11 +1,23 @@
 ---
-description: Plan & Solve+. Atomic planning before execution. For architecture, refactoring, multi-step tasks.
+description: Plan & Solve+ (PS+). Atomic planning before execution. For architecture, refactoring, multi-step tasks.
 globs: []
 alwaysApply: false
 short_name: PlanSolvePlus
 one_liner: atomic planning before execution
 ---
 ## Pattern
-1. **Plan**: Decompose into atomic, sequential steps.
-2. **Solve**: Execute each step, using the output of the previous one.
+1. **Plan**: Decompose into atomic, sequential steps. Each step should have a clear input/output.
+2. **Solve**: Execute each step, using the output of the previous one. Show intermediate results.
 3. **Verify**: Check that the final result satisfies the original goal.
+
+## When to Use
+- Mathematical reasoning (comparable to 8-shot CoT in accuracy)
+- Architecture and refactoring tasks requiring careful sequencing
+- Multi-step problems where skipping steps leads to errors
+- Tasks where explicit planning prevents common errors (calculation, missing-step, semantic)
+
+## Limitations
+- Planning overhead is wasteful for simple, single-step tasks
+- Plan can be wrong — a bad plan executed perfectly still gives wrong results
+- Sequential execution can't be parallelized
+- Rigid plan may not adapt when intermediate results reveal new information

--- a/implants/implant-premortem.mdc
+++ b/implants/implant-premortem.mdc
@@ -20,3 +20,9 @@ one_liner: assume failure happened then work backwards to prevent it
 - Before committing to significant decisions or plans.
 - When a team is overconfident or has groupthink.
 - At project kickoff to surface hidden risks.
+
+## Limitations
+- Can become a negativity exercise that paralyzes action rather than improving the plan
+- Brainstormed failures may be speculative or unlikely — prioritization is critical
+- Mitigations add complexity — over-mitigating can make a plan worse
+- Best done in groups; a single perspective may miss systemic risks

--- a/implants/implant-program-of-thoughts.mdc
+++ b/implants/implant-program-of-thoughts.mdc
@@ -6,6 +6,18 @@ short_name: PoT
 one_liner: write code to compute answer instead of guessing
 ---
 ## Pattern
-1. **Code**: Write code that computes the answer.
-2. **Execute**: Run (or mentally simulate) the code.
+1. **Code**: Write executable code (Python, etc.) that computes the answer from given data.
+2. **Execute**: Run the code (or mentally simulate execution with variable tracking).
 3. **Answer**: Report the computed result.
+
+## When to Use
+- Numerical calculations where mental math is error-prone
+- Data manipulation and transformation tasks
+- Statistical computations and aggregations
+- Any task where precise computation is more reliable than reasoning in natural language
+
+## Limitations
+- Requires a code execution environment for real execution (not just mental simulation)
+- Not suitable for qualitative reasoning, opinions, or creative tasks
+- Code bugs produce confidently wrong answers
+- Overkill for simple arithmetic that CoT handles well

--- a/implants/implant-prompt-chaining.mdc
+++ b/implants/implant-prompt-chaining.mdc
@@ -1,11 +1,23 @@
 ---
-description: Prompt Chaining. Breaking task into sequence of LLM calls.
+description: Prompt Chaining. Breaking task into a sequence of dependent LLM calls where each output feeds the next input.
 globs: []
 alwaysApply: false
 short_name: PromptChaining
 one_liner: break task into sequence of LLM calls
 ---
 ## Pattern
-1. Prompt A -> Result A.
-2. Prompt B (with Result A) -> Result B.
-3. Synthesis.
+1. **Prompt A**: First LLM call → Result A (e.g., extract data, analyze, summarize).
+2. **Prompt B**: Second LLM call using Result A as context → Result B (e.g., transform, evaluate, generate).
+3. **Synthesis**: Final LLM call (if needed) to combine all intermediate results.
+
+## When to Use
+- Multi-stage workflows (extract → transform → generate)
+- Tasks requiring different model capabilities at each stage
+- When a single prompt is too complex for reliable output
+- Pipeline architectures in production systems
+
+## Limitations
+- Errors compound across the chain — each step amplifies upstream mistakes
+- Latency grows linearly with chain length
+- Token cost multiplied by number of calls
+- Debugging is harder — must trace through multiple steps to find the failure point

--- a/implants/implant-react.mdc
+++ b/implants/implant-react.mdc
@@ -15,3 +15,20 @@ one_liner: interleave reasoning with actions and observations
 - Never act without a preceding thought.
 - Never ignore an observation — always update your reasoning.
 - Stop when the observation satisfies the original goal.
+- Set a maximum iteration count to prevent infinite loops.
+
+## Modern Implementation
+In agentic systems with structured tool-calling (function calling, MCP tools), the Thought→Action→Observation loop is implemented at the **API/framework level** rather than as literal prompt text. The conceptual pattern remains identical — the model reasons, calls a tool, observes the result, and decides the next step. Modern frameworks (LangChain, LlamaIndex, Claude Code) abstract this into structured tool-call APIs.
+
+## When to Use
+- Multi-step tasks requiring external information retrieval
+- Debugging with tool access (read logs, run tests, inspect state)
+- Research tasks combining reasoning with search
+- Any task where acting without thinking leads to wasted tool calls
+- Tasks requiring grounded answers (not just generation)
+
+## Limitations
+- Overhead for simple tasks that don't need tool interaction
+- Can loop indefinitely without a stop condition — always set max iterations
+- Observation interpretation errors compound across steps
+- Token cost grows linearly with loop iterations

--- a/implants/implant-recursion-of-thought.mdc
+++ b/implants/implant-recursion-of-thought.mdc
@@ -6,4 +6,19 @@ short_name: RoT
 one_liner: handle nested recursive structures via sub-calls
 ---
 ## Pattern
-"Identify recursive structure. Call abstract function 'solve_subtask' for each nested part."
+1. **Identify Recursion**: Detect the recursive/nested structure in the problem (nested lists, trees, recursive definitions).
+2. **Define Base Case**: What is the simplest, non-recursive instance? How is it solved directly?
+3. **Define Recursive Step**: "Call abstract function `solve_subtask` for each nested part."
+4. **Combine**: Merge results from sub-calls into the parent solution.
+
+## When to Use
+- Nested data structures (JSON parsing, tree traversal, nested lists)
+- Problems with recursive definitions (factorial, Fibonacci, fractal descriptions)
+- Hierarchical analysis (organizational structures, dependency trees)
+- Any problem that contains smaller versions of itself
+
+## Limitations
+- Context window limits recursion depth — deep nesting overflows available tokens
+- Models struggle with deep recursion (>3-4 levels)
+- Overkill for flat, non-recursive problems
+- Accumulating context from nested sub-calls is token-expensive

--- a/implants/implant-reflexion.mdc
+++ b/implants/implant-reflexion.mdc
@@ -1,5 +1,5 @@
 ---
-description: Reflexion. Self-critique loop for high-stakes tasks. Actor-Critic-Reflector cycle.
+description: Reflexion. Self-critique loop for high-stakes tasks. Actor-Critic-Reflector cycle with episodic memory.
 globs: []
 alwaysApply: false
 short_name: Reflexion
@@ -7,5 +7,28 @@ one_liner: self-critique loop for high-stakes tasks
 ---
 ## Pattern
 1. **Actor**: Generate solution.
-2. **Critic**: Evaluate — what is wrong or suboptimal?
-3. **Reflector**: Synthesize feedback into improved solution. Repeat if needed.
+2. **Critic**: Evaluate against success criteria — what is wrong, missing, or suboptimal?
+3. **Reflector**: Synthesize feedback into a verbal lesson learned (e.g., "I missed edge case X because I assumed Y").
+4. **Memory Update**: Store the lesson in episodic memory for future attempts.
+5. **Retry**: Generate improved solution consulting memory. Repeat until success criteria are met or max iterations reached.
+
+## Key Differentiator
+Reflexion maintains **episodic memory** across attempts — each retry benefits from accumulated lessons. This is what distinguishes it from Self-Refine (single-pass iterative polish without memory).
+
+## Variant: Multi-Agent Reflexion (MAR)
+Separate agents for Actor, Critic, and Reflector roles. Research shows +6.2 point improvement on HumanEval (76.4 → 82.6) over single-agent Reflexion, reducing stagnation.
+
+## When to Use
+- Multi-attempt problem solving (code generation with test feedback)
+- Tasks with clear success/failure signals (tests pass, benchmark met)
+- High-stakes outputs requiring iterative improvement (security reviews, production deploys)
+- Programming benchmarks and competitive coding
+
+## Limitations
+- Requires clear success/failure signal for the Critic — vague criteria lead to poor reflections
+- Diminishing returns after 3-4 iterations
+- Self-evaluation accuracy is bounded by the model's capability
+- Higher token cost than single-pass approaches
+
+## See Also
+- **Self-Refine**: Single-pass iterative polish without episodic memory — use when you need quick improvement, not multi-attempt learning.

--- a/implants/implant-rephrase-and-respond.mdc
+++ b/implants/implant-rephrase-and-respond.mdc
@@ -1,11 +1,28 @@
 ---
-description: Rephrase and Respond. Clarifying ambiguous requests before answering.
+description: Rephrase and Respond (RaR). Clarifying ambiguous requests before answering. Addresses human-LLM communication gaps.
 globs: []
 alwaysApply: false
 short_name: RephraseAndRespond
 one_liner: clarify ambiguous requests before answering
 ---
 ## Pattern
-1. "Rephrase and expand my request to be maximally precise."
-2. "I understood the task as: [Interpretation]."
-3. "Answering the expanded version."
+1. **Rephrase**: "Rephrase and expand the request to be maximally precise. State implicit assumptions explicitly."
+2. **State Interpretation**: "I understood the task as: [expanded interpretation]."
+3. **Answer**: Respond to the expanded version, not the original ambiguous one.
+
+## Variants
+- **One-step RaR**: Single prompt — "Rephrase and expand this question, then respond." Simpler, lower latency.
+- **Two-step RaR**: First LLM rephrases; second LLM receives original + rephrased, then responds. Higher accuracy on complex queries.
+
+## When to Use
+- Ambiguous or terse user queries
+- Questions with implicit assumptions or missing context
+- Complex multi-part requests where clarity prevents wasted effort
+- When understanding the question correctly is more important than speed
+- Can be combined with CoT for even better results
+
+## Limitations
+- Adds latency (especially two-step variant)
+- Rephrasing can introduce interpretation errors — may alter original intent
+- Unnecessary for clear, well-specified questions
+- May over-complicate simple queries

--- a/implants/implant-reverse-cot.mdc
+++ b/implants/implant-reverse-cot.mdc
@@ -1,11 +1,23 @@
 ---
-description: Reverse CoT. Reconstructing conditions from the solution to check consistency.
+description: Reverse CoT. Reconstructing conditions from the solution to verify consistency and catch errors.
 globs: []
 alwaysApply: false
 short_name: ReverseCoT
 one_liner: verify solution by reconstructing conditions
 ---
 ## Pattern
-1. Solve task.
-2. "Now reconstruct original conditions from your solution."
-3. "Compare with original. Fix discrepancies."
+1. **Solve**: Solve the task using any appropriate method.
+2. **Reconstruct**: "Given this solution, reconstruct the original conditions/requirements."
+3. **Compare**: Compare reconstructed conditions with the actual original. Fix any discrepancies.
+
+## When to Use
+- Math and logic problems where you can verify by working backwards
+- Code generation — "does this code actually meet the requirements?"
+- Constraint satisfaction — verify that all constraints are met
+- Any task with a clear set of input conditions that the solution must satisfy
+
+## Limitations
+- Not all problems allow backward reconstruction (e.g., creative writing, open-ended tasks)
+- Reconstruction may pass even if the solution is wrong (if reconstruction is also flawed)
+- Doubles the reasoning cost (solve + reconstruct + compare)
+- Less useful when the original conditions are ambiguous

--- a/implants/implant-role-play-expert.mdc
+++ b/implants/implant-role-play-expert.mdc
@@ -1,9 +1,31 @@
 ---
-description: Role-Play Expert. Deep expertise via persona assignment.
+description: Role-Play Expert. Deep expertise via persona assignment for reasoning style and analytical frameworks.
 globs: []
 alwaysApply: false
 short_name: RolePlayExpert
 one_liner: apply expert persona for domain analysis
 ---
+## Warning
+Research (2026) shows expert personas can **degrade factual accuracy** on knowledge-retrieval tasks. The model becomes more confident but not more correct. Use personas for **reasoning style and analytical frameworks**, not for knowledge claims.
+
 ## Pattern
-"You are a [Role] with [Years] experience. Analyze from the perspective of [Specific Framework]."
+1. **Define Role Scope**: "You are a [Role] with [Years] experience in [Domain]." Keep it concise and task-relevant.
+2. **Specify Methodology**: "Analyze using [Specific Framework/Methodology]." (e.g., STRIDE for threat modeling, SOLID for code review, Porter's Five Forces for market analysis).
+3. **Constrain to Domain**: "Focus your analysis on [specific aspect]. Do not speculate on areas outside your stated expertise."
+4. **Cross-Check**: "Would a real [Role] stake their professional reputation on this claim? If not, flag as uncertain."
+
+## Safer Alternative
+Instead of "You are an expert in X," try: "Apply the methodology of [X discipline] to analyze this problem." This gets the reasoning structure without the overconfidence.
+
+## When to Use
+- Code review from a specific architectural perspective (e.g., security engineer, performance specialist)
+- Design critique using established frameworks (e.g., Nielsen heuristics, WCAG)
+- Structured analysis within a specific methodology (e.g., STRIDE, SWOT, root cause analysis)
+- Role-based brainstorming (e.g., "as a skeptical customer, what would concern you?")
+- Setting analytical tone and vocabulary for a domain
+
+## Limitations
+- **Degrades factual accuracy**: persona activates instruction-following mode at the expense of factual recall
+- Overly elaborate personas add noise — keep role definitions concise
+- Avoid for factual questions, knowledge retrieval, or tasks where accuracy of specific facts matters more than reasoning structure
+- Do not use for medical, legal, or financial advice — persona does not grant domain knowledge

--- a/implants/implant-second-order-thinking.mdc
+++ b/implants/implant-second-order-thinking.mdc
@@ -28,3 +28,9 @@ Decision: Introduce mandatory code reviews
 - Before any decision with lasting effects.
 - When first-order effects seem obviously good (beware hidden costs).
 - When stakeholders disagree (often seeing different order effects).
+
+## Limitations
+- Can lead to analysis paralysis — at some point you must decide despite uncertainty
+- Third-order effects are increasingly speculative and unreliable
+- Interaction mapping between effects can become combinatorially complex
+- Not every decision warrants multi-order analysis — overkill for low-stakes choices

--- a/implants/implant-self-consistency.mdc
+++ b/implants/implant-self-consistency.mdc
@@ -1,10 +1,31 @@
 ---
-description: Self-Consistency. Majority Vote. Generate multiple answers, select most frequent.
+description: Self-Consistency. Majority Vote. Generate multiple reasoning paths, select most frequent answer.
 globs: []
 alwaysApply: false
 short_name: SelfConsistency
 one_liner: select answer by majority vote across multiple runs
 ---
 ## Pattern
-1. Generate 5 independent answers (CoT).
-2. Select the answer that appears most frequently (Consensus).
+1. **Set Diversity**: Use temperature 0.7-1.0 to ensure diverse reasoning paths.
+2. **Generate Multiple Chains**: Produce 5-10 independent Chain-of-Thought solutions for the same problem.
+3. **Extract Answers**: From each chain, extract the final answer.
+4. **Majority Vote**: Select the answer that appears most frequently. Break ties by selecting the chain with the most detailed reasoning.
+
+## Configuration
+- **Minimum paths**: 5 (below this, majority vote is unreliable)
+- **Recommended paths**: 7-10 (best accuracy-to-cost ratio)
+- **Above 15**: Diminishing returns — marginal accuracy gains don't justify cost
+
+## When to Use
+- Mathematical reasoning with a single correct answer
+- Logic puzzles and commonsense reasoning
+- Fact-based questions where consensus signals correctness
+- Any multi-step problem where you can afford multiple generations
+- Combined with CoT for maximum reasoning accuracy
+
+## Limitations
+- 5-10x token cost compared to single generation
+- Useless if all paths share the same systematic error (garbage in, garbage out)
+- Fails on open-ended tasks with no single correct answer
+- Effectiveness varies significantly by model and task type
+- Majority can be wrong — consensus ≠ correctness

--- a/implants/implant-self-discover.mdc
+++ b/implants/implant-self-discover.mdc
@@ -1,9 +1,24 @@
 ---
-description: Self-Discover. Adaptive Reasoning. Selects thinking modules for new tasks.
+description: Self-Discover. Adaptive Reasoning. Selects and composes thinking modules for new tasks.
 globs: []
 alwaysApply: false
 short_name: SelfDiscover
 one_liner: select thinking modules for new tasks
 ---
 ## Pattern
-"Select and combine necessary thinking modules (e.g. decomposition, critical thinking) for this task. Build structure and execute."
+1. **Select Modules**: From available reasoning strategies (decomposition, critical thinking, analogical reasoning, causal analysis, etc.), identify which 2-3 are most relevant to this task.
+2. **Adapt**: Customize the selected modules to the specific problem — what does "decomposition" mean for THIS task?
+3. **Build Structure**: Compose the adapted modules into a step-by-step reasoning plan.
+4. **Execute**: Follow the composed structure to solve the problem.
+
+## When to Use
+- Novel tasks that don't fit a single known reasoning pattern
+- Complex problems requiring multiple reasoning strategies combined
+- When you're unsure which prompting technique to apply
+- Meta-reasoning — choosing HOW to think before thinking
+
+## Limitations
+- Module selection is itself a reasoning task that can go wrong
+- Overhead of meta-reasoning is wasteful for simple, well-understood tasks
+- Composed structures may be incoherent if modules conflict
+- Works best with frontier models that have strong meta-cognitive capabilities

--- a/implants/implant-self-harmonized-cot.mdc
+++ b/implants/implant-self-harmonized-cot.mdc
@@ -1,11 +1,23 @@
 ---
-description: Self-Harmonized CoT. Generates multiple solutions and harmonizes/merges them.
+description: Self-Harmonized CoT (SH-CoT). Generates multiple solutions and harmonizes/merges them into the best combined answer.
 globs: []
 alwaysApply: false
 short_name: SHCoT
 one_liner: merge multiple solutions into best combined answer
 ---
 ## Pattern
-1. Generate 3 independent solutions.
-2. Compare and highlight strong points.
-3. Synthesize final answer by combining best parts.
+1. **Generate**: Produce 3 independent solutions using different reasoning approaches.
+2. **Compare**: Highlight strong points and weak points of each solution.
+3. **Synthesize**: Combine the best elements from all solutions into a final harmonized answer.
+
+## When to Use
+- Complex problems where no single approach captures all aspects
+- Design decisions benefiting from multiple perspectives
+- Writing tasks where different drafts have complementary strengths
+- Any task where "best of all approaches" outperforms "best single approach"
+
+## Limitations
+- 3x token cost compared to single generation
+- Merging can introduce incoherence if solutions fundamentally conflict
+- Requires clear criteria for what constitutes "strong" vs. "weak" elements
+- Less effective than Self-Consistency for problems with a single correct answer (use majority vote instead)

--- a/implants/implant-self-refine.mdc
+++ b/implants/implant-self-refine.mdc
@@ -10,3 +10,19 @@ one_liner: iterative self-improvement via internal critique
 2. **Critique**: Evaluate your own output — what is weak, missing, or incorrect?
 3. **Refine**: Improve the solution based on self-critique.
 4. **Stop**: When critique finds no significant issues, output the final version.
+
+## When to Use
+- Writing improvement (tone, clarity, structure)
+- Code polish (readability, edge cases, naming)
+- Incremental refinement of any single output
+- Tasks where "good enough" can be iteratively improved to "great"
+- When external feedback is not available
+
+## Limitations
+- Single-pass only — no memory across separate attempts
+- Critique quality is bounded by the model's own capability (can't catch errors it doesn't recognize)
+- Can over-refine — diminishing returns after 2-3 cycles
+- Risk of "polishing" away useful rough edges in creative work
+
+## See Also
+- **Reflexion**: Multi-attempt improvement with episodic memory — use when you need to learn from failures across multiple tries, not just polish a single output.

--- a/implants/implant-skeleton-of-thought.mdc
+++ b/implants/implant-skeleton-of-thought.mdc
@@ -1,10 +1,23 @@
 ---
-description: Skeleton-of-Thought. Speed & Coherence. Outline first, then expand parallel.
+description: Skeleton-of-Thought (SoT). Speed & Coherence. Outline first, then expand sections in parallel.
 globs: []
 alwaysApply: false
 short_name: SoT
 one_liner: outline first then expand in parallel
 ---
 ## Pattern
-1. **Skeleton**: Generate concise outline (headers only).
-2. **Expansion**: Expand each point in parallel/sequence.
+1. **Skeleton**: Generate a concise outline (headers/bullet points only — no content).
+2. **Expansion**: Expand each point independently (can be parallelized for speed).
+3. **Assemble**: Combine expanded sections into the final coherent response.
+
+## When to Use
+- Long-form QA and structured responses (2x speed improvement on most models)
+- Document generation with clear section structure
+- Real-time applications where latency matters
+- Any structured output where sections are independent
+
+## Limitations
+- Not suitable for step-by-step reasoning where later points depend on earlier ones
+- Can produce incoherent results when skeleton points are interdependent
+- Higher total token usage despite lower latency
+- Overkill for short answers or simple questions

--- a/implants/implant-steel-man.mdc
+++ b/implants/implant-steel-man.mdc
@@ -20,3 +20,15 @@ one_liner: construct the strongest opposing argument before criticizing
 - Misrepresenting a weak version of the argument to easily defeat it.
 - Attacking the person, not the argument.
 - Cherry-picking the weakest evidence to refute.
+
+## When to Use
+- Evaluating controversial claims or decisions
+- Debates and adversarial analysis
+- Avoiding confirmation bias in reviews
+- Any situation where you might dismiss an idea too quickly
+
+## Limitations
+- Can be used to legitimize genuinely bad arguments by over-strengthening them
+- Time-consuming for low-stakes decisions
+- Model may struggle to truly argue against its own initial assessment
+- Not needed when the position's merits are already obvious

--- a/implants/implant-step-back-prompting.mdc
+++ b/implants/implant-step-back-prompting.mdc
@@ -1,11 +1,24 @@
 ---
-description: Step-Back Prompting. Abstract principle first, then apply to specifics. For complex problems.
+description: Step-Back Prompting. Abstract principle first, then apply to specifics. For complex problems where details obscure the core issue.
 globs: []
 alwaysApply: false
 short_name: StepBack
 one_liner: abstract principle first for complex problems
 ---
 ## Pattern
-1. **Step Back**: "What is the underlying principle or concept?"
-2. **Abstract**: Formulate the general rule.
-3. **Apply**: Use the principle to solve the specific problem.
+1. **Step Back**: "What is the underlying principle, concept, or category this problem belongs to?"
+2. **Abstract**: Formulate the general rule or first principle that governs this type of problem.
+3. **Apply**: Use the principle to solve the specific problem with concrete details.
+
+## When to Use
+- Physics, chemistry, and science problems (+7-27% accuracy improvement)
+- Temporal reasoning and timeline questions
+- Debugging when details obscure the root cause
+- Architecture decisions where implementation details cloud strategic thinking
+- Any complex problem where "zooming out" helps
+
+## Limitations
+- Adds latency for the abstraction step
+- Abstraction may identify the wrong principle, leading to a wrong answer
+- Overkill for straightforward concrete problems
+- Some problems are inherently detail-dependent and resist abstraction

--- a/implants/implant-system-2-attention.mdc
+++ b/implants/implant-system-2-attention.mdc
@@ -1,11 +1,23 @@
 ---
-description: System 2 Attention. Input cleaning. Removes bias/flattery before answering.
+description: System 2 Attention (S2A). Input cleaning. Removes bias, flattery, and leading framing before answering.
 globs: []
 alwaysApply: false
 short_name: S2A
 one_liner: remove bias and flattery before answering
 ---
 ## Pattern
-1. **Analyze**: Check for bias/flattery/leading questions.
-2. **Clean**: Rewrite request to contain ONLY objective facts.
-3. **Execute**: Answer the cleaned request.
+1. **Analyze**: Check the input for bias, flattery, leading questions, emotional framing, or anchoring.
+2. **Clean**: Rewrite the request to contain ONLY objective facts and the actual question.
+3. **Execute**: Answer the cleaned request, ignoring the original framing.
+
+## When to Use
+- User requests that contain flattery or emotional pressure ("You're so smart, surely you can...")
+- Leading questions that embed assumptions ("Given that X is clearly the best approach...")
+- Anchored inputs that prime a specific answer
+- Any input where the framing might bias the output away from objectivity
+
+## Limitations
+- May strip useful context along with bias (overly aggressive cleaning)
+- Some framing is legitimate and intentional (e.g., a user specifying their preference)
+- Adds a pre-processing step that increases latency
+- The model's bias detection is imperfect — subtle framing may pass through

--- a/implants/implant-take-a-deep-breath.mdc
+++ b/implants/implant-take-a-deep-breath.mdc
@@ -1,5 +1,5 @@
 ---
-description: Take a Deep Breath. Zero-shot CoT trigger.
+description: Take a Deep Breath. Zero-shot CoT trigger. Simplest possible reasoning activation.
 globs: []
 alwaysApply: false
 short_name: DeepBreath
@@ -7,3 +7,15 @@ one_liner: trigger step-by-step reasoning with zero-shot
 ---
 ## Pattern
 "Take a deep breath and work on this step by step."
+
+## When to Use
+- Quick improvement over zero-shot when no time for structured prompting
+- Tight token budgets where full CoT instructions are too expensive
+- Baseline technique to add to any prompt for marginal reasoning improvement
+- When you don't know which specific CoT variant to apply
+
+## Limitations
+- Outperformed by all structured CoT techniques on hard problems
+- Effect is marginal on frontier models that already reason well by default
+- No control over reasoning depth or direction
+- "Step by step" may produce unnecessarily verbose output on simple tasks

--- a/implants/implant-thread-of-thought.mdc
+++ b/implants/implant-thread-of-thought.mdc
@@ -1,9 +1,24 @@
 ---
-description: Thread of Thought. Long context understanding. Summarize steps holding the thread.
+description: Thread of Thought (ThoT). Long context understanding. Walk through chaotic context sequentially, holding the thread.
 globs: []
 alwaysApply: false
 short_name: ThreadOfThought
 one_liner: hold thread through long chaotic context
 ---
 ## Pattern
-"Walk sequentially through chaotic context. Summarize each step, holding the 'thread' of meaning."
+1. **Walk Sequentially**: Process the long/chaotic context section by section, in order.
+2. **Summarize Each Step**: At each section, extract the key takeaway and how it connects to the "thread."
+3. **Maintain Thread**: Keep a running summary of the overall narrative/argument/state.
+4. **Conclude**: Use the accumulated thread to answer the question.
+
+## When to Use
+- Long documents with non-linear or chaotic structure
+- Meeting transcripts with many speakers and topic shifts
+- Debugging long log files where context accumulates over time
+- Any task where the context exceeds comfortable single-pass comprehension
+
+## Limitations
+- Slow — requires sequential processing of the entire context
+- Running summary can drift from the original meaning
+- Token-expensive for very long contexts
+- Not needed for well-structured, short inputs

--- a/implants/implant-tree-of-thought.mdc
+++ b/implants/implant-tree-of-thought.mdc
@@ -11,3 +11,20 @@ one_liner: explore multiple reasoning paths with evaluation and backtracking
 3. **Select**: Pursue the most promising branch.
 4. **Backtrack**: If a branch leads to dead-end, return to last branching point and try another.
 5. **Conclude**: When a branch reaches the goal, output the solution path.
+
+## Variant: Tree-of-Quote (ToQ)
+For research and evidence-based tasks: each thought node is grounded by a direct quote from source material. Improves factuality and attribution.
+
+## When to Use
+- Puzzle solving and constraint satisfaction problems
+- Planning tasks where wrong paths need to be abandoned
+- Creative problem solving requiring exploration of alternatives
+- Tasks where backtracking is more efficient than restarting
+- Complex problems with potential dead-ends
+
+## Limitations
+- Significant token overhead — each branch multiplies generation cost
+- Not useful for simple sequential tasks
+- Requires clear evaluation criteria to score branches
+- Real-time response not feasible — exploration takes time
+- Can over-explore when a direct approach would suffice

--- a/implants/implant-uncertainty-quantification.mdc
+++ b/implants/implant-uncertainty-quantification.mdc
@@ -20,3 +20,15 @@ one_liner: calibrate confidence to prevent overconfident claims
 4. **Source Your Confidence**: "I rate this HIGH because [specific evidence]" — not just "I'm confident."
 
 5. **Anti-Hallucination Gate**: Before stating any specific fact (date, number, name, quote), ask: "Do I actually know this, or am I pattern-matching?" If unsure → hedge or say "I don't have this information."
+
+## When to Use
+- Knowledge-intensive outputs where hallucination risk is high
+- Advisory responses (medical, legal, financial context)
+- Research synthesis where sources have varying reliability
+- Any output where the user will act on the information provided
+
+## Limitations
+- Models are notoriously poorly calibrated — self-assessed confidence often doesn't match accuracy
+- Classification overhead adds tokens and latency
+- Users may over-trust the confidence labels themselves
+- "Don't know" responses can be frustrating when partial answers would help


### PR DESCRIPTION
Standardizes and enhances the documentation structure for all implants:
- Introduces `When to Use` and `Limitations` sections to implant files for improved clarity and guidance.
- Expands the `Pattern` sections with more detailed, step-by-step instructions.
- Adds `short_name` and `one_liner` fields to the implant metadata template.

Introduces three new reasoning techniques:
- `dr-cot`: Dynamic Recursive CoT, for adaptive depth reasoning.
- `output-priming`: Provides an answer opening to steer completion format.
- `dynamic-few-shot`: Selects task-relevant examples from a pool.

Updates existing implant descriptions for better understanding, including a warning for `role-play-expert` regarding factual accuracy and highlighting `reflexion`'s episodic memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only for implant definitions plus minor `.gitignore` updates, with no runtime logic modified.
> 
> **Overview**
> Standardizes implant documentation by expanding `Pattern` steps and making `When to Use` and `Limitations` first-class sections across many existing implant `.mdc` files, and updates the implant template in `implants/README.md` (including new frontmatter fields `short_name` and `one_liner`).
> 
> Adds three new implant docs—`implant-dr-cot.mdc`, `implant-output-priming.mdc`, and `implant-dynamic-few-shot.mdc`—and updates the README category tables accordingly. Separately updates `.gitignore` to exclude `agents_private.egg-info/` and `uv.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68783687d0eaca07e8d190984521be83b5781d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->