### PR TITLE
fix(init): use direct byte comparison for trailing newline check

### DIFF
--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -696,7 +696,7 @@ MEMORY_EOF
             if [ -f "$MEMORY_INDEX" ]; then
                 if ! grep -qF "feedback_agents_core_routing.md" "$MEMORY_INDEX" 2>/dev/null; then
                     # Ensure a trailing newline before appending
-                    [ -s "$MEMORY_INDEX" ] && [ "$(tail -c1 "$MEMORY_INDEX" | wc -l)" -eq 0 ] && printf '\n' >> "$MEMORY_INDEX"
+                    [ -s "$MEMORY_INDEX" ] && [ "$(tail -c1 "$MEMORY_INDEX")" != "" ] && printf '\n' >> "$MEMORY_INDEX"
                     echo "$MEMORY_ENTRY" >> "$MEMORY_INDEX"
                     print_success "Entry added to MEMORY.md index"
                 else


### PR DESCRIPTION
Replace `tail -c1 | wc -l` (fragile due to wc whitespace padding)
with `[ "$(tail -c1 ...)" != "" ]` which relies on command
substitution stripping the trailing newline naturally.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small shell-script logic tweak that only affects how `init_repo.sh` decides to append a newline before adding an entry to the global `MEMORY.md` index.
> 
> **Overview**
> Fixes `scripts/init_repo.sh` trailing-newline detection when appending the Agents-Core memory index entry by replacing the `tail -c1 | wc -l` check with a direct `tail -c1` byte comparison, avoiding `wc` formatting quirks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97839b002766bfe0cbec9e59f159c0b78075d39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->