### PR TITLE
feat(memory): per-repo memory subsystem — describe_repo, history.md, managed CLAUDE.md section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ dist/
 .mcp.json
 CLAUDE.md
 
+# Repository memory.
+# history.md captures raw prompts/responses, so it's gitignored by default
+# to avoid leaking secrets pasted into Claude. Remove (or negate with
+# !history.md) if you want the action log visible in PRs.
+history.md
+history/
+
 # Large model files (prevent accidental commits)
 whisper_models/
 *.pt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ This applies to ALL queries: coding, research, questions, documentation, debuggi
 3. **Post-flight (after EVERY response):**
    - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
    - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
-   - Call `log_interaction(agent_name, query, response_content)`.
+   - Call `log_interaction(agent_name, query, response_content)` — this **always** appends an entry to `history.md` and (if Langfuse is configured) sends a generation trace. For meaningful turns (decisions, fixes, refactors, new features), additionally pass `intent=`, `action=`, `outcome=`, `files=[...]`, `tags=[...]` to curate the entry; otherwise the raw query/response are used.
+
+4. **Repository memory (first session per repo):**
+   - On the first session in an unfamiliar repo, call `describe_repo()` once to bootstrap the managed Repository Memory section in CLAUDE.md. Subsequent calls are no-ops unless `force_refresh=True` or the repo manifest changes.
 
 ## Available MCP Tools
 
@@ -35,8 +38,10 @@ This applies to ALL queries: coding, research, questions, documentation, debuggi
 | `get_agent_context(agent_name, query)` | Load a specific agent (after ROUTE_REQUIRED) |
 | `load_implants(task_type)` | Load reasoning strategies (debugging/analysis/creative/planning) |
 | `list_agents()` | List all available agents |
-| `log_interaction(...)` | Log the turn to observability backend |
+| `log_interaction(agent_name, query, response_content, intent?, action?, outcome?, files?, tags?)` | End-of-turn logger — **always** appends to `history.md` (deduped) and, if Langfuse is configured, records a generation trace. Curate the history entry with the optional `intent`/`action`/`outcome` params. |
 | `clear_session_cache()` | Clear routing cache (use when switching contexts) |
+| `describe_repo(force_refresh=False)` | One-shot repo bootstrap — writes summary into CLAUDE.md |
+| `read_history(limit?, since?, query?)` | Recent entries or lazy semantic recall over history |
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The enrichment pipeline resolves capabilities to skill bundles via `agents/capab
 The server ships with a per-repo memory subsystem so each new Claude session does not have to re-explore the codebase from scratch:
 
 - **`describe_repo`** — generates a compressed, LLM-consumable repo overview via MCP sampling and writes it into the managed *Repository Memory* section of `CLAUDE.md`. Idempotent: re-runs are no-ops unless the repo manifest changes or `force_refresh=True`.
-- **`log_interaction`** — end-of-turn logger. Appends `intent / action / outcome` entries (with optional files, tags, metadata) to `history.md` at the repo root; deduplicated by content hash; rotated to `history/YYYY-MM.md` when the file exceeds 512 KB. Also sends a Langfuse generation trace if keys are configured.
+- **`log_interaction`** — end-of-turn logger. Appends `intent / action / outcome` entries (with optional files and tags) to `history.md` at the repo root; deduplicated by content hash; rotated to `history/YYYY-MM.md` when the file exceeds 512 KB. Also sends a Langfuse generation trace if keys are configured.
 - **`read_history`** — returns recent entries by recency/`since` filter, or runs a lazy semantic search backed by the same `NumpyVectorStore` used for routing.
 
 The full design and step-by-step rationale lives in [`docs/memory-subsystem-spec.md`](docs/memory-subsystem-spec.md).

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ The server exposes MCP tools that any compatible client can call:
 | `get_agent_context(agent_name, query)` | Direct agent loading when the target is already known |
 | `load_implants(query\|task_type)` | Load cognitive reasoning strategies by semantic query or preset bundle |
 | `list_agents()` | Enumerate all available agents with metadata |
-| `log_interaction(...)` | Observability logging (Langfuse) |
+| `log_interaction(agent_name, query, response, intent?, action?, outcome?, files?, tags?)` | End-of-turn logger — appends to `history.md` (deduped by content hash) and, if configured, sends a Langfuse generation trace |
 | `clear_session_cache()` | Reset session cache |
+| `describe_repo(force_refresh=False)` | One-shot repo bootstrap — writes a structured summary into the managed Repository Memory section of CLAUDE.md |
+| `read_history(limit?, since?, query?)` | Recent entries or lazy semantic recall over the action log |
 
 ### Routing Flow
 
@@ -202,6 +204,20 @@ capabilities: [development, dev-security]
 ```
 
 The enrichment pipeline resolves capabilities to skill bundles via `agents/capabilities/registry.yaml`. Available capabilities: `critical-analysis`, `content-structure`, `development`, `dense-summary`, `trust-weighted-research`, `bio-health`, `tech-documentation`, `dev-security`, `consultative-intake`, `creative-writing`, `psychology`, `3d-printing`, `data-investigation`, `epistemic-analysis`, `code-review`, `decision-making`, `product-thinking`, `temporal-research`, `performance-engineering`, `prompt-design`, `prompt-security`, `roblox-development`, `dev-tools`, `blender-scripting`, `health-optimization`, `consumer-research`, `visualization`, `child-psychology`.
+
+---
+
+## 🧠 Repository Memory
+
+The server ships with a per-repo memory subsystem so each new Claude session does not have to re-explore the codebase from scratch:
+
+- **`describe_repo`** — generates a compressed, LLM-consumable repo overview via MCP sampling and writes it into the managed *Repository Memory* section of `CLAUDE.md`. Idempotent: re-runs are no-ops unless the repo manifest changes or `force_refresh=True`.
+- **`log_interaction`** — end-of-turn logger. Appends `intent / action / outcome` entries (with optional files, tags, metadata) to `history.md` at the repo root; deduplicated by content hash; rotated to `history/YYYY-MM.md` when the file exceeds 512 KB. Also sends a Langfuse generation trace if keys are configured.
+- **`read_history`** — returns recent entries by recency/`since` filter, or runs a lazy semantic search backed by the same `NumpyVectorStore` used for routing.
+
+The full design and step-by-step rationale lives in [`docs/memory-subsystem-spec.md`](docs/memory-subsystem-spec.md).
+
+> ⚠️ **Privacy warning** — `history.md` captures raw prompts and responses. If you paste secrets (API keys, tokens, credentials) into Claude, they will land in this file. It is **gitignored by default** to keep them out of git history; if you want the action log visible in PRs, remove `history.md` / `history/` from `.gitignore` and review entries before pushing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The server exposes MCP tools that any compatible client can call:
 | `get_agent_context(agent_name, query)` | Direct agent loading when the target is already known |
 | `load_implants(query\|task_type)` | Load cognitive reasoning strategies by semantic query or preset bundle |
 | `list_agents()` | Enumerate all available agents with metadata |
-| `log_interaction(agent_name, query, response, intent?, action?, outcome?, files?, tags?)` | End-of-turn logger — appends to `history.md` (deduped by content hash) and, if configured, sends a Langfuse generation trace |
+| `log_interaction(agent_name, query, response_content, intent?, action?, outcome?, files?, tags?)` | End-of-turn logger — appends to `history.md` (deduped by content hash) and, if configured, sends a Langfuse generation trace |
 | `clear_session_cache()` | Reset session cache |
 | `describe_repo(force_refresh=False)` | One-shot repo bootstrap — writes a structured summary into the managed Repository Memory section of CLAUDE.md |
 | `read_history(limit?, since?, query?)` | Recent entries or lazy semantic recall over the action log |

--- a/docs/memory-subsystem-spec.md
+++ b/docs/memory-subsystem-spec.md
@@ -1,144 +1,143 @@
-# Подсистема памяти Agents-Core: `describe` + `history.md`
+# Agents-Core Memory Subsystem: `describe` + `history.md`
 
-> ТЗ и пошаговая реализация механизма репо-памяти для MCP-сервера Agents-Core.
-> Статус: реализовано 2026-04-15. См. Приложение C — отличия фактической имплементации от плана.
+> Specification and step-by-step implementation plan for the per-repo memory mechanism of the Agents-Core MCP server.
+> Status: implemented 2026-04-15. See Appendix C for deviations between the plan and the actual implementation.
 
-> **Update 2026-04-15 (post-implementation):** MCP-инструмент `record_history` слит с
-> `log_interaction`. Теперь `log_interaction(...)` всегда дозаписывает в `history.md` (с
-> опциональными `intent`/`action`/`outcome`/`files`/`tags` для курирования) и, если
-> подключен Langfuse, дополнительно отправляет generation-трейс. Класс `HistoryWriter`
-> и формат `history.md` не изменились — описанное ниже про дедупликацию, ротацию,
-> формат и `read_history` остаётся в силе. Отдельный MCP-tool `record_history` удалён,
-> чтобы не дублировать инструкции для модели.
+> **Update 2026-04-15 (post-implementation):** The standalone `record_history` MCP tool was merged
+> into `log_interaction`. Now `log_interaction(...)` always appends to `history.md` (with optional
+> `intent`/`action`/`outcome`/`files`/`tags` for curated entries) and, when Langfuse is configured,
+> additionally sends a generation trace. The `HistoryWriter` class and `history.md` format are
+> unchanged — everything below about deduplication, rotation, format, and `read_history` still
+> applies. The separate `record_history` tool was removed to avoid duplicate instructions for the model.
 
 ---
 
-## 1. Контекст и мотивация
+## 1. Context & Motivation
 
-У MCP-сервера Agents-Core (`/home/wondermr/repos/Agents`) сейчас нет постоянной per-repo памяти: каждая новая сессия Claude Code заново изучает кодовую базу и забывает смысл прошлых действий. Это сжигает токены, теряет архитектурные решения и делает работу невоспроизводимой.
+The Agents-Core MCP server (`/home/wondermr/repos/Agents`) currently lacks persistent per-repo memory: every new Claude Code session re-explores the codebase from scratch and forgets the meaning of past actions. This wastes tokens, loses architectural decisions, and makes work non-reproducible.
 
-Внедряем два дополняющих механизма — файловые (markdown), привязанные к репозиторию, переиспользуемые между LLM:
+We introduce two complementary mechanisms — file-based (markdown), repo-bound, reusable across LLMs:
 
-1. **Режим `describe`** — однократный bootstrap, который дистиллирует репозиторий в качественный краткий обзор, сохраняемый в управляемую секцию `CLAUDE.md`. Будущие сессии читают его вместо повторного исследования.
-2. **Режим `history.md`** — append-only журнал *intent + action + outcome* для каждого значимого turn'а; даёт воспроизводимую историю действий, которую можно подгружать в контекст по требованию.
+1. **`describe` mode** — a one-shot bootstrap that distills the repository into a high-quality compressed overview saved into a managed section of `CLAUDE.md`. Future sessions read it instead of re-exploring.
+2. **`history.md` mode** — an append-only *intent + action + outcome* log for each meaningful turn; provides a reproducible action history that can be loaded into context on demand.
 
-Подсистема **переиспользует существующие примитивы** Agents-Core (FastMCP-сервер, `NumpyVectorStore`, маркер-редактор `CLAUDE.md`, эмбеддер, hash-инвалидация). Никакой новой инфраструктуры не вводится.
+The subsystem **reuses existing Agents-Core primitives** (FastMCP server, `NumpyVectorStore`, `CLAUDE.md` marker editor, embedder, hash-based invalidation). No new infrastructure is introduced.
 
-### Проектные решения (зафиксированы)
+### Design Decisions (locked)
 
-| Решение | Выбор | Обоснование |
+| Decision | Choice | Rationale |
 |---|---|---|
-| Способ генерации describe | **Prompt + MCP sampling** | Сервер строит prompt и контекст-bundle, через `ctx.session.create_message(...)` просит вызывающий LLM сгенерировать summary, затем сам пишет результат в `CLAUDE.md`. Уже используется в `route_and_load` (`src/server.py:196`). |
-| Расположение `history.md` | **Корень репо, по умолчанию не коммитится в git** | Файл остаётся локальной per-repo памятью рядом с кодом, но `gitignore`-ится по умолчанию, чтобы не засорять PR и не утекать секретам. При необходимости команда может убрать из `.gitignore` и вернуться к versioned-подходу. |
-| Триггер записи в history | **`log_interaction(...)`** | Отдельный `record_history()` удалён: `log_interaction(...)` всегда дозаписывает запись в `history.md` и опционально отправляет Langfuse generation-трейс. |
-| Семантический поиск | **Lazy** | `log_interaction(...)` остаётся быстрым (только append в `history.md`). `NumpyVectorStore` строится при первом `read_history(query=...)` и инкрементально обновляется по mtime. |
+| Describe generation method | **Prompt + MCP sampling** | The server builds a prompt and context bundle, requests the calling LLM to generate a summary via `ctx.session.create_message(...)`, then writes the result to `CLAUDE.md`. Already used in `route_and_load` (`src/server.py:196`). |
+| `history.md` location | **Repo root, gitignored by default** | The file stays as local per-repo memory next to the code, but is gitignored by default to avoid polluting PRs and leaking secrets. Teams can remove it from `.gitignore` to opt into a versioned approach. |
+| History write trigger | **`log_interaction(...)`** | The standalone `record_history()` was removed: `log_interaction(...)` always appends an entry to `history.md` and optionally sends a Langfuse generation trace. |
+| Semantic search | **Lazy** | `log_interaction(...)` stays fast (append only to `history.md`). `NumpyVectorStore` is built on the first `read_history(query=...)` call and incrementally refreshed by mtime. |
 
-### Сверка с аналогами
+### Prior Art Comparison
 
-| Источник | Чем вдохновляемся |
+| Source | Inspiration |
 |---|---|
-| **claude-recall** (TS, SQLite, hooks-driven) | Outcome-aware memory; content-hash dedup; JIT-инъекция активных правил. **Не берём:** SQLite (для нашего use-case markdown проще и git-friendly), хуки (Phase 2). |
-| **mcp-memory-keeper** (TS, SQLite, explicit tools) | Идея явных tool'ов вместо хуков; checkpoint-семантика; channel-based scoping. **Адаптируем:** explicit tool surface, без channels (пока). |
-| **mcp-memory-service** (Python, REST+MCP) | Идея autonomous consolidation (decay + compress) — кладём в Phase 5. **Не берём:** knowledge graph с типизированными рёбрами. |
-| **Mintlify guidance** | Принцип: native CLAUDE.md = постоянный контекст; MCP = real-time запросы. У нас describe пишет в CLAUDE.md (читается на старте), history запрашивается по требованию через MCP. |
+| **claude-recall** (TS, SQLite, hooks-driven) | Outcome-aware memory; content-hash dedup; JIT injection of active rules. **Not adopted:** SQLite (markdown is simpler and git-friendly for our use case), hooks (Phase 2). |
+| **mcp-memory-keeper** (TS, SQLite, explicit tools) | Idea of explicit tools instead of hooks; checkpoint semantics; channel-based scoping. **Adapted:** explicit tool surface, no channels (for now). |
+| **mcp-memory-service** (Python, REST+MCP) | Idea of autonomous consolidation (decay + compress) — deferred to Phase 5. **Not adopted:** knowledge graph with typed edges. |
+| **Mintlify guidance** | Principle: native CLAUDE.md = persistent context; MCP = real-time queries. Our describe writes to CLAUDE.md (read on startup), history is queried on demand via MCP. |
 
 ---
 
-## 2. Цели и не-цели
+## 2. Goals & Non-Goals
 
-**Цели**
-- Три новых MCP-инструмента: `describe_repo`, `record_history`, `read_history`.
-- Идемпотентное, неразрушающее редактирование `CLAUDE.md` через новую пару маркеров (отдельную от существующей секции routing-protocol).
-- Append-only `history.md` в корне репо с content-hash dedup, ежемесячной ротацией, опциональным семантическим recall.
-- Тесты в стиле существующих (`pytest`, `tmp_path`, mock-эмбеддер).
-- Промпт describe-режима — production-grade (BLUF, MECE, структура Mega-Prompting).
+**Goals**
+- Two new MCP tools: `describe_repo`, `read_history`; history writing integrated into existing `log_interaction`.
+- Idempotent, non-destructive editing of `CLAUDE.md` via a new marker pair (separate from the existing routing-protocol section).
+- Append-only `history.md` at the repo root with content-hash dedup, monthly rotation, optional semantic recall.
+- Tests in the style of existing ones (`pytest`, `tmp_path`, mock embedder).
+- Describe-mode prompt — production-grade (BLUF, MECE, Mega-Prompting structure).
 
-**Не-цели**
-- Hooks для авто-захвата (Phase 2; в репо ещё нет `.claude/settings.json` с хуками).
-- Knowledge graph с типизированными рёбрами.
-- Consolidation/decay памяти (Phase 5).
-- Cross-repo федерация памяти.
-- Изменение существующей секции routing-protocol в `CLAUDE.md`.
+**Non-Goals**
+- Hooks for auto-capture (Phase 2; the repo does not yet have `.claude/settings.json` with hooks).
+- Knowledge graph with typed edges.
+- Memory consolidation/decay (Phase 5).
+- Cross-repo memory federation.
+- Modification of the existing routing-protocol section in `CLAUDE.md`.
 
 ---
 
-## 3. Архитектура
+## 3. Architecture
 
-### 3.1 Поток данных
+### 3.1 Data Flow
 
 ```
 describe_repo(repo_path?, force_refresh=False)
-  ├─ RepoDescriber.compute_repo_hash()       # MD5 от pyproject/package.json/top-level dirs/начала README
-  ├─ если хэш не изменился и не force → return {status:"up-to-date"}
-  ├─ обход дерева (depth ≤ 3, исключаем vendor) + чтение ключевых файлов → CONTEXT_BUNDLE
-  ├─ render DESCRIBE_PROMPT (template) с CONTEXT_BUNDLE
-  ├─ ctx.session.create_message(prompt)      # MCP sampling — Claude генерирует summary
+  ├─ RepoDescriber.compute_repo_hash()       # MD5 of pyproject/package.json/top-level dirs/README head
+  ├─ if hash unchanged and not force → return {status:"up-to-date"}
+  ├─ tree walk (depth ≤ 3, excluding vendor) + reading key files → CONTEXT_BUNDLE
+  ├─ render DESCRIBE_PROMPT (template) with CONTEXT_BUNDLE
+  ├─ ctx.session.create_message(prompt)      # MCP sampling — Claude generates summary
   ├─ managed_section.upsert(CLAUDE.md, DESCRIBE_MARKER_BEGIN/END, summary)
-  ├─ сохраняем хэш → DESCRIBE_HASH_FILE
+  ├─ save hash → DESCRIBE_HASH_FILE
   └─ return {status, path, hash, word_count, summary_preview}
 
-record_history(intent, action, outcome, files?, tags?, metadata?)
+log_interaction(..., intent, action, outcome, files?, tags?)
   ├─ HistoryWriter.compute_entry_hash()      # SHA256(intent+action+outcome)[:12]
-  ├─ скан последних 50 записей на дубль → return {status:"duplicate"} при совпадении
-  ├─ форматируем markdown-запись
-  ├─ fcntl.flock + атомарный append к history.md
-  ├─ maybe_rotate() если файл > 512 KB → архив в history/YYYY-MM.md
+  ├─ scan last 50 entries for duplicate → return {status:"duplicate"} on match
+  ├─ format markdown entry
+  ├─ fcntl.flock + atomic append to history.md
+  ├─ maybe_rotate() if file > 512 KB → archive to history/YYYY-MM.md
   └─ return {status:"recorded", entry_id, path}
 
 read_history(limit=20, since?, query?)
-  ├─ если query:
-  │    ├─ HistoryStore.ensure_index()        # lazy: rebuild если mtime файла > mtime store
-  │    └─ семантический поиск через NumpyVectorStore + эмбеддер
-  └─ иначе:
-       └─ HistoryReader.read_recent()        # парсинг снизу вверх, фильтр по since
+  ├─ if query:
+  │    ├─ HistoryStore.ensure_index()        # lazy: rebuild if file mtime > store mtime
+  │    └─ semantic search via NumpyVectorStore + embedder
+  └─ else:
+       └─ HistoryReader.read_recent()        # parse bottom-up, filter by since
 ```
 
-### 3.2 Раскладка модулей
+### 3.2 Module Layout
 
-| Новый файл | Роль |
+| New file | Role |
 |---|---|
-| `src/memory/__init__.py` | Маркер пакета |
-| `src/memory/config.py` | Константы: пути, маркеры, пороги; импортирует `REPO_ROOT`/`DATA_DIR` из `src/engine/config.py:7-8` |
-| `src/memory/managed_section.py` | Чистый Python-порт маркер-редактора из `scripts/init_repo.sh:636-672`. Функции: `upsert_section`, `read_section`, `remove_section`. Атомарная запись через `tempfile` + `os.replace`. |
+| `src/memory/__init__.py` | Package marker |
+| `src/memory/config.py` | Constants: paths, markers, thresholds; imports `REPO_ROOT`/`DATA_DIR` from `src/engine/config.py:7-8` |
+| `src/memory/managed_section.py` | Pure Python port of the marker editor from `scripts/init_repo.sh:636-672`. Functions: `upsert_section`, `read_section`, `remove_section`. Atomic writes via `tempfile` + `os.replace`. |
 | `src/memory/describer.py` | `RepoDescriber`: hash → bundle → prompt → sampling → upsert |
-| `src/memory/history.py` | `HistoryWriter` (append, dedup, rotate) + `HistoryReader` (recent + lazy semantic) + `HistoryStore` (обёртка над NumpyVectorStore) |
-| `tests/test_managed_section.py` | Тесты маркер-редактора (стиль `tests/test_vector_store.py`) |
-| `tests/test_describer.py` | Хэш, refresh-логика, мок sampling, проверка upsert |
-| `tests/test_history.py` | Append, dedup, ротация, recent read, семантический поиск (mock embedder) |
+| `src/memory/history.py` | `HistoryWriter` (append, dedup, rotate) + `HistoryReader` (recent + lazy semantic) + `HistoryStore` (wrapper around NumpyVectorStore) |
+| `tests/test_managed_section.py` | Marker editor tests (style of `tests/test_vector_store.py`) |
+| `tests/test_describer.py` | Hash, refresh logic, mock sampling, upsert verification |
+| `tests/test_history.py` | Append, dedup, rotation, recent read, semantic search (mock embedder) |
 
-| Изменяемый файл | Что меняем |
+| Modified file | What changes |
 |---|---|
-| `src/server.py` | Добавить `@mcp.tool()` для `describe_repo`, `record_history`, `read_history` |
-| `CLAUDE.md` (корень проекта) | Добавить короткую инструкцию в routing protocol: после шагов протокола агент должен вызывать `record_history()` в конце значимого turn'а; на первой сессии в незнакомом репо — сначала `describe_repo()` |
-| `.gitignore` | Закомментированные строки opt-out для `history.md` |
+| `src/server.py` | Add `@mcp.tool()` for `describe_repo`, `read_history`; extend `log_interaction` with history append |
+| `CLAUDE.md` (project root) | Add short instruction to routing protocol: after protocol steps the agent should call `log_interaction()` at the end of meaningful turns; on first session in an unfamiliar repo — call `describe_repo()` first |
+| `.gitignore` | Entries for `history.md` and `history/` |
 
-### 3.3 Карта переиспользования (НЕ переписывать заново)
+### 3.3 Reuse Map (do NOT rewrite from scratch)
 
-| Существующее | Расположение | Где переиспользуем |
+| Existing | Location | Where reused |
 |---|---|---|
-| FastMCP `@mcp.tool()` декоратор + JSON-string возвраты | `src/server.py:70-608` | Все три новых tool'а — тот же паттерн регистрации |
-| MCP sampling через `ctx.session.create_message(...)` | `src/server.py:196` | `describe_repo` использует тот же sampling-вызов |
-| Маркер-редактор CLAUDE.md (inline Python) | `scripts/init_repo.sh:636-672` | Портируем буквально в `src/memory/managed_section.py` — bash-инсталлер и MCP-tool используют одну реализацию (bash подцепит через subprocess) |
+| FastMCP `@mcp.tool()` decorator + JSON-string returns | `src/server.py:70-608` | All new tools — same registration pattern |
+| MCP sampling via `ctx.session.create_message(...)` | `src/server.py:196` | `describe_repo` uses the same sampling call |
+| Marker editor for CLAUDE.md (inline Python) | `scripts/init_repo.sh:636-672` | Ported literally to `src/memory/managed_section.py` — bash installer and MCP tool share one implementation |
 | `SkillRetriever._compute_dir_hash` + `_needs_reindex` | `src/engine/skills.py:32-51` | `RepoDescriber._compute_repo_hash` + `_needs_refresh` |
-| `NumpyVectorStore` (атомарные .npz+.json, thread-safe) | `src/engine/vector_store.py:39` | `HistoryStore` для семантического recall |
-| `embed_texts` / `embed_query` (FastEmbed) | `src/engine/embedder.py:83,89` | Векторизация записей и запросов |
-| `LanguageDetector` | `src/engine/language.py:39` | Тегирование записей по языку |
-| `debug_log` | `src/utils/debug_logger.py:18` | Инструментация всех трёх tool'ов |
-| `@observe` из `langfuse_compat` | `src/utils/langfuse_compat.py` | Опциональная observability |
-| `REPO_ROOT`, `DATA_DIR` | `src/engine/config.py:7-8` | Базовые пути |
-| pytest-фикстуры (`tmp_path`, `populated_store`) | `tests/test_vector_store.py:12-31` | Зеркалим для новых тестов |
+| `NumpyVectorStore` (atomic .npz+.json, thread-safe) | `src/engine/vector_store.py:39` | `HistoryStore` for semantic recall |
+| `embed_texts` / `embed_query` (FastEmbed) | `src/engine/embedder.py:83,89` | Vectorization of entries and queries |
+| `LanguageDetector` | `src/engine/language.py:39` | Language tagging of entries |
+| `debug_log` | `src/utils/debug_logger.py:18` | Instrumentation of all tools |
+| `@observe` from `langfuse_compat` | `src/utils/langfuse_compat.py` | Optional observability |
+| `REPO_ROOT`, `DATA_DIR` | `src/engine/config.py:7-8` | Base paths |
+| pytest fixtures (`tmp_path`, `populated_store`) | `tests/test_vector_store.py:12-31` | Mirrored for new tests |
 
 ---
 
-## 4. Контракты форматов
+## 4. Format Contracts
 
-### 4.1 `CLAUDE.md` (управляемая секция)
+### 4.1 `CLAUDE.md` (managed section)
 
-Сосуществуют две пары маркеров. Новая пара ставится **ниже** существующей секции routing-protocol, чтобы повторные запуски `init_repo.sh` и повторные `describe_repo` никогда не пересекались.
+Two marker pairs coexist. The new pair is placed **below** the existing routing-protocol section so that reruns of `init_repo.sh` and `describe_repo` never overlap.
 
 ```
 # >>> Agents-Core Routing Protocol (managed by init_repo) >>>
-… существующее …
+… existing content …
 # <<< Agents-Core Routing Protocol (managed by init_repo) <<<
 
 # >>> Agents-Core Repository Memory (managed by describe_repo) >>>
@@ -171,11 +170,11 @@ read_history(limit=20, since?, query?)
 # <<< Agents-Core Repository Memory (managed by describe_repo) <<<
 ```
 
-**Бюджет слов:** 800–1500 (проверяется тестами). Жёсткий cap, чтобы `CLAUDE.md` не раздул контекстное окно.
+**Word budget:** 800–1500 (enforced by tests). Hard cap to prevent `CLAUDE.md` from bloating the context window.
 
-### 4.2 `history.md` (append-only, корень репо)
+### 4.2 `history.md` (append-only, repo root)
 
-Шапка файла (пишется один раз при первом append):
+File header (written once on first append):
 ```yaml
 ---
 repo: agents-core
@@ -184,26 +183,26 @@ format_version: 1
 ---
 ```
 
-Шаблон записи:
+Entry template:
 ```markdown
 ## 2026-04-15T14:32:00Z | a1b2c3d4e5f6
-**Intent:** Включить семантический recall прошлых действий для подгрузки в контекст.
-**Action:** Добавил `HistoryStore` поверх `NumpyVectorStore` в `src/memory/history.py`; записи эмбеддятся лениво.
-**Outcome:** `pytest tests/test_history.py::test_semantic_search_returns_relevant` проходит; индекс пересобирается, когда mtime history.md растёт.
+**Intent:** Enable semantic recall of past actions for context loading.
+**Action:** Added `HistoryStore` on top of `NumpyVectorStore` in `src/memory/history.py`; entries are embedded lazily.
+**Outcome:** `pytest tests/test_history.py::test_semantic_search_returns_relevant` passes; index rebuilds when history.md mtime grows.
 **Files:** src/memory/history.py, tests/test_history.py
 **Tags:** #feature #memory
 ```
 
-**Правила:**
-- `entry_id` (12-hex суффикс в заголовке) = `sha256(intent+action+outcome)[:12]`. Стабильный, дедупится.
-- Dedup: скан последних 50 записей по id перед append. Дубли коротко-замыкаются.
-- Только append. Прошлые записи никогда не редактируются и не удаляются.
-- `fcntl.flock(LOCK_EX)` на запись (защита от параллельных сессий).
-- Ротация: при `os.path.getsize > 512 KB` — переносим файл в `history/YYYY-MM.md` (месяц по timestamp последней записи), открываем свежий `history.md` со ссылкой-шапкой на архив.
+**Rules:**
+- `entry_id` (12-hex suffix in the heading) = `sha256(intent+action+outcome)[:12]`. Stable, deduplicated.
+- Dedup: scan the last 50 entries by id before append. Duplicates short-circuit.
+- Append-only. Past entries are never edited or deleted.
+- `fcntl.flock(LOCK_EX)` for writes (protects against concurrent sessions).
+- Rotation: when `os.path.getsize > 512 KB` — move file to `history/YYYY-MM.md` (month from the last entry's timestamp), create a fresh `history.md` with a header pointing to the archive.
 - UTF-8, `\n` line endings.
-- `tags` — свободные `#хэштеги`; `metadata` — плоский JSON, если задан, сериализуется inline как `**Meta:** {...}`.
+- `tags` — free-form `#hashtags`; `metadata` — flat JSON, if provided, serialized inline as `**Meta:** {...}`.
 
-### 4.3 Сигнатуры MCP-инструментов (добавляются в `src/server.py`)
+### 4.3 MCP Tool Signatures (added to `src/server.py`)
 
 ```python
 @mcp.tool()
@@ -216,22 +215,24 @@ async def describe_repo(
     and writes it into the managed Repository Memory section of CLAUDE.md.
 
     Returns JSON: {status, path, hash, word_count, summary_preview}.
-    status ∈ {"refreshed", "up-to-date", "error"}.
+    status ∈ {"refreshed", "up-to-date", "rejected", "error"}.
     """
 
 @mcp.tool()
-async def record_history(
-    intent: str,
-    action: str,
-    outcome: str,
+async def log_interaction(
+    agent_name: str,
+    query: str,
+    response_content: str,
+    intent: str | None = None,
+    action: str | None = None,
+    outcome: str | None = None,
     files: list[str] | None = None,
     tags: list[str] | None = None,
-    metadata: dict | None = None,
 ) -> str:
-    """Append a single intent-centric entry to history.md (append-only, deduped by content hash).
+    """End-of-turn logger. Always appends to history.md (append-only, deduped by
+    content hash) and optionally sends a Langfuse generation trace.
 
-    Returns JSON: {status, entry_id, path}.
-    status ∈ {"recorded", "duplicate", "error"}.
+    Returns JSON: {request_id, langfuse: {status}, history: {status, entry_id, path}}.
     """
 
 @mcp.tool()
@@ -240,22 +241,26 @@ async def read_history(
     since: str | None = None,
     query: str | None = None,
 ) -> str:
-    """Read recent entries (limit/since) or run a lazy semantic search (query). Returns JSON.
+    """Read recent entries (limit/since) or run a lazy semantic search (query).
 
-    Returns JSON: {entries: [{id, timestamp, intent, action, outcome, files, tags, distance?}], total, mode}.
+    Returns JSON: {entries: [...], total, mode}.
     mode ∈ {"recency", "semantic"}.
+
+    Entry shape depends on mode:
+    - recency: {id, timestamp, intent, action, outcome, files, tags, metadata}.
+    - semantic: {id, distance, document, timestamp, intent, tags}.
     """
 ```
 
-Все три возвращают JSON-строки (как существующий паттерн в `src/server.py`).
+All tools return JSON strings (following the existing pattern in `src/server.py`).
 
 ---
 
-## 5. Промпт describe-режима (центральный артефакт)
+## 5. Describe Prompt (central artifact)
 
-`RepoDescriber` строит этот промпт и отправляет через `ctx.session.create_message(...)`. Плейсхолдер `{{CONTEXT_BUNDLE}}` заполняется детерминированно: дерево файлов (depth ≤ 3), `pyproject.toml` / `package.json` / `Cargo.toml` / `go.mod`, README.md (первые 200 строк), заголовки entry-point файлов, sample frontmatter `.mdc`, список тестов, скрипты.
+`RepoDescriber` builds this prompt and sends it via `ctx.session.create_message(...)`. The `{{CONTEXT_BUNDLE}}` placeholder is filled deterministically: file tree (depth ≤ 3), `pyproject.toml` / `package.json` / `Cargo.toml` / `go.mod`, README.md (first 200 lines), entry-point file headers, sample `.mdc` frontmatter, test list, scripts.
 
-> Текст промпта оставлен на английском намеренно — будущие сессии Claude в любом языковом контексте смогут его выполнить, а структура output совпадает с английскими секциями `CLAUDE.md`.
+> The prompt text is kept in English intentionally — future Claude sessions in any language context will be able to execute it, and the output structure matches the English sections of `CLAUDE.md`.
 
 ```
 You are a **Repository Analyst** performing a one-time deep study of a codebase.
@@ -319,159 +324,159 @@ Table: term | definition. Domain-specific terms only. Max 15.
 
 ---
 
-## 6. Пошаговая реализация
+## 6. Step-by-Step Implementation
 
 ### Phase 1 — Foundation (1 PR)
 
-1. Создать `src/memory/__init__.py` (пустой).
-2. Создать `src/memory/config.py` с константами: `MEMORY_DATA_DIR`, `HISTORY_FILE`, `DESCRIBE_HASH_FILE`, `DESCRIBE_MARKER_BEGIN/END`, `HISTORY_VECTOR_STORE_NAME`, `HISTORY_ROTATION_THRESHOLD_KB = 512`. Все пути привязаны к `REPO_ROOT`/`DATA_DIR` из `src/engine/config.py`.
-3. Создать `src/memory/managed_section.py` с `upsert_section`, `read_section`, `remove_section`. Портировать inline Python из `scripts/init_repo.sh:636-672` строка-в-строку, добавить атомарную запись через `tempfile.NamedTemporaryFile` + `os.replace`. Валидировать уникальность маркеров; кидать ошибку при частичных маркерах.
-4. Написать `tests/test_managed_section.py`: create, replace, append, partial-marker rejection, сохранение контента вне маркеров, атомарная запись при сбое.
+1. Create `src/memory/__init__.py` (empty).
+2. Create `src/memory/config.py` with constants: `MEMORY_DATA_DIR`, `HISTORY_FILE`, `DESCRIBE_HASH_FILE`, `DESCRIBE_MARKER_BEGIN/END`, `HISTORY_VECTOR_STORE_NAME`, `HISTORY_ROTATION_THRESHOLD_KB = 512`. All paths bound to `REPO_ROOT`/`DATA_DIR` from `src/engine/config.py`.
+3. Create `src/memory/managed_section.py` with `upsert_section`, `read_section`, `remove_section`. Port inline Python from `scripts/init_repo.sh:636-672` line-by-line, add atomic writes via `tempfile.NamedTemporaryFile` + `os.replace`. Validate marker uniqueness; raise on partial markers.
+4. Write `tests/test_managed_section.py`: create, replace, append, partial-marker rejection, content outside markers preserved, atomic write on failure.
 
 ### Phase 2 — Describe (1 PR)
 
-5. Создать `src/memory/describer.py`:
+5. Create `src/memory/describer.py`:
    - `RepoDescriber.__init__(repo_path)`.
-   - `_compute_repo_hash()` — MD5 от: отсортированных top-level имён файлов, содержимого `pyproject.toml`, содержимого `package.json`, имён директорий depth-1 + depth-2, первых 200 строк README.md.
-   - `_needs_refresh(force) → (bool, hash)` — паттерн из `src/engine/skills.py:43-51`.
-   - `_build_context_bundle() → str` — рендерит блок `{{CONTEXT_BUNDLE}}`: дерево (`Path.rglob` с фильтрами, depth ≤ 3, исключая `node_modules`, `.venv`, `__pycache__`, `.git`, `data/`), содержимое ключевых файлов, sample frontmatter `.mdc`.
-   - `_render_prompt(bundle, repo_name) → str` — подставляет плейсхолдеры в шаблон describe-промпта (хранится как multiline-константа в модуле).
-   - `async describe(ctx, force=False) → dict` — оркестратор: если refresh не нужен — вернуть кэш summary, прочитанный через `managed_section.read_section`; иначе построить prompt, вызвать `ctx.session.create_message(...)` (sampling), `managed_section.upsert_section(CLAUDE.md, …, generated)`, сохранить хэш, вернуть status.
-6. Добавить tool `describe_repo` в `src/server.py`. Обернуть в `@observe`, если Langfuse подгружен. Вернуть JSON.
-7. Написать `tests/test_describer.py`: детерминированный хэш, refresh-on-change, refresh-skipped-when-unchanged, моканый `ctx.session.create_message` с заранее заготовленным summary, проверка upsert, ассерт word-count (800–1500).
+   - `_compute_repo_hash()` — MD5 of: sorted top-level file names, `pyproject.toml` contents, `package.json` contents, depth-1 + depth-2 directory names, first 200 lines of README.md.
+   - `_needs_refresh(force) → (bool, hash)` — pattern from `src/engine/skills.py:43-51`.
+   - `_build_context_bundle() → str` — renders the `{{CONTEXT_BUNDLE}}` block: tree (`Path.rglob` with filters, depth ≤ 3, excluding `node_modules`, `.venv`, `__pycache__`, `.git`, `data/`), key file contents, sample `.mdc` frontmatter.
+   - `_render_prompt(bundle, repo_name) → str` — substitutes placeholders in the describe prompt template (stored as a multiline constant in the module).
+   - `async describe(ctx, force=False) → dict` — orchestrator: if no refresh needed — return cached summary read via `managed_section.read_section`; otherwise build prompt, call `ctx.session.create_message(...)` (sampling), `managed_section.upsert_section(CLAUDE.md, …, generated)`, save hash, return status.
+6. Add `describe_repo` tool to `src/server.py`. Wrap with `@observe` if Langfuse is loaded. Return JSON.
+7. Write `tests/test_describer.py`: deterministic hash, refresh-on-change, refresh-skipped-when-unchanged, mocked `ctx.session.create_message` with a pre-built summary, upsert verification, word-count assertion (800–1500).
 
 ### Phase 3 — History (1 PR)
 
-8. Создать `src/memory/history.py`:
-   - `HistoryWriter`: `__init__(history_path)`, `_compute_entry_hash`, `_is_duplicate` (tail-scan последних 50), `append_entry` (format → `flock` → атомарный append → `maybe_rotate`), `maybe_rotate`.
-   - `HistoryReader`: `read_recent(limit, since)` — парсинг снизу вверх через regex `## {ts} | {id}`.
-   - `HistoryStore`: lazy-обёртка над `NumpyVectorStore`. `ensure_index()` сравнивает mtime store и файла; если устарел — переэмбеддит все записи (или инкрементально: только записи, чьего id нет в store). `search(query, limit)` эмбеддит запрос, возвращает топ-N с distance.
-9. Добавить `record_history` и `read_history` в `src/server.py`. Оба возвращают JSON.
-10. Написать `tests/test_history.py`: append создаёт файл с шапкой, format roundtrip, dedup, порядок recent read, фильтр `since`, ротация триггерит + создаёт архив, lazy-семантический индекс пересобирается при изменении файла (mock embedder).
+8. Create `src/memory/history.py`:
+   - `HistoryWriter`: `__init__(history_path)`, `_compute_entry_hash`, `_is_duplicate` (tail-scan last 50), `append_entry` (format → `flock` → atomic append → `maybe_rotate`), `maybe_rotate`.
+   - `HistoryReader`: `read_recent(limit, since)` — bottom-up parsing via regex `## {ts} | {id}`.
+   - `HistoryStore`: lazy wrapper around `NumpyVectorStore`. `ensure_index()` compares store and file mtime; if stale — re-embeds all entries (or incrementally: only entries whose id is not in the store). `search(query, limit)` embeds the query, returns top-N with distance.
+9. Extend `log_interaction` in `src/server.py` to append history entries. Add `read_history`. Both return JSON.
+10. Write `tests/test_history.py`: append creates file with header, format roundtrip, dedup, recent read order, `since` filter, rotation triggers + creates archive, lazy semantic index rebuilds on file change (mock embedder).
 
 ### Phase 4 — Wiring & Documentation (1 PR)
 
-11. Обновить `CLAUDE.md` (корень проекта) — короткая post-flight инструкция внутри секции routing protocol: *"After completing a meaningful turn, call `record_history(intent, action, outcome, files)`. On first session in an unfamiliar repo, call `describe_repo()` first."* Распространится в `~/.claude/CLAUDE.md` при следующем запуске `init_repo.sh`.
-12. Обновить `.gitignore` закомментированным opt-out:
+11. Update `CLAUDE.md` (project root) — short post-flight instruction inside the routing protocol section: *"After completing a meaningful turn, call `log_interaction(intent, action, outcome, files)`. On first session in an unfamiliar repo, call `describe_repo()` first."* Propagated to `~/.claude/CLAUDE.md` on next `init_repo.sh` run.
+12. Update `.gitignore`:
     ```
-    # Uncomment if you prefer to keep action history private:
-    # history.md
-    # history/
+    # history.md and history/ are gitignored by default for privacy.
+    history.md
+    history/
     ```
-13. Обновить корневой `README.md` — короткий раздел "Repository memory: `describe_repo` / `record_history`" со ссылкой на эту спецификацию.
+13. Update root `README.md` — short "Repository Memory" section with a link to this specification.
 
-### Phase 5 — Опциональные follow-ups (отдельные PR, не в текущем scope)
+### Phase 5 — Optional Follow-ups (separate PRs, out of current scope)
 
-14. **Hooks:** добавить шаблон `.claude/settings.json` с `PostToolUse`-хуком, который напоминает Claude вызвать `record_history`. Документировать в спеке, по умолчанию не включать.
-15. **Memory consolidation:** ночная задача, которая сжимает записи старше N дней в месячные summary.
-16. **Интеграция с `init_repo.sh`:** опциональный флаг `--describe`, который запускает `describe_repo` при первой установке.
+14. **Hooks:** add a `.claude/settings.json` template with a `PostToolUse` hook that reminds Claude to include curated fields in `log_interaction`. Document in the spec, disabled by default.
+15. **Memory consolidation:** nightly task that compresses entries older than N days into monthly summaries.
+16. **Integration with `init_repo.sh`:** optional `--describe` flag that runs `describe_repo` during first install.
 
 ---
 
-## 7. План тестирования
+## 7. Test Plan
 
-### 7.1 Юнит-тесты (pytest)
+### 7.1 Unit Tests (pytest)
 
-| Тест | Что проверяет |
+| Test | What it verifies |
 |---|---|
-| `test_managed_section_create` | Создание файла с маркерами и контентом |
-| `test_managed_section_replace` | Замена существующей секции, контент вне маркеров не тронут |
-| `test_managed_section_append` | Append при отсутствии маркеров |
-| `test_managed_section_partial_markers` | Ошибка при частичных маркерах (только begin или только end) |
-| `test_describer_hash_deterministic` | Один и тот же репо → один и тот же хэш |
-| `test_describer_hash_changes_on_file_add` | Новый top-level файл → хэш меняется |
-| `test_describer_skips_when_unchanged` | Второй вызов без force → `status:"up-to-date"` |
-| `test_describer_force_refresh_overwrites` | `force_refresh=True` → перегенерация даже при том же хэше |
-| `test_describer_word_count_in_range` | Сгенерированный summary укладывается в 800–1500 слов |
-| `test_history_append_creates_file` | Первый вызов создаёт `history.md` с frontmatter |
-| `test_history_format_roundtrip` | Append → read → все поля совпадают |
-| `test_history_dedup_by_hash` | Повторный вызов с тем же intent/action/outcome → `status:"duplicate"` |
-| `test_history_read_recent_order` | Возвращает записи в обратном хронологическом порядке |
-| `test_history_read_since_filter` | Фильтрация по timestamp работает |
-| `test_history_rotation_triggers` | Файл > 512 KB → перенос в `history/YYYY-MM.md` |
-| `test_history_semantic_lazy_index` | Векторный store не существует до первого `read_history(query=...)` |
-| `test_history_semantic_returns_relevant` | Mock-эмбеддер: запрос возвращает наиболее релевантную запись |
+| `test_managed_section_create` | File creation with markers and content |
+| `test_managed_section_replace` | Replacing existing section, content outside markers untouched |
+| `test_managed_section_append` | Append when no markers exist |
+| `test_managed_section_partial_markers` | Error on partial markers (only begin or only end) |
+| `test_describer_hash_deterministic` | Same repo → same hash |
+| `test_describer_hash_changes_on_file_add` | New top-level file → hash changes |
+| `test_describer_skips_when_unchanged` | Second call without force → `status:"up-to-date"` |
+| `test_describer_force_refresh_overwrites` | `force_refresh=True` → regeneration even with same hash |
+| `test_describer_word_count_in_range` | Generated summary fits within 800–1500 words |
+| `test_history_append_creates_file` | First call creates `history.md` with frontmatter |
+| `test_history_format_roundtrip` | Append → read → all fields match |
+| `test_history_dedup_by_hash` | Repeat call with same intent/action/outcome → `status:"duplicate"` |
+| `test_history_read_recent_order` | Returns entries in reverse chronological order |
+| `test_history_read_since_filter` | Timestamp filtering works |
+| `test_history_rotation_triggers` | File > 512 KB → moves to `history/YYYY-MM.md` |
+| `test_history_semantic_lazy_index` | Vector store does not exist until first `read_history(query=...)` |
+| `test_history_semantic_returns_relevant` | Mock embedder: query returns the most relevant entry |
 
-### 7.2 Live MCP-проверки (вручную)
+### 7.2 Live MCP Checks (manual)
 
-1. Поднять сервер: `bash scripts/run_tests.sh && python -m src.server`.
-2. В Claude Code сессии:
-   - `describe_repo()` → подтвердить, что `CLAUDE.md` обновился; routing-секция не тронута.
-   - Повторно `describe_repo()` → `status:"up-to-date"`.
-   - `describe_repo(force_refresh=True)` → перегенерация.
-   - `record_history(intent="Verify integration", action="Manual test", outcome="passed")` → запись в `history.md`.
-   - Повторно тот же `record_history` → `status:"duplicate"`.
-   - `read_history(limit=5)` → запись видна.
-   - `read_history(query="verify integration")` → семантический матч.
-3. Регрессии: `pytest tests/test_routing.py` — `route_and_load` корректно роутит существующие тестовые запросы.
+1. Start server: `bash scripts/run_tests.sh && python -m src.server`.
+2. In a Claude Code session:
+   - `describe_repo()` → confirm that `CLAUDE.md` was updated; routing section untouched.
+   - Repeat `describe_repo()` → `status:"up-to-date"`.
+   - `describe_repo(force_refresh=True)` → regeneration.
+   - `log_interaction(...)` with curated `intent="Verify integration", action="Manual test", outcome="passed"` → entry in `history.md`.
+   - Repeat same `log_interaction` → `status:"duplicate"`.
+   - `read_history(limit=5)` → entry visible.
+   - `read_history(query="verify integration")` → semantic match.
+3. Regressions: `pytest tests/test_routing.py` — `route_and_load` correctly routes existing test queries.
 
-### 7.3 Метрики качества
+### 7.3 Quality Metrics
 
-| Метрика | Цель |
+| Metric | Target |
 |---|---|
-| Word count describe-summary | 800–1500 |
-| Размер `CLAUDE.md` после describe | < 15 KB |
-| Латентность `record_history` | < 20 ms (без векторизации) |
-| Латентность `read_history(query=...)` (cold) | < 500 ms (включая первичную индексацию ≤ 100 записей) |
-| Точность семантического поиска | top-1 совпадает с ожидаемым в ≥ 90% тестов |
+| Word count of describe summary | 800–1500 |
+| Size of `CLAUDE.md` after describe | < 15 KB |
+| Latency of `log_interaction` (history append) | < 20 ms (no vectorization) |
+| Latency of `read_history(query=...)` (cold) | < 500 ms (including initial indexing of ≤ 100 entries) |
+| Semantic search accuracy | top-1 matches expected in ≥ 90% of tests |
 
 ---
 
-## 8. Открытые решения (не блокируют v1)
+## 8. Open Questions (non-blocking for v1)
 
-- **Категории в `record_history`?** Принимать ли enum `category` (decision/refactor/fix/feature) для фильтрованного чтения? **Рекомендация:** пропустить в v1; tags покрывают это с нулевой жёсткостью схемы.
-- **Git-метаданные в describe?** Включать ли текущую ветку и последний коммит? **Рекомендация:** да — append блока `## Git State` в конце управляемой секции, перегенеряется при каждом refresh.
-- **Phase 2 hooks:** opt-in PostToolUse для авто-подсказки `record_history`. **Не в scope v1;** контракт хука зафиксировать в этой спеке (раздел Phase 5).
+- **Categories in `log_interaction`?** Accept an enum `category` (decision/refactor/fix/feature) for filtered reading? **Recommendation:** skip in v1; tags cover this with zero schema rigidity.
+- **Git metadata in describe?** Include current branch and last commit? **Recommendation:** yes — append a `## Git State` block at the end of the managed section, regenerated on each refresh.
+- **Phase 2 hooks:** opt-in PostToolUse for auto-reminder to include curated fields in `log_interaction`. **Not in scope for v1;** hook contract to be specified in this doc (Phase 5 section).
 
 ---
 
-## Приложение A. Затрагиваемые файлы (быстрая навигация)
+## Appendix A. Affected Files (quick navigation)
 
-**Создаём:**
+**Created:**
 - `src/memory/__init__.py`
-- `src/memory/config.py` — константы
-- `src/memory/managed_section.py` — маркер-редактор (порт из `scripts/init_repo.sh:636-672`)
-- `src/memory/describer.py` — `RepoDescriber` + шаблон describe-промпта
+- `src/memory/config.py` — constants
+- `src/memory/managed_section.py` — marker editor (port from `scripts/init_repo.sh:636-672`)
+- `src/memory/describer.py` — `RepoDescriber` + describe prompt template
 - `src/memory/history.py` — `HistoryWriter`, `HistoryReader`, `HistoryStore`
 - `tests/test_managed_section.py`
 - `tests/test_describer.py`
 - `tests/test_history.py`
 
-**Изменяем:**
-- `src/server.py` — три новых `@mcp.tool()`
-- `CLAUDE.md` — добавить post-flight инструкцию (один абзац) внутрь routing protocol
-- `.gitignore` — закомментированный opt-out для `history.md`
-- `README.md` — один абзац про подсистему памяти со ссылкой на эту спеку
+**Modified:**
+- `src/server.py` — new `@mcp.tool()` registrations + extended `log_interaction`
+- `CLAUDE.md` — added post-flight instruction (one paragraph) inside routing protocol
+- `.gitignore` — `history.md` and `history/` gitignored by default
+- `README.md` — one paragraph about the memory subsystem with a link to this spec
 
-## Приложение C. Implementation Notes (что реально вошло в код)
+## Appendix C. Implementation Notes (what actually shipped)
 
-Реализация на 2026-04-15 совпадает со спекой. Уточнения, появившиеся при кодинге:
+The implementation as of 2026-04-15 matches the spec. Clarifications that emerged during coding:
 
-1. **Модуль `src/memory/config.py`** добавляет константы, не упомянутые в плане явно: `CLAUDE_MD_FILE`, `HISTORY_ARCHIVE_DIR`, `DESCRIBE_TREE_MAX_DEPTH`, `DESCRIBE_README_HEAD_LINES`, `DESCRIBE_EXCLUDED_DIRS`, `DESCRIBE_WORD_MIN/MAX`. Все — производные от значений, упомянутых в спеке (512 KB, 800–1500 слов, depth ≤ 3).
+1. **Module `src/memory/config.py`** adds constants not explicitly mentioned in the plan: `CLAUDE_MD_FILE`, `HISTORY_ARCHIVE_DIR`, `DESCRIBE_TREE_MAX_DEPTH`, `DESCRIBE_README_HEAD_LINES`, `DESCRIBE_EXCLUDED_DIRS`, `DESCRIBE_WORD_MIN/MAX`. All are derived from values mentioned in the spec (512 KB, 800–1500 words, depth ≤ 3).
 
-2. **Hash CLAUDE.md/history.md исключается из repo-hash** (`_HASH_EXCLUDED_FILES` в `describer.py`). Без этого `describe_repo` инвалидировал бы собственный кэш на каждом запуске — побочный эффект записи в CLAUDE.md меняет top-level filenames.
+2. **CLAUDE.md/history.md hashes are excluded from the repo hash** (`_HASH_EXCLUDED_FILES` in `describer.py`). Without this, `describe_repo` would invalidate its own cache on every run — the side effect of writing to CLAUDE.md changes the top-level filenames.
 
-3. **`RepoDescriber` разбит на `plan() / build_prompt() / write_summary()`**, а вызов `ctx.session.create_message(...)` остался в `src/server.py`. Это позволяет писать unit-тесты без MCP-контекста — тесты не используют sampling.
+3. **`RepoDescriber` is split into `plan() / build_prompt() / write_summary()`**, and the `ctx.session.create_message(...)` call stays in `src/server.py`. This allows writing unit tests without an MCP context — tests do not use sampling.
 
-4. **`HistoryWriter`/`HistoryReader` — pure stdlib**, без numpy. `HistoryStore` (семантический recall) импортирует `NumpyVectorStore` и эмбеддер только при первом `search()`. Это критично для NixOS-окружения: writer/reader работают даже когда numpy не может загрузиться (тесты semantic-store при этом помечаются `skipif`).
+4. **`HistoryWriter`/`HistoryReader` are pure stdlib**, without numpy. `HistoryStore` (semantic recall) imports `NumpyVectorStore` and the embedder only on the first `search()`. This is critical for NixOS environments: writer/reader work even when numpy cannot load (semantic-store tests are marked `skipif` in that case).
 
-5. **`HistoryStore.search` принимает `embed_query` / `embed_texts` как аргументы** (DI). По умолчанию подгружаются `src.engine.embedder.*`; в тестах подсовывается `FakeEmbedder` с детерминированными векторами, не требующий загрузки реальной модели.
+5. **`HistoryStore.search` accepts `embed_query` / `embed_texts` as arguments** (DI). By default they load `src.engine.embedder.*`; in tests a `FakeEmbedder` with deterministic vectors is injected, requiring no real model download.
 
-6. **fcntl-обёртка** `_lock_exclusive` / `_unlock` в `history.py` — no-op на Windows, чтобы модуль импортировался кросс-платформенно.
+6. **fcntl wrapper** `_lock_exclusive` / `_unlock` in `history.py` — no-op on Windows so the module imports cross-platform.
 
-7. **Tag-нормализация:** хэштеги без префикса `#` дополняются им автоматически (`"feature"` → `"#feature"`).
+7. **Tag normalization:** hashtags without a `#` prefix are automatically prefixed (`"feature"` → `"#feature"`).
 
-8. **Rotation merge:** если `history/YYYY-MM.md` уже существует на момент ротации (несколько ротаций в один месяц), новый снапшот аппендится с разделителем `<!-- merged on rotation -->`, а не перезаписывает старый архив.
+8. **Rotation merge:** if `history/YYYY-MM.md` already exists at rotation time (multiple rotations in one month), the new snapshot is appended with a `<!-- merged on rotation -->` separator rather than overwriting the existing archive.
 
-9. **CLI-инструкция в `CLAUDE.md`** добавлена как пункт `4. Repository memory (first session per repo)` — отдельный раздел внутри Routing Flow, чтобы не путаться с post-flight шагом 3.
+9. **CLI instruction in `CLAUDE.md`** added as item `4. Repository memory (first session per repo)` — a separate section within the Routing Flow to avoid confusion with post-flight step 3.
 
-10. **README.md** содержит раздел `🧠 Repository Memory` со ссылкой на эту спеку и упоминанием `.gitignore` opt-out.
+10. **README.md** contains a `Repository Memory` section with a link to this spec and a mention of the `.gitignore` opt-out.
 
 ---
 
-## Приложение B. Источники (research)
+## Appendix B. References (research)
 
-- `https://github.com/raoulbia-ai/claude-recall` — outcome-aware memory, hooks, JIT-инъекция
+- `https://github.com/raoulbia-ai/claude-recall` — outcome-aware memory, hooks, JIT injection
 - `https://github.com/mkreyman/mcp-memory-keeper` — explicit tool surface, checkpoints, channels
 - `https://github.com/doobidoo/mcp-memory-service` — autonomous consolidation, knowledge graph
 - `https://www.mintlify.com/blog/how-claudes-memory-and-mcp-work` — split native CLAUDE.md vs MCP

--- a/docs/memory-subsystem-spec.md
+++ b/docs/memory-subsystem-spec.md
@@ -29,9 +29,9 @@
 | Решение | Выбор | Обоснование |
 |---|---|---|
 | Способ генерации describe | **Prompt + MCP sampling** | Сервер строит prompt и контекст-bundle, через `ctx.session.create_message(...)` просит вызывающий LLM сгенерировать summary, затем сам пишет результат в `CLAUDE.md`. Уже используется в `route_and_load` (`src/server.py:196`). |
-| Расположение `history.md` | **Корень репо, коммитится в git** | Видим в PR, ревьюабельно, шарится между разработчиками. `.gitignore` opt-out — закомментированный. |
-| Триггер записи в history | **Явный `record_history()`** | Без хуков (в репо пока нет `.claude/settings.json`). Инструкция в `CLAUDE.md` обязывает Claude вызывать tool в конце каждого значимого turn'а. |
-| Семантический поиск | **Lazy** | `record_history` остаётся быстрым (только append). `NumpyVectorStore` строится при первом `read_history(query=...)` и инкрементально обновляется по mtime. |
+| Расположение `history.md` | **Корень репо, по умолчанию не коммитится в git** | Файл остаётся локальной per-repo памятью рядом с кодом, но `gitignore`-ится по умолчанию, чтобы не засорять PR и не утекать секретам. При необходимости команда может убрать из `.gitignore` и вернуться к versioned-подходу. |
+| Триггер записи в history | **`log_interaction(...)`** | Отдельный `record_history()` удалён: `log_interaction(...)` всегда дозаписывает запись в `history.md` и опционально отправляет Langfuse generation-трейс. |
+| Семантический поиск | **Lazy** | `log_interaction(...)` остаётся быстрым (только append в `history.md`). `NumpyVectorStore` строится при первом `read_history(query=...)` и инкрементально обновляется по mtime. |
 
 ### Сверка с аналогами
 

--- a/docs/memory-subsystem-spec.md
+++ b/docs/memory-subsystem-spec.md
@@ -1,0 +1,477 @@
+# Подсистема памяти Agents-Core: `describe` + `history.md`
+
+> ТЗ и пошаговая реализация механизма репо-памяти для MCP-сервера Agents-Core.
+> Статус: реализовано 2026-04-15. См. Приложение C — отличия фактической имплементации от плана.
+
+> **Update 2026-04-15 (post-implementation):** MCP-инструмент `record_history` слит с
+> `log_interaction`. Теперь `log_interaction(...)` всегда дозаписывает в `history.md` (с
+> опциональными `intent`/`action`/`outcome`/`files`/`tags` для курирования) и, если
+> подключен Langfuse, дополнительно отправляет generation-трейс. Класс `HistoryWriter`
+> и формат `history.md` не изменились — описанное ниже про дедупликацию, ротацию,
+> формат и `read_history` остаётся в силе. Отдельный MCP-tool `record_history` удалён,
+> чтобы не дублировать инструкции для модели.
+
+---
+
+## 1. Контекст и мотивация
+
+У MCP-сервера Agents-Core (`/home/wondermr/repos/Agents`) сейчас нет постоянной per-repo памяти: каждая новая сессия Claude Code заново изучает кодовую базу и забывает смысл прошлых действий. Это сжигает токены, теряет архитектурные решения и делает работу невоспроизводимой.
+
+Внедряем два дополняющих механизма — файловые (markdown), привязанные к репозиторию, переиспользуемые между LLM:
+
+1. **Режим `describe`** — однократный bootstrap, который дистиллирует репозиторий в качественный краткий обзор, сохраняемый в управляемую секцию `CLAUDE.md`. Будущие сессии читают его вместо повторного исследования.
+2. **Режим `history.md`** — append-only журнал *intent + action + outcome* для каждого значимого turn'а; даёт воспроизводимую историю действий, которую можно подгружать в контекст по требованию.
+
+Подсистема **переиспользует существующие примитивы** Agents-Core (FastMCP-сервер, `NumpyVectorStore`, маркер-редактор `CLAUDE.md`, эмбеддер, hash-инвалидация). Никакой новой инфраструктуры не вводится.
+
+### Проектные решения (зафиксированы)
+
+| Решение | Выбор | Обоснование |
+|---|---|---|
+| Способ генерации describe | **Prompt + MCP sampling** | Сервер строит prompt и контекст-bundle, через `ctx.session.create_message(...)` просит вызывающий LLM сгенерировать summary, затем сам пишет результат в `CLAUDE.md`. Уже используется в `route_and_load` (`src/server.py:196`). |
+| Расположение `history.md` | **Корень репо, коммитится в git** | Видим в PR, ревьюабельно, шарится между разработчиками. `.gitignore` opt-out — закомментированный. |
+| Триггер записи в history | **Явный `record_history()`** | Без хуков (в репо пока нет `.claude/settings.json`). Инструкция в `CLAUDE.md` обязывает Claude вызывать tool в конце каждого значимого turn'а. |
+| Семантический поиск | **Lazy** | `record_history` остаётся быстрым (только append). `NumpyVectorStore` строится при первом `read_history(query=...)` и инкрементально обновляется по mtime. |
+
+### Сверка с аналогами
+
+| Источник | Чем вдохновляемся |
+|---|---|
+| **claude-recall** (TS, SQLite, hooks-driven) | Outcome-aware memory; content-hash dedup; JIT-инъекция активных правил. **Не берём:** SQLite (для нашего use-case markdown проще и git-friendly), хуки (Phase 2). |
+| **mcp-memory-keeper** (TS, SQLite, explicit tools) | Идея явных tool'ов вместо хуков; checkpoint-семантика; channel-based scoping. **Адаптируем:** explicit tool surface, без channels (пока). |
+| **mcp-memory-service** (Python, REST+MCP) | Идея autonomous consolidation (decay + compress) — кладём в Phase 5. **Не берём:** knowledge graph с типизированными рёбрами. |
+| **Mintlify guidance** | Принцип: native CLAUDE.md = постоянный контекст; MCP = real-time запросы. У нас describe пишет в CLAUDE.md (читается на старте), history запрашивается по требованию через MCP. |
+
+---
+
+## 2. Цели и не-цели
+
+**Цели**
+- Три новых MCP-инструмента: `describe_repo`, `record_history`, `read_history`.
+- Идемпотентное, неразрушающее редактирование `CLAUDE.md` через новую пару маркеров (отдельную от существующей секции routing-protocol).
+- Append-only `history.md` в корне репо с content-hash dedup, ежемесячной ротацией, опциональным семантическим recall.
+- Тесты в стиле существующих (`pytest`, `tmp_path`, mock-эмбеддер).
+- Промпт describe-режима — production-grade (BLUF, MECE, структура Mega-Prompting).
+
+**Не-цели**
+- Hooks для авто-захвата (Phase 2; в репо ещё нет `.claude/settings.json` с хуками).
+- Knowledge graph с типизированными рёбрами.
+- Consolidation/decay памяти (Phase 5).
+- Cross-repo федерация памяти.
+- Изменение существующей секции routing-protocol в `CLAUDE.md`.
+
+---
+
+## 3. Архитектура
+
+### 3.1 Поток данных
+
+```
+describe_repo(repo_path?, force_refresh=False)
+  ├─ RepoDescriber.compute_repo_hash()       # MD5 от pyproject/package.json/top-level dirs/начала README
+  ├─ если хэш не изменился и не force → return {status:"up-to-date"}
+  ├─ обход дерева (depth ≤ 3, исключаем vendor) + чтение ключевых файлов → CONTEXT_BUNDLE
+  ├─ render DESCRIBE_PROMPT (template) с CONTEXT_BUNDLE
+  ├─ ctx.session.create_message(prompt)      # MCP sampling — Claude генерирует summary
+  ├─ managed_section.upsert(CLAUDE.md, DESCRIBE_MARKER_BEGIN/END, summary)
+  ├─ сохраняем хэш → DESCRIBE_HASH_FILE
+  └─ return {status, path, hash, word_count, summary_preview}
+
+record_history(intent, action, outcome, files?, tags?, metadata?)
+  ├─ HistoryWriter.compute_entry_hash()      # SHA256(intent+action+outcome)[:12]
+  ├─ скан последних 50 записей на дубль → return {status:"duplicate"} при совпадении
+  ├─ форматируем markdown-запись
+  ├─ fcntl.flock + атомарный append к history.md
+  ├─ maybe_rotate() если файл > 512 KB → архив в history/YYYY-MM.md
+  └─ return {status:"recorded", entry_id, path}
+
+read_history(limit=20, since?, query?)
+  ├─ если query:
+  │    ├─ HistoryStore.ensure_index()        # lazy: rebuild если mtime файла > mtime store
+  │    └─ семантический поиск через NumpyVectorStore + эмбеддер
+  └─ иначе:
+       └─ HistoryReader.read_recent()        # парсинг снизу вверх, фильтр по since
+```
+
+### 3.2 Раскладка модулей
+
+| Новый файл | Роль |
+|---|---|
+| `src/memory/__init__.py` | Маркер пакета |
+| `src/memory/config.py` | Константы: пути, маркеры, пороги; импортирует `REPO_ROOT`/`DATA_DIR` из `src/engine/config.py:7-8` |
+| `src/memory/managed_section.py` | Чистый Python-порт маркер-редактора из `scripts/init_repo.sh:636-672`. Функции: `upsert_section`, `read_section`, `remove_section`. Атомарная запись через `tempfile` + `os.replace`. |
+| `src/memory/describer.py` | `RepoDescriber`: hash → bundle → prompt → sampling → upsert |
+| `src/memory/history.py` | `HistoryWriter` (append, dedup, rotate) + `HistoryReader` (recent + lazy semantic) + `HistoryStore` (обёртка над NumpyVectorStore) |
+| `tests/test_managed_section.py` | Тесты маркер-редактора (стиль `tests/test_vector_store.py`) |
+| `tests/test_describer.py` | Хэш, refresh-логика, мок sampling, проверка upsert |
+| `tests/test_history.py` | Append, dedup, ротация, recent read, семантический поиск (mock embedder) |
+
+| Изменяемый файл | Что меняем |
+|---|---|
+| `src/server.py` | Добавить `@mcp.tool()` для `describe_repo`, `record_history`, `read_history` |
+| `CLAUDE.md` (корень проекта) | Добавить короткую инструкцию в routing protocol: после шагов протокола агент должен вызывать `record_history()` в конце значимого turn'а; на первой сессии в незнакомом репо — сначала `describe_repo()` |
+| `.gitignore` | Закомментированные строки opt-out для `history.md` |
+
+### 3.3 Карта переиспользования (НЕ переписывать заново)
+
+| Существующее | Расположение | Где переиспользуем |
+|---|---|---|
+| FastMCP `@mcp.tool()` декоратор + JSON-string возвраты | `src/server.py:70-608` | Все три новых tool'а — тот же паттерн регистрации |
+| MCP sampling через `ctx.session.create_message(...)` | `src/server.py:196` | `describe_repo` использует тот же sampling-вызов |
+| Маркер-редактор CLAUDE.md (inline Python) | `scripts/init_repo.sh:636-672` | Портируем буквально в `src/memory/managed_section.py` — bash-инсталлер и MCP-tool используют одну реализацию (bash подцепит через subprocess) |
+| `SkillRetriever._compute_dir_hash` + `_needs_reindex` | `src/engine/skills.py:32-51` | `RepoDescriber._compute_repo_hash` + `_needs_refresh` |
+| `NumpyVectorStore` (атомарные .npz+.json, thread-safe) | `src/engine/vector_store.py:39` | `HistoryStore` для семантического recall |
+| `embed_texts` / `embed_query` (FastEmbed) | `src/engine/embedder.py:83,89` | Векторизация записей и запросов |
+| `LanguageDetector` | `src/engine/language.py:39` | Тегирование записей по языку |
+| `debug_log` | `src/utils/debug_logger.py:18` | Инструментация всех трёх tool'ов |
+| `@observe` из `langfuse_compat` | `src/utils/langfuse_compat.py` | Опциональная observability |
+| `REPO_ROOT`, `DATA_DIR` | `src/engine/config.py:7-8` | Базовые пути |
+| pytest-фикстуры (`tmp_path`, `populated_store`) | `tests/test_vector_store.py:12-31` | Зеркалим для новых тестов |
+
+---
+
+## 4. Контракты форматов
+
+### 4.1 `CLAUDE.md` (управляемая секция)
+
+Сосуществуют две пары маркеров. Новая пара ставится **ниже** существующей секции routing-protocol, чтобы повторные запуски `init_repo.sh` и повторные `describe_repo` никогда не пересекались.
+
+```
+# >>> Agents-Core Routing Protocol (managed by init_repo) >>>
+… существующее …
+# <<< Agents-Core Routing Protocol (managed by init_repo) <<<
+
+# >>> Agents-Core Repository Memory (managed by describe_repo) >>>
+
+# Repository: agents-core
+> Auto-generated by `describe_repo` on 2026-04-15T10:00:00Z. Hash: a1b2c3.
+> Re-run with `describe_repo(force_refresh=True)` to update.
+
+## Project Identity
+…
+## Tech Stack
+…
+## Entry Points
+…
+## Module Map
+…
+## Conventions
+…
+## Key Workflows
+…
+## Architecture Patterns
+…
+## Test Strategy
+…
+## Gotchas
+…
+## Glossary
+…
+
+# <<< Agents-Core Repository Memory (managed by describe_repo) <<<
+```
+
+**Бюджет слов:** 800–1500 (проверяется тестами). Жёсткий cap, чтобы `CLAUDE.md` не раздул контекстное окно.
+
+### 4.2 `history.md` (append-only, корень репо)
+
+Шапка файла (пишется один раз при первом append):
+```yaml
+---
+repo: agents-core
+created: 2026-04-15T09:30:00Z
+format_version: 1
+---
+```
+
+Шаблон записи:
+```markdown
+## 2026-04-15T14:32:00Z | a1b2c3d4e5f6
+**Intent:** Включить семантический recall прошлых действий для подгрузки в контекст.
+**Action:** Добавил `HistoryStore` поверх `NumpyVectorStore` в `src/memory/history.py`; записи эмбеддятся лениво.
+**Outcome:** `pytest tests/test_history.py::test_semantic_search_returns_relevant` проходит; индекс пересобирается, когда mtime history.md растёт.
+**Files:** src/memory/history.py, tests/test_history.py
+**Tags:** #feature #memory
+```
+
+**Правила:**
+- `entry_id` (12-hex суффикс в заголовке) = `sha256(intent+action+outcome)[:12]`. Стабильный, дедупится.
+- Dedup: скан последних 50 записей по id перед append. Дубли коротко-замыкаются.
+- Только append. Прошлые записи никогда не редактируются и не удаляются.
+- `fcntl.flock(LOCK_EX)` на запись (защита от параллельных сессий).
+- Ротация: при `os.path.getsize > 512 KB` — переносим файл в `history/YYYY-MM.md` (месяц по timestamp последней записи), открываем свежий `history.md` со ссылкой-шапкой на архив.
+- UTF-8, `\n` line endings.
+- `tags` — свободные `#хэштеги`; `metadata` — плоский JSON, если задан, сериализуется inline как `**Meta:** {...}`.
+
+### 4.3 Сигнатуры MCP-инструментов (добавляются в `src/server.py`)
+
+```python
+@mcp.tool()
+async def describe_repo(
+    ctx: Context,
+    repo_path: str | None = None,
+    force_refresh: bool = False,
+) -> str:
+    """One-shot repo bootstrap. Generates a structured summary via MCP sampling
+    and writes it into the managed Repository Memory section of CLAUDE.md.
+
+    Returns JSON: {status, path, hash, word_count, summary_preview}.
+    status ∈ {"refreshed", "up-to-date", "error"}.
+    """
+
+@mcp.tool()
+async def record_history(
+    intent: str,
+    action: str,
+    outcome: str,
+    files: list[str] | None = None,
+    tags: list[str] | None = None,
+    metadata: dict | None = None,
+) -> str:
+    """Append a single intent-centric entry to history.md (append-only, deduped by content hash).
+
+    Returns JSON: {status, entry_id, path}.
+    status ∈ {"recorded", "duplicate", "error"}.
+    """
+
+@mcp.tool()
+async def read_history(
+    limit: int = 20,
+    since: str | None = None,
+    query: str | None = None,
+) -> str:
+    """Read recent entries (limit/since) or run a lazy semantic search (query). Returns JSON.
+
+    Returns JSON: {entries: [{id, timestamp, intent, action, outcome, files, tags, distance?}], total, mode}.
+    mode ∈ {"recency", "semantic"}.
+    """
+```
+
+Все три возвращают JSON-строки (как существующий паттерн в `src/server.py`).
+
+---
+
+## 5. Промпт describe-режима (центральный артефакт)
+
+`RepoDescriber` строит этот промпт и отправляет через `ctx.session.create_message(...)`. Плейсхолдер `{{CONTEXT_BUNDLE}}` заполняется детерминированно: дерево файлов (depth ≤ 3), `pyproject.toml` / `package.json` / `Cargo.toml` / `go.mod`, README.md (первые 200 строк), заголовки entry-point файлов, sample frontmatter `.mdc`, список тестов, скрипты.
+
+> Текст промпта оставлен на английском намеренно — будущие сессии Claude в любом языковом контексте смогут его выполнить, а структура output совпадает с английскими секциями `CLAUDE.md`.
+
+```
+You are a **Repository Analyst** performing a one-time deep study of a codebase.
+Your output will be saved into CLAUDE.md as the project memory and read by every
+future Claude session, so future sessions can work effectively without re-exploring
+the codebase.
+
+## Task
+Produce a compressed, LLM-consumable repository overview for `{{REPO_NAME}}`.
+
+## Input (CONTEXT_BUNDLE)
+{{CONTEXT_BUNDLE}}
+
+## Output Format
+Produce exactly these sections in this order. Use compressed markdown
+(BLUF, atomic paragraphs, no filler).
+
+### Project Identity
+One paragraph: name, purpose, primary language, framework, package manager.
+
+### Tech Stack
+Bulleted list of key dependencies with version and purpose. Max 15 items.
+
+### Entry Points
+Table: path | purpose. Include: main, tests, config, CI/CD, scripts.
+
+### Module Map
+Depth-2 directory listing. One line per directory: `path/ — purpose`.
+Skip generated/vendor dirs.
+
+### Conventions
+Bulleted list: naming, imports, error handling, logging, frontmatter format,
+code style.
+
+### Key Workflows
+For each script / Make target / npm script: `name — what it does`. Max 10.
+
+### Architecture Patterns
+2–3 paragraphs: data flow, key abstractions, dependency injection style,
+async patterns.
+
+### Test Strategy
+Runner, fixture patterns, mock strategy, coverage config. One paragraph.
+
+### Gotchas
+Bulleted list of non-obvious things: env vars needed, startup order,
+known limitations, common mistakes.
+
+### Glossary
+Table: term | definition. Domain-specific terms only. Max 15.
+
+## Rules
+- BLUF: lead every section with the most important fact.
+- Compress: no filler ("this project is", "in order to", "it is worth noting").
+- Atomic: one paragraph = one idea.
+- Concrete: cite file paths and line numbers, not vague references.
+- Skip empty sections rather than writing "N/A".
+- Total output: 800–1500 words. Exceeding wastes context; under-shooting loses info.
+- Output ONLY the markdown sections above. No preamble, no closing remarks.
+```
+
+---
+
+## 6. Пошаговая реализация
+
+### Phase 1 — Foundation (1 PR)
+
+1. Создать `src/memory/__init__.py` (пустой).
+2. Создать `src/memory/config.py` с константами: `MEMORY_DATA_DIR`, `HISTORY_FILE`, `DESCRIBE_HASH_FILE`, `DESCRIBE_MARKER_BEGIN/END`, `HISTORY_VECTOR_STORE_NAME`, `HISTORY_ROTATION_THRESHOLD_KB = 512`. Все пути привязаны к `REPO_ROOT`/`DATA_DIR` из `src/engine/config.py`.
+3. Создать `src/memory/managed_section.py` с `upsert_section`, `read_section`, `remove_section`. Портировать inline Python из `scripts/init_repo.sh:636-672` строка-в-строку, добавить атомарную запись через `tempfile.NamedTemporaryFile` + `os.replace`. Валидировать уникальность маркеров; кидать ошибку при частичных маркерах.
+4. Написать `tests/test_managed_section.py`: create, replace, append, partial-marker rejection, сохранение контента вне маркеров, атомарная запись при сбое.
+
+### Phase 2 — Describe (1 PR)
+
+5. Создать `src/memory/describer.py`:
+   - `RepoDescriber.__init__(repo_path)`.
+   - `_compute_repo_hash()` — MD5 от: отсортированных top-level имён файлов, содержимого `pyproject.toml`, содержимого `package.json`, имён директорий depth-1 + depth-2, первых 200 строк README.md.
+   - `_needs_refresh(force) → (bool, hash)` — паттерн из `src/engine/skills.py:43-51`.
+   - `_build_context_bundle() → str` — рендерит блок `{{CONTEXT_BUNDLE}}`: дерево (`Path.rglob` с фильтрами, depth ≤ 3, исключая `node_modules`, `.venv`, `__pycache__`, `.git`, `data/`), содержимое ключевых файлов, sample frontmatter `.mdc`.
+   - `_render_prompt(bundle, repo_name) → str` — подставляет плейсхолдеры в шаблон describe-промпта (хранится как multiline-константа в модуле).
+   - `async describe(ctx, force=False) → dict` — оркестратор: если refresh не нужен — вернуть кэш summary, прочитанный через `managed_section.read_section`; иначе построить prompt, вызвать `ctx.session.create_message(...)` (sampling), `managed_section.upsert_section(CLAUDE.md, …, generated)`, сохранить хэш, вернуть status.
+6. Добавить tool `describe_repo` в `src/server.py`. Обернуть в `@observe`, если Langfuse подгружен. Вернуть JSON.
+7. Написать `tests/test_describer.py`: детерминированный хэш, refresh-on-change, refresh-skipped-when-unchanged, моканый `ctx.session.create_message` с заранее заготовленным summary, проверка upsert, ассерт word-count (800–1500).
+
+### Phase 3 — History (1 PR)
+
+8. Создать `src/memory/history.py`:
+   - `HistoryWriter`: `__init__(history_path)`, `_compute_entry_hash`, `_is_duplicate` (tail-scan последних 50), `append_entry` (format → `flock` → атомарный append → `maybe_rotate`), `maybe_rotate`.
+   - `HistoryReader`: `read_recent(limit, since)` — парсинг снизу вверх через regex `## {ts} | {id}`.
+   - `HistoryStore`: lazy-обёртка над `NumpyVectorStore`. `ensure_index()` сравнивает mtime store и файла; если устарел — переэмбеддит все записи (или инкрементально: только записи, чьего id нет в store). `search(query, limit)` эмбеддит запрос, возвращает топ-N с distance.
+9. Добавить `record_history` и `read_history` в `src/server.py`. Оба возвращают JSON.
+10. Написать `tests/test_history.py`: append создаёт файл с шапкой, format roundtrip, dedup, порядок recent read, фильтр `since`, ротация триггерит + создаёт архив, lazy-семантический индекс пересобирается при изменении файла (mock embedder).
+
+### Phase 4 — Wiring & Documentation (1 PR)
+
+11. Обновить `CLAUDE.md` (корень проекта) — короткая post-flight инструкция внутри секции routing protocol: *"After completing a meaningful turn, call `record_history(intent, action, outcome, files)`. On first session in an unfamiliar repo, call `describe_repo()` first."* Распространится в `~/.claude/CLAUDE.md` при следующем запуске `init_repo.sh`.
+12. Обновить `.gitignore` закомментированным opt-out:
+    ```
+    # Uncomment if you prefer to keep action history private:
+    # history.md
+    # history/
+    ```
+13. Обновить корневой `README.md` — короткий раздел "Repository memory: `describe_repo` / `record_history`" со ссылкой на эту спецификацию.
+
+### Phase 5 — Опциональные follow-ups (отдельные PR, не в текущем scope)
+
+14. **Hooks:** добавить шаблон `.claude/settings.json` с `PostToolUse`-хуком, который напоминает Claude вызвать `record_history`. Документировать в спеке, по умолчанию не включать.
+15. **Memory consolidation:** ночная задача, которая сжимает записи старше N дней в месячные summary.
+16. **Интеграция с `init_repo.sh`:** опциональный флаг `--describe`, который запускает `describe_repo` при первой установке.
+
+---
+
+## 7. План тестирования
+
+### 7.1 Юнит-тесты (pytest)
+
+| Тест | Что проверяет |
+|---|---|
+| `test_managed_section_create` | Создание файла с маркерами и контентом |
+| `test_managed_section_replace` | Замена существующей секции, контент вне маркеров не тронут |
+| `test_managed_section_append` | Append при отсутствии маркеров |
+| `test_managed_section_partial_markers` | Ошибка при частичных маркерах (только begin или только end) |
+| `test_describer_hash_deterministic` | Один и тот же репо → один и тот же хэш |
+| `test_describer_hash_changes_on_file_add` | Новый top-level файл → хэш меняется |
+| `test_describer_skips_when_unchanged` | Второй вызов без force → `status:"up-to-date"` |
+| `test_describer_force_refresh_overwrites` | `force_refresh=True` → перегенерация даже при том же хэше |
+| `test_describer_word_count_in_range` | Сгенерированный summary укладывается в 800–1500 слов |
+| `test_history_append_creates_file` | Первый вызов создаёт `history.md` с frontmatter |
+| `test_history_format_roundtrip` | Append → read → все поля совпадают |
+| `test_history_dedup_by_hash` | Повторный вызов с тем же intent/action/outcome → `status:"duplicate"` |
+| `test_history_read_recent_order` | Возвращает записи в обратном хронологическом порядке |
+| `test_history_read_since_filter` | Фильтрация по timestamp работает |
+| `test_history_rotation_triggers` | Файл > 512 KB → перенос в `history/YYYY-MM.md` |
+| `test_history_semantic_lazy_index` | Векторный store не существует до первого `read_history(query=...)` |
+| `test_history_semantic_returns_relevant` | Mock-эмбеддер: запрос возвращает наиболее релевантную запись |
+
+### 7.2 Live MCP-проверки (вручную)
+
+1. Поднять сервер: `bash scripts/run_tests.sh && python -m src.server`.
+2. В Claude Code сессии:
+   - `describe_repo()` → подтвердить, что `CLAUDE.md` обновился; routing-секция не тронута.
+   - Повторно `describe_repo()` → `status:"up-to-date"`.
+   - `describe_repo(force_refresh=True)` → перегенерация.
+   - `record_history(intent="Verify integration", action="Manual test", outcome="passed")` → запись в `history.md`.
+   - Повторно тот же `record_history` → `status:"duplicate"`.
+   - `read_history(limit=5)` → запись видна.
+   - `read_history(query="verify integration")` → семантический матч.
+3. Регрессии: `pytest tests/test_routing.py` — `route_and_load` корректно роутит существующие тестовые запросы.
+
+### 7.3 Метрики качества
+
+| Метрика | Цель |
+|---|---|
+| Word count describe-summary | 800–1500 |
+| Размер `CLAUDE.md` после describe | < 15 KB |
+| Латентность `record_history` | < 20 ms (без векторизации) |
+| Латентность `read_history(query=...)` (cold) | < 500 ms (включая первичную индексацию ≤ 100 записей) |
+| Точность семантического поиска | top-1 совпадает с ожидаемым в ≥ 90% тестов |
+
+---
+
+## 8. Открытые решения (не блокируют v1)
+
+- **Категории в `record_history`?** Принимать ли enum `category` (decision/refactor/fix/feature) для фильтрованного чтения? **Рекомендация:** пропустить в v1; tags покрывают это с нулевой жёсткостью схемы.
+- **Git-метаданные в describe?** Включать ли текущую ветку и последний коммит? **Рекомендация:** да — append блока `## Git State` в конце управляемой секции, перегенеряется при каждом refresh.
+- **Phase 2 hooks:** opt-in PostToolUse для авто-подсказки `record_history`. **Не в scope v1;** контракт хука зафиксировать в этой спеке (раздел Phase 5).
+
+---
+
+## Приложение A. Затрагиваемые файлы (быстрая навигация)
+
+**Создаём:**
+- `src/memory/__init__.py`
+- `src/memory/config.py` — константы
+- `src/memory/managed_section.py` — маркер-редактор (порт из `scripts/init_repo.sh:636-672`)
+- `src/memory/describer.py` — `RepoDescriber` + шаблон describe-промпта
+- `src/memory/history.py` — `HistoryWriter`, `HistoryReader`, `HistoryStore`
+- `tests/test_managed_section.py`
+- `tests/test_describer.py`
+- `tests/test_history.py`
+
+**Изменяем:**
+- `src/server.py` — три новых `@mcp.tool()`
+- `CLAUDE.md` — добавить post-flight инструкцию (один абзац) внутрь routing protocol
+- `.gitignore` — закомментированный opt-out для `history.md`
+- `README.md` — один абзац про подсистему памяти со ссылкой на эту спеку
+
+## Приложение C. Implementation Notes (что реально вошло в код)
+
+Реализация на 2026-04-15 совпадает со спекой. Уточнения, появившиеся при кодинге:
+
+1. **Модуль `src/memory/config.py`** добавляет константы, не упомянутые в плане явно: `CLAUDE_MD_FILE`, `HISTORY_ARCHIVE_DIR`, `DESCRIBE_TREE_MAX_DEPTH`, `DESCRIBE_README_HEAD_LINES`, `DESCRIBE_EXCLUDED_DIRS`, `DESCRIBE_WORD_MIN/MAX`. Все — производные от значений, упомянутых в спеке (512 KB, 800–1500 слов, depth ≤ 3).
+
+2. **Hash CLAUDE.md/history.md исключается из repo-hash** (`_HASH_EXCLUDED_FILES` в `describer.py`). Без этого `describe_repo` инвалидировал бы собственный кэш на каждом запуске — побочный эффект записи в CLAUDE.md меняет top-level filenames.
+
+3. **`RepoDescriber` разбит на `plan() / build_prompt() / write_summary()`**, а вызов `ctx.session.create_message(...)` остался в `src/server.py`. Это позволяет писать unit-тесты без MCP-контекста — тесты не используют sampling.
+
+4. **`HistoryWriter`/`HistoryReader` — pure stdlib**, без numpy. `HistoryStore` (семантический recall) импортирует `NumpyVectorStore` и эмбеддер только при первом `search()`. Это критично для NixOS-окружения: writer/reader работают даже когда numpy не может загрузиться (тесты semantic-store при этом помечаются `skipif`).
+
+5. **`HistoryStore.search` принимает `embed_query` / `embed_texts` как аргументы** (DI). По умолчанию подгружаются `src.engine.embedder.*`; в тестах подсовывается `FakeEmbedder` с детерминированными векторами, не требующий загрузки реальной модели.
+
+6. **fcntl-обёртка** `_lock_exclusive` / `_unlock` в `history.py` — no-op на Windows, чтобы модуль импортировался кросс-платформенно.
+
+7. **Tag-нормализация:** хэштеги без префикса `#` дополняются им автоматически (`"feature"` → `"#feature"`).
+
+8. **Rotation merge:** если `history/YYYY-MM.md` уже существует на момент ротации (несколько ротаций в один месяц), новый снапшот аппендится с разделителем `<!-- merged on rotation -->`, а не перезаписывает старый архив.
+
+9. **CLI-инструкция в `CLAUDE.md`** добавлена как пункт `4. Repository memory (first session per repo)` — отдельный раздел внутри Routing Flow, чтобы не путаться с post-flight шагом 3.
+
+10. **README.md** содержит раздел `🧠 Repository Memory` со ссылкой на эту спеку и упоминанием `.gitignore` opt-out.
+
+---
+
+## Приложение B. Источники (research)
+
+- `https://github.com/raoulbia-ai/claude-recall` — outcome-aware memory, hooks, JIT-инъекция
+- `https://github.com/mkreyman/mcp-memory-keeper` — explicit tool surface, checkpoints, channels
+- `https://github.com/doobidoo/mcp-memory-service` — autonomous consolidation, knowledge graph
+- `https://www.mintlify.com/blog/how-claudes-memory-and-mcp-work` — split native CLAUDE.md vs MCP

--- a/docs/memory-subsystem-spec.md
+++ b/docs/memory-subsystem-spec.md
@@ -14,7 +14,7 @@
 
 ## 1. Context & Motivation
 
-The Agents-Core MCP server (`/home/wondermr/repos/Agents`) currently lacks persistent per-repo memory: every new Claude Code session re-explores the codebase from scratch and forgets the meaning of past actions. This wastes tokens, loses architectural decisions, and makes work non-reproducible.
+The Agents-Core MCP server in this repo currently lacks persistent per-repo memory: every new Claude Code session re-explores the codebase from scratch and forgets the meaning of past actions. This wastes tokens, loses architectural decisions, and makes work non-reproducible.
 
 We introduce two complementary mechanisms — file-based (markdown), repo-bound, reusable across LLMs:
 

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,0 +1,7 @@
+"""Repository memory subsystem: describe + history.
+
+Provides three MCP tools (registered in src/server.py):
+  - describe_repo:  one-shot bootstrap → managed section in CLAUDE.md
+  - record_history: append-only intent/action/outcome log → history.md
+  - read_history:   recent + lazy semantic recall over the log
+"""

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,7 +1,7 @@
-"""Repository memory subsystem: describe + history.
+"""Repository memory subsystem: describe + interaction history.
 
 Provides three MCP tools (registered in src/server.py):
-  - describe_repo:  one-shot bootstrap → managed section in CLAUDE.md
-  - record_history: append-only intent/action/outcome log → history.md
-  - read_history:   recent + lazy semantic recall over the log
+  - describe_repo:   one-shot bootstrap → managed section in CLAUDE.md
+  - log_interaction: append-only intent/action/outcome log → history.md
+  - read_history:    recent + lazy semantic recall over the log
 """

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -35,7 +35,8 @@ DESCRIBE_MARKER_END = "# <<< Agents-Core Repository Memory (managed by describe_
 # --- Tunables ----------------------------------------------------------------
 
 # Rotation threshold for history.md before it is moved to history/YYYY-MM.md.
-HISTORY_ROTATION_THRESHOLD_KB = 512
+# Override via env for testing: HISTORY_ROTATION_THRESHOLD_KB=1
+HISTORY_ROTATION_THRESHOLD_KB = int(os.environ.get("HISTORY_ROTATION_THRESHOLD_KB", "512"))
 
 # Tail-scan window for content-hash deduplication on append.
 HISTORY_DEDUP_TAIL_SIZE = 50

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -14,7 +14,7 @@ from src.engine.config import DATA_DIR, REPO_ROOT
 # git-ignored data root as the routing/skills/implants stores.
 MEMORY_DATA_DIR = os.path.join(DATA_DIR, "memory")
 
-# Repo-root markdown artifacts (committed to git by default — see .gitignore).
+# Repo-root markdown artifacts (git-ignored by default — see .gitignore).
 HISTORY_FILE = os.path.join(REPO_ROOT, "history.md")
 HISTORY_ARCHIVE_DIR = os.path.join(REPO_ROOT, "history")
 CLAUDE_MD_FILE = os.path.join(REPO_ROOT, "CLAUDE.md")

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -1,0 +1,72 @@
+"""Constants for the repository memory subsystem.
+
+All paths are derived from REPO_ROOT / DATA_DIR exposed by the engine config,
+so the memory tools pick up overrides made elsewhere automatically.
+"""
+
+import os
+
+from src.engine.config import DATA_DIR, REPO_ROOT
+
+# --- Filesystem layout -------------------------------------------------------
+
+# Vector store + hash file live under data/memory so they share the same
+# git-ignored data root as the routing/skills/implants stores.
+MEMORY_DATA_DIR = os.path.join(DATA_DIR, "memory")
+
+# Repo-root markdown artifacts (committed to git by default — see .gitignore).
+HISTORY_FILE = os.path.join(REPO_ROOT, "history.md")
+HISTORY_ARCHIVE_DIR = os.path.join(REPO_ROOT, "history")
+CLAUDE_MD_FILE = os.path.join(REPO_ROOT, "CLAUDE.md")
+
+# Hash file used by RepoDescriber to skip work when the repo hasn't changed.
+DESCRIBE_HASH_FILE = os.path.join(MEMORY_DATA_DIR, ".describe_hash")
+
+# Vector store for lazy semantic recall over history entries.
+HISTORY_VECTOR_STORE_NAME = "history_store"
+
+# --- Managed section markers (CLAUDE.md) -------------------------------------
+
+# Kept distinct from the Routing-Protocol markers managed by init_repo.sh
+# so the two managed sections never collide.
+DESCRIBE_MARKER_BEGIN = "# >>> Agents-Core Repository Memory (managed by describe_repo) >>>"
+DESCRIBE_MARKER_END = "# <<< Agents-Core Repository Memory (managed by describe_repo) <<<"
+
+# --- Tunables ----------------------------------------------------------------
+
+# Rotation threshold for history.md before it is moved to history/YYYY-MM.md.
+HISTORY_ROTATION_THRESHOLD_KB = 512
+
+# Tail-scan window for content-hash deduplication on append.
+HISTORY_DEDUP_TAIL_SIZE = 50
+
+# Schema version stamped into the history.md frontmatter.
+HISTORY_FORMAT_VERSION = 1
+
+# Acceptable describe-summary word count window — enforced by tests, surfaced
+# in the response so callers can detect drift.
+DESCRIBE_WORD_MIN = 800
+DESCRIBE_WORD_MAX = 1500
+
+# Directory tree depth used to build the describe context bundle.
+DESCRIBE_TREE_MAX_DEPTH = 3
+
+# Top of README sampled into the describe context bundle.
+DESCRIBE_README_HEAD_LINES = 200
+
+# Directories excluded from the describe tree walk and the repo hash.
+DESCRIBE_EXCLUDED_DIRS = frozenset({
+    ".git",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "node_modules",
+    "data",
+    "logs",
+    "dist",
+    "build",
+    ".obsidian",
+    ".idea",
+    ".vscode",
+    "history",  # archived history files — describe doesn't care
+})

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -331,12 +331,14 @@ class RepoDescriber:
         repo_name = os.path.basename(self.repo_path) or self.repo_path
         # Use str.replace instead of str.format — the bundle contains raw file
         # contents (JSON, TOML) with curly braces that would crash .format().
+        # Replace simple placeholders first, then CONTEXT_BUNDLE last so any
+        # literal "{WORD_MIN}" / "{WORD_MAX}" in file contents isn't corrupted.
         return (
             DESCRIBE_PROMPT_TEMPLATE
             .replace("{REPO_NAME}", repo_name)
-            .replace("{CONTEXT_BUNDLE}", bundle)
             .replace("{WORD_MIN}", str(DESCRIBE_WORD_MIN))
             .replace("{WORD_MAX}", str(DESCRIBE_WORD_MAX))
+            .replace("{CONTEXT_BUNDLE}", bundle)
         )
 
     # ----------------------------------------------------------------- write

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -423,7 +423,7 @@ class RepoDescriber:
 
     def _save_hash(self, digest: str) -> None:
         os.makedirs(os.path.dirname(self.hash_file) or ".", exist_ok=True)
-        managed_section._atomic_write(self.hash_file, digest)
+        managed_section.atomic_write(self.hash_file, digest)
 
     # ----------------------------------------------------------------- helpers exposed for the MCP tool
     @staticmethod

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -1,0 +1,447 @@
+"""One-shot repository bootstrap: build a context bundle, ask the calling LLM
+to summarize it via MCP sampling, and persist the summary into the managed
+Repository Memory section of CLAUDE.md.
+
+The describer never calls an LLM directly. It builds the prompt, the caller
+performs ``ctx.session.create_message(...)`` (mirroring the pattern in
+``src/server.py:196``), and the result is fed back into ``write_summary``.
+This split keeps the module unit-testable without an MCP context.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from src.engine.config import REPO_ROOT
+from src.memory import managed_section
+from src.memory.config import (
+    CLAUDE_MD_FILE,
+    DESCRIBE_EXCLUDED_DIRS,
+    DESCRIBE_HASH_FILE,
+    DESCRIBE_MARKER_BEGIN,
+    DESCRIBE_MARKER_END,
+    DESCRIBE_README_HEAD_LINES,
+    DESCRIBE_TREE_MAX_DEPTH,
+    DESCRIBE_WORD_MAX,
+    DESCRIBE_WORD_MIN,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Files we always sample into the context bundle if present at the repo root.
+_KEY_MANIFEST_FILES = (
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "requirements.txt",
+    "Pipfile",
+    "Gemfile",
+    "composer.json",
+)
+
+# Files written *by* the memory subsystem itself — must not feed into the hash
+# or each refresh would invalidate its own cache.
+_HASH_EXCLUDED_FILES = frozenset({
+    "CLAUDE.md",
+    "history.md",
+    ".describe_hash",
+})
+
+
+DESCRIBE_PROMPT_TEMPLATE = """\
+You are a **Repository Analyst** performing a one-time deep study of a codebase.
+Your output will be saved into CLAUDE.md as the project memory and read by every
+future Claude session, so future sessions can work effectively without re-exploring
+the codebase.
+
+## Task
+Produce a compressed, LLM-consumable repository overview for `{REPO_NAME}`.
+
+## Input (CONTEXT_BUNDLE)
+{CONTEXT_BUNDLE}
+
+## Output Format
+Produce exactly these sections in this order. Use compressed markdown
+(BLUF, atomic paragraphs, no filler).
+
+### Project Identity
+One paragraph: name, purpose, primary language, framework, package manager.
+
+### Tech Stack
+Bulleted list of key dependencies with version and purpose. Max 15 items.
+
+### Entry Points
+Table: path | purpose. Include: main, tests, config, CI/CD, scripts.
+
+### Module Map
+Depth-2 directory listing. One line per directory: `path/ — purpose`.
+Skip generated/vendor dirs.
+
+### Conventions
+Bulleted list: naming, imports, error handling, logging, frontmatter format,
+code style.
+
+### Key Workflows
+For each script / Make target / npm script: `name — what it does`. Max 10.
+
+### Architecture Patterns
+2–3 paragraphs: data flow, key abstractions, dependency injection style,
+async patterns.
+
+### Test Strategy
+Runner, fixture patterns, mock strategy, coverage config. One paragraph.
+
+### Gotchas
+Bulleted list of non-obvious things: env vars needed, startup order,
+known limitations, common mistakes.
+
+### Glossary
+Table: term | definition. Domain-specific terms only. Max 15.
+
+## Rules
+- BLUF: lead every section with the most important fact.
+- Compress: no filler ("this project is", "in order to", "it is worth noting").
+- Atomic: one paragraph = one idea.
+- Concrete: cite file paths and line numbers, not vague references.
+- Skip empty sections rather than writing "N/A".
+- Total output: {WORD_MIN}–{WORD_MAX} words. Exceeding wastes context; under-shooting loses info.
+- Output ONLY the markdown sections above. No preamble, no closing remarks.
+"""
+
+
+@dataclass
+class DescribeDecision:
+    """Outcome of ``RepoDescriber.plan()``."""
+    needs_refresh: bool
+    current_hash: str
+    cached_hash: Optional[str]
+    cached_summary: Optional[str]
+
+
+class RepoDescriber:
+    """Build the describe prompt, write the resulting summary back to CLAUDE.md.
+
+    Splitting the work into ``plan()`` / ``build_prompt()`` / ``write_summary()``
+    keeps the LLM-facing call (``ctx.session.create_message``) outside the class
+    so unit tests don't need to fake an MCP context.
+    """
+
+    def __init__(
+        self,
+        repo_path: Optional[str] = None,
+        claude_md_path: Optional[str] = None,
+        hash_file: Optional[str] = None,
+    ):
+        self.repo_path = os.path.abspath(repo_path) if repo_path else REPO_ROOT
+        # When the caller overrides repo_path, default the CLAUDE.md and hash
+        # file to live inside that repo unless explicit paths are given —
+        # otherwise tests would clobber the real CLAUDE.md.
+        if claude_md_path is not None:
+            self.claude_md_path = claude_md_path
+        elif repo_path:
+            self.claude_md_path = os.path.join(self.repo_path, "CLAUDE.md")
+        else:
+            self.claude_md_path = CLAUDE_MD_FILE
+
+        if hash_file is not None:
+            self.hash_file = hash_file
+        elif repo_path:
+            self.hash_file = os.path.join(
+                self.repo_path, "data", "memory", ".describe_hash"
+            )
+        else:
+            self.hash_file = DESCRIBE_HASH_FILE
+
+    # ------------------------------------------------------------------ hash
+    def compute_repo_hash(self) -> str:
+        """Stable hash that changes whenever a *meaningful* repo property
+        changes: top-level files, depth-1/2 directory names, manifest contents,
+        and the head of README.md.
+
+        Patterned after ``SkillRetriever._compute_dir_hash`` in
+        ``src/engine/skills.py:32``.
+        """
+        h = hashlib.md5()
+        repo = Path(self.repo_path)
+
+        # Top-level filenames (sorted for determinism).
+        try:
+            top_names = sorted(p.name for p in repo.iterdir())
+        except FileNotFoundError:
+            return h.hexdigest()
+        for name in top_names:
+            if name in DESCRIBE_EXCLUDED_DIRS or name in _HASH_EXCLUDED_FILES:
+                continue
+            h.update(name.encode("utf-8"))
+
+        # Depth-1 + depth-2 directory names.
+        for depth in (1, 2):
+            for d in sorted(self._iter_dirs_at_depth(repo, depth)):
+                h.update(d.encode("utf-8"))
+
+        # Manifest contents.
+        for manifest in _KEY_MANIFEST_FILES:
+            mpath = repo / manifest
+            if mpath.is_file():
+                try:
+                    h.update(mpath.read_bytes())
+                except OSError:
+                    continue
+
+        # Head of README.md (if present).
+        readme = repo / "README.md"
+        if readme.is_file():
+            try:
+                with readme.open("r", encoding="utf-8", errors="replace") as f:
+                    head = "".join(f.readline() for _ in range(DESCRIBE_README_HEAD_LINES))
+                h.update(head.encode("utf-8"))
+            except OSError:
+                pass
+
+        return h.hexdigest()
+
+    def _iter_dirs_at_depth(self, root: Path, depth: int) -> Iterable[str]:
+        """Yield directory paths *exactly* ``depth`` levels below ``root``.
+
+        Excludes directories listed in ``DESCRIBE_EXCLUDED_DIRS``. Uses a
+        pruning ``os.walk`` so vendored trees (``.git``, ``node_modules``,
+        ``data``) are never descended into.
+        """
+        if depth < 1:
+            return
+        root_str = str(root)
+        for current, dirs, _files in os.walk(root_str):
+            # Prune in-place so os.walk skips excluded subtrees entirely.
+            dirs[:] = sorted(d for d in dirs if d not in DESCRIBE_EXCLUDED_DIRS)
+            rel = os.path.relpath(current, root_str)
+            if rel == ".":
+                # Root itself — emit its depth-1 children on the next iteration.
+                continue
+            parts = rel.split(os.sep)
+            if len(parts) == depth:
+                yield "/".join(parts)
+
+    # ------------------------------------------------------------------ plan
+    def plan(self, force_refresh: bool = False) -> DescribeDecision:
+        current = self.compute_repo_hash()
+        cached_hash = self._read_cached_hash()
+        cached_summary = managed_section.read_section(
+            self.claude_md_path, DESCRIBE_MARKER_BEGIN, DESCRIBE_MARKER_END
+        )
+        # Refresh if forced, hash changed, or the managed section is missing
+        # despite a stored hash (someone hand-deleted it).
+        needs = (
+            force_refresh
+            or cached_hash != current
+            or cached_summary is None
+        )
+        return DescribeDecision(
+            needs_refresh=needs,
+            current_hash=current,
+            cached_hash=cached_hash,
+            cached_summary=cached_summary,
+        )
+
+    # ----------------------------------------------------------------- prompt
+    def build_context_bundle(self) -> str:
+        """Render the deterministic ``{CONTEXT_BUNDLE}`` block."""
+        repo = Path(self.repo_path)
+        sections: list[str] = []
+
+        # Tree (depth ≤ DESCRIBE_TREE_MAX_DEPTH)
+        sections.append("### Directory Tree (depth ≤ %d)" % DESCRIBE_TREE_MAX_DEPTH)
+        sections.append("```\n" + self._render_tree(repo) + "```")
+
+        # Manifests
+        for manifest in _KEY_MANIFEST_FILES:
+            mpath = repo / manifest
+            if mpath.is_file():
+                sections.append(f"### {manifest}")
+                try:
+                    text = mpath.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                sections.append("```\n" + text.strip() + "\n```")
+
+        # README head
+        readme = repo / "README.md"
+        if readme.is_file():
+            try:
+                with readme.open("r", encoding="utf-8", errors="replace") as f:
+                    head = "".join(f.readline() for _ in range(DESCRIBE_README_HEAD_LINES))
+                sections.append("### README.md (head)")
+                sections.append("```\n" + head.rstrip() + "\n```")
+            except OSError:
+                pass
+
+        return "\n\n".join(sections)
+
+    def _render_tree(self, root: Path) -> str:
+        """Indented directory listing, depth-bounded, vendor-pruned."""
+        lines: list[str] = []
+        max_depth = DESCRIBE_TREE_MAX_DEPTH
+
+        def walk(path: Path, depth: int) -> None:
+            if depth > max_depth:
+                return
+            try:
+                children = sorted(path.iterdir(), key=lambda p: (not p.is_dir(), p.name))
+            except (PermissionError, OSError):
+                return
+            for child in children:
+                if child.name in DESCRIBE_EXCLUDED_DIRS:
+                    continue
+                if child.name.startswith(".") and child.name not in (".env.example",):
+                    continue
+                indent = "  " * (depth - 1)
+                marker = "/" if child.is_dir() else ""
+                lines.append(f"{indent}{child.name}{marker}")
+                if child.is_dir():
+                    walk(child, depth + 1)
+
+        walk(root, 1)
+        return "\n".join(lines) + "\n"
+
+    def build_prompt(self) -> str:
+        bundle = self.build_context_bundle()
+        repo_name = os.path.basename(self.repo_path) or self.repo_path
+        return DESCRIBE_PROMPT_TEMPLATE.format(
+            REPO_NAME=repo_name,
+            CONTEXT_BUNDLE=bundle,
+            WORD_MIN=DESCRIBE_WORD_MIN,
+            WORD_MAX=DESCRIBE_WORD_MAX,
+        )
+
+    # ----------------------------------------------------------------- write
+    # Minimum usable summary length — below this we refuse to persist so a
+    # bad sampling response (empty string, refusal, truncation) cannot wipe
+    # out a good cached summary.
+    MIN_PERSIST_WORD_COUNT = 200
+    # Minimum structural marker — a valid summary has at least one ``##`` or
+    # ``###`` heading from the template (Project Identity, Tech Stack, ...).
+    _HEADING_MARKER = "## "
+
+    def write_summary(self, summary: str, repo_hash: str) -> dict:
+        """Persist a finished summary to CLAUDE.md and update the hash file.
+
+        Refuses to persist summaries shorter than ``MIN_PERSIST_WORD_COUNT``
+        words or lacking any ``##`` headings — such outputs usually indicate
+        a failed or refused sampling call and overwriting a good cached
+        summary with them would be worse than leaving the old one in place.
+
+        Returns a JSON-friendly dict with status, path, hash, word_count,
+        and a short preview of the stored summary.
+        """
+        word_count = len(summary.split())
+        has_heading = self._HEADING_MARKER in summary
+
+        if word_count < self.MIN_PERSIST_WORD_COUNT or not has_heading:
+            return {
+                "status": "rejected",
+                "reason": (
+                    f"sampled summary failed sanity check "
+                    f"(word_count={word_count}, has_heading={has_heading}); "
+                    f"refusing to overwrite CLAUDE.md"
+                ),
+                "word_count": word_count,
+                "has_heading": has_heading,
+                "summary_preview": "\n".join(summary.splitlines()[:6]),
+            }
+
+        repo_name = os.path.basename(self.repo_path) or self.repo_path
+        timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+        wrapped = self._wrap_summary(summary, repo_name, timestamp, repo_hash)
+
+        action = managed_section.upsert_section(
+            self.claude_md_path,
+            DESCRIBE_MARKER_BEGIN,
+            DESCRIBE_MARKER_END,
+            wrapped,
+        )
+        self._save_hash(repo_hash)
+
+        preview = "\n".join(summary.splitlines()[:6])
+
+        return {
+            "status": "refreshed",
+            "action": action,
+            "path": self.claude_md_path,
+            "hash": repo_hash,
+            "word_count": word_count,
+            "in_word_budget": DESCRIBE_WORD_MIN <= word_count <= DESCRIBE_WORD_MAX,
+            "summary_preview": preview,
+        }
+
+    @staticmethod
+    def _wrap_summary(summary: str, repo_name: str, timestamp: str, repo_hash: str) -> str:
+        header = (
+            f"# Repository: {repo_name}\n"
+            f"> Auto-generated by `describe_repo` on {timestamp}. Hash: {repo_hash[:8]}.\n"
+            f"> Re-run with `describe_repo(force_refresh=True)` to update.\n"
+        )
+        return header + "\n" + summary.strip("\n") + "\n"
+
+    # ----------------------------------------------------------------- helpers
+    def _read_cached_hash(self) -> Optional[str]:
+        try:
+            with open(self.hash_file, "r", encoding="utf-8") as f:
+                value = f.read().strip()
+                return value or None
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
+
+    def _save_hash(self, digest: str) -> None:
+        os.makedirs(os.path.dirname(self.hash_file), exist_ok=True)
+        # Atomic write — same pattern as managed_section
+        target_dir = os.path.dirname(self.hash_file)
+        fd, tmp = tempfile.mkstemp(dir=target_dir, prefix=".describe_hash.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(digest)
+            os.replace(tmp, self.hash_file)
+        except Exception:
+            if os.path.exists(tmp):
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+            raise
+
+    # ----------------------------------------------------------------- helpers exposed for the MCP tool
+    def up_to_date_response(self, decision: DescribeDecision) -> dict:
+        preview = ""
+        if decision.cached_summary:
+            preview = "\n".join(decision.cached_summary.splitlines()[:6])
+        return {
+            "status": "up-to-date",
+            "path": self.claude_md_path,
+            "hash": decision.current_hash,
+            "summary_preview": preview,
+        }
+
+
+__all__ = [
+    "DESCRIBE_PROMPT_TEMPLATE",
+    "DescribeDecision",
+    "RepoDescriber",
+]
+
+
+# Kept for callers that want a one-line dict serialization.
+def to_json(payload: dict) -> str:
+    return json.dumps(payload, ensure_ascii=False)

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -329,11 +329,14 @@ class RepoDescriber:
     def build_prompt(self) -> str:
         bundle = self.build_context_bundle()
         repo_name = os.path.basename(self.repo_path) or self.repo_path
-        return DESCRIBE_PROMPT_TEMPLATE.format(
-            REPO_NAME=repo_name,
-            CONTEXT_BUNDLE=bundle,
-            WORD_MIN=DESCRIBE_WORD_MIN,
-            WORD_MAX=DESCRIBE_WORD_MAX,
+        # Use str.replace instead of str.format — the bundle contains raw file
+        # contents (JSON, TOML) with curly braces that would crash .format().
+        return (
+            DESCRIBE_PROMPT_TEMPLATE
+            .replace("{REPO_NAME}", repo_name)
+            .replace("{CONTEXT_BUNDLE}", bundle)
+            .replace("{WORD_MIN}", str(DESCRIBE_WORD_MIN))
+            .replace("{WORD_MAX}", str(DESCRIBE_WORD_MAX))
         )
 
     # ----------------------------------------------------------------- write

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -317,7 +317,7 @@ class RepoDescriber:
                 indent = "  " * (depth - 1)
                 marker = "/" if child.is_dir() else ""
                 lines.append(f"{indent}{child.name}{marker}")
-                if child.is_dir():
+                if child.is_dir() and not child.is_symlink():
                     walk(child, depth + 1)
 
         walk(root, 1)

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -435,10 +435,18 @@ class RepoDescriber:
             raise
 
     # ----------------------------------------------------------------- helpers exposed for the MCP tool
+    @staticmethod
+    def _strip_wrapper_header(text: str) -> str:
+        """Remove the _wrap_summary header so word count matches write_summary."""
+        # Header and body are separated by a blank line.
+        parts = text.split("\n\n", 1)
+        return parts[1] if len(parts) > 1 else text
+
     def up_to_date_response(self, decision: DescribeDecision) -> dict:
         cached = decision.cached_summary or ""
-        preview = "\n".join(cached.splitlines()[:6])
-        word_count = len(cached.split())
+        raw = self._strip_wrapper_header(cached)
+        preview = "\n".join(raw.splitlines()[:6])
+        word_count = len(raw.split())
         return {
             "status": "up-to-date",
             "path": self.claude_md_path,

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -224,7 +224,12 @@ class RepoDescriber:
         root_str = str(root)
         for current, dirs, _files in os.walk(root_str):
             # Prune in-place so os.walk skips excluded subtrees entirely.
-            dirs[:] = sorted(d for d in dirs if d not in DESCRIBE_EXCLUDED_DIRS)
+            # Also skip hidden dirs (matching _render_tree's dotfile filter)
+            # so the hash and context bundle agree on which dirs matter.
+            dirs[:] = sorted(
+                d for d in dirs
+                if d not in DESCRIBE_EXCLUDED_DIRS and not d.startswith(".")
+            )
             rel = os.path.relpath(current, root_str)
             if rel == ".":
                 # Root itself — emit its depth-1 children on the next iteration.

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import datetime as _dt
 import hashlib
-import json
 import logging
 import os
 import tempfile
@@ -233,6 +232,10 @@ class RepoDescriber:
             parts = rel.split(os.sep)
             if len(parts) == depth:
                 yield "/".join(parts)
+                # No need to descend further — prune children.
+                dirs[:] = []
+            elif len(parts) > depth:
+                dirs[:] = []
 
     # ------------------------------------------------------------------ plan
     def plan(self, force_refresh: bool = False) -> DescribeDecision:
@@ -332,21 +335,22 @@ class RepoDescriber:
     MIN_PERSIST_WORD_COUNT = 200
     # Minimum structural marker — a valid summary has at least one ``##`` or
     # ``###`` heading from the template (Project Identity, Tech Stack, ...).
-    _HEADING_MARKER = "## "
+    _HEADING_MARKERS = ("## ", "### ")
 
     def write_summary(self, summary: str, repo_hash: str) -> dict:
         """Persist a finished summary to CLAUDE.md and update the hash file.
 
         Refuses to persist summaries shorter than ``MIN_PERSIST_WORD_COUNT``
-        words or lacking any ``##`` headings — such outputs usually indicate
-        a failed or refused sampling call and overwriting a good cached
-        summary with them would be worse than leaving the old one in place.
+        words or lacking any Markdown section headings (``##`` or ``###``) —
+        such outputs usually indicate a failed or refused sampling call and
+        overwriting a good cached summary with them would be worse than
+        leaving the old one in place.
 
         Returns a JSON-friendly dict with status, path, hash, word_count,
         and a short preview of the stored summary.
         """
         word_count = len(summary.split())
-        has_heading = self._HEADING_MARKER in summary
+        has_heading = any(m in summary for m in self._HEADING_MARKERS)
 
         if word_count < self.MIN_PERSIST_WORD_COUNT or not has_heading:
             return {
@@ -440,8 +444,3 @@ __all__ = [
     "DescribeDecision",
     "RepoDescriber",
 ]
-
-
-# Kept for callers that want a one-line dict serialization.
-def to_json(payload: dict) -> str:
-    return json.dumps(payload, ensure_ascii=False)

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -184,6 +184,9 @@ class RepoDescriber:
         for name in top_names:
             if name in DESCRIBE_EXCLUDED_DIRS or name in _HASH_EXCLUDED_FILES:
                 continue
+            # Skip hidden files/dirs to match _render_tree's dotfile filter.
+            if name.startswith(".") and name not in (".env.example",):
+                continue
             h.update(name.encode("utf-8"))
 
         # Depth-1 + depth-2 directory names.
@@ -433,13 +436,15 @@ class RepoDescriber:
 
     # ----------------------------------------------------------------- helpers exposed for the MCP tool
     def up_to_date_response(self, decision: DescribeDecision) -> dict:
-        preview = ""
-        if decision.cached_summary:
-            preview = "\n".join(decision.cached_summary.splitlines()[:6])
+        cached = decision.cached_summary or ""
+        preview = "\n".join(cached.splitlines()[:6])
+        word_count = len(cached.split())
         return {
             "status": "up-to-date",
             "path": self.claude_md_path,
             "hash": decision.current_hash,
+            "word_count": word_count,
+            "in_word_budget": DESCRIBE_WORD_MIN <= word_count <= DESCRIBE_WORD_MAX,
             "summary_preview": preview,
         }
 

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -14,7 +14,6 @@ import datetime as _dt
 import hashlib
 import logging
 import os
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
@@ -423,21 +422,8 @@ class RepoDescriber:
             return None
 
     def _save_hash(self, digest: str) -> None:
-        target_dir = os.path.dirname(self.hash_file) or "."
-        os.makedirs(target_dir, exist_ok=True)
-        # Atomic write — same pattern as managed_section
-        fd, tmp = tempfile.mkstemp(dir=target_dir, prefix=".describe_hash.", suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(digest)
-            os.replace(tmp, self.hash_file)
-        except Exception:
-            if os.path.exists(tmp):
-                try:
-                    os.unlink(tmp)
-                except OSError:
-                    pass
-            raise
+        os.makedirs(os.path.dirname(self.hash_file) or ".", exist_ok=True)
+        managed_section._atomic_write(self.hash_file, digest)
 
     # ----------------------------------------------------------------- helpers exposed for the MCP tool
     @staticmethod

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -193,18 +193,18 @@ class RepoDescriber:
             for d in sorted(self._iter_dirs_at_depth(repo, depth)):
                 h.update(d.encode("utf-8"))
 
-        # Manifest contents.
+        # Manifest contents (skip symlinks to stay within the sandbox).
         for manifest in _KEY_MANIFEST_FILES:
             mpath = repo / manifest
-            if mpath.is_file():
+            if mpath.is_file() and not mpath.is_symlink():
                 try:
                     h.update(mpath.read_bytes())
                 except OSError:
                     continue
 
-        # Head of README.md (if present).
+        # Head of README.md (if present, skip if symlinked).
         readme = repo / "README.md"
-        if readme.is_file():
+        if readme.is_file() and not readme.is_symlink():
             try:
                 with readme.open("r", encoding="utf-8", errors="replace") as f:
                     head = "".join(f.readline() for _ in range(DESCRIBE_README_HEAD_LINES))
@@ -275,10 +275,10 @@ class RepoDescriber:
         sections.append("### Directory Tree (depth ≤ %d)" % DESCRIBE_TREE_MAX_DEPTH)
         sections.append("```\n" + self._render_tree(repo) + "```")
 
-        # Manifests
+        # Manifests (skip symlinks to stay within the sandbox)
         for manifest in _KEY_MANIFEST_FILES:
             mpath = repo / manifest
-            if mpath.is_file():
+            if mpath.is_file() and not mpath.is_symlink():
                 sections.append(f"### {manifest}")
                 try:
                     text = mpath.read_text(encoding="utf-8", errors="replace")
@@ -286,9 +286,9 @@ class RepoDescriber:
                     continue
                 sections.append("```\n" + text.strip() + "\n```")
 
-        # README head
+        # README head (skip if symlinked)
         readme = repo / "README.md"
-        if readme.is_file():
+        if readme.is_file() and not readme.is_symlink():
             try:
                 with readme.open("r", encoding="utf-8", errors="replace") as f:
                     head = "".join(f.readline() for _ in range(DESCRIBE_README_HEAD_LINES))

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -410,9 +410,9 @@ class RepoDescriber:
             return None
 
     def _save_hash(self, digest: str) -> None:
-        os.makedirs(os.path.dirname(self.hash_file), exist_ok=True)
+        target_dir = os.path.dirname(self.hash_file) or "."
+        os.makedirs(target_dir, exist_ok=True)
         # Atomic write — same pattern as managed_section
-        target_dir = os.path.dirname(self.hash_file)
         fd, tmp = tempfile.mkstemp(dir=target_dir, prefix=".describe_hash.", suffix=".tmp")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -25,7 +25,6 @@ import logging
 import os
 import re
 import shutil
-import tempfile
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -310,6 +309,7 @@ class HistoryReader:
         since: Optional[str] = None,
     ) -> List[HistoryEntry]:
         """Newest-first list, optionally filtered by ``since`` (ISO timestamp prefix)."""
+        limit = max(1, limit) if limit > 0 else 20
         entries = self.read_all()
         entries.sort(key=lambda e: e.timestamp, reverse=True)
         if since:

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -204,12 +204,17 @@ class HistoryWriter:
         tags: Optional[List[str]],
         metadata: Optional[Dict[str, Any]],
     ) -> str:
+        # Collapse newlines to spaces so multi-line raw query/response
+        # doesn't break the single-line **Field:** format that the parser expects.
+        def _oneline(s: str) -> str:
+            return " ".join(s.split())
+
         lines = [
             "",  # blank separator before the heading
             f"## {timestamp} | {entry_id}",
-            f"**Intent:** {intent}",
-            f"**Action:** {action}",
-            f"**Outcome:** {outcome}",
+            f"**Intent:** {_oneline(intent)}",
+            f"**Action:** {_oneline(action)}",
+            f"**Outcome:** {_oneline(outcome)}",
         ]
         if files:
             lines.append(f"**Files:** {', '.join(files)}")

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -1,0 +1,497 @@
+"""Append-only intent/action/outcome history with optional semantic recall.
+
+Three classes:
+
+* ``HistoryWriter`` — stdlib-only. Writes deduplicated, content-hashed entries
+  to ``history.md`` under an exclusive file lock. Rotates to
+  ``history/YYYY-MM.md`` when the file grows past
+  ``HISTORY_ROTATION_THRESHOLD_KB``.
+
+* ``HistoryReader`` — stdlib-only. Parses entries from disk and serves
+  recency / ``since`` queries.
+
+* ``HistoryStore`` — lazy ``NumpyVectorStore`` wrapper. Built only on the
+  first ``read_history(query=...)`` call; rebuilds when the markdown file
+  is newer than the persisted store. The embedder is imported lazily so
+  ``HistoryWriter``/``HistoryReader`` users never pay the numpy cost.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+from src.memory.config import (
+    HISTORY_ARCHIVE_DIR,
+    HISTORY_DEDUP_TAIL_SIZE,
+    HISTORY_FILE,
+    HISTORY_FORMAT_VERSION,
+    HISTORY_ROTATION_THRESHOLD_KB,
+    HISTORY_VECTOR_STORE_NAME,
+    MEMORY_DATA_DIR,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Cross-platform file lock — fcntl on POSIX, no-op shim on Windows where the
+# MCP server does not support concurrent stdio sessions anyway.
+try:  # pragma: no cover - exercised via integration only
+    import fcntl as _fcntl
+
+    def _lock_exclusive(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX)
+
+    def _unlock(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+
+except ImportError:  # pragma: no cover - Windows
+    def _lock_exclusive(fh) -> None:
+        return None
+
+    def _unlock(fh) -> None:
+        return None
+
+
+_HEADER_RE = re.compile(
+    r"^##\s+(?P<ts>\S+)\s+\|\s+(?P<id>[0-9a-f]{12})\s*$",
+    re.MULTILINE,
+)
+_FIELD_RE = re.compile(r"^\*\*(?P<name>[A-Za-z]+):\*\*\s*(?P<value>.*)$")
+
+
+@dataclass
+class HistoryEntry:
+    """In-memory representation of a single history entry."""
+    id: str
+    timestamp: str
+    intent: str
+    action: str
+    outcome: str
+    files: List[str] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# --- Writer ------------------------------------------------------------------
+
+class HistoryWriter:
+    """Append-only writer for ``history.md``."""
+
+    def __init__(
+        self,
+        history_path: Optional[str] = None,
+        archive_dir: Optional[str] = None,
+        rotation_kb: int = HISTORY_ROTATION_THRESHOLD_KB,
+        dedup_tail: int = HISTORY_DEDUP_TAIL_SIZE,
+    ):
+        self.history_path = history_path or HISTORY_FILE
+        self.archive_dir = archive_dir or HISTORY_ARCHIVE_DIR
+        self.rotation_kb = rotation_kb
+        self.dedup_tail = dedup_tail
+
+    # ------------------------------------------------------------------ public
+    def append_entry(
+        self,
+        intent: str,
+        action: str,
+        outcome: str,
+        files: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Append a single entry; returns a JSON-friendly status dict."""
+        intent = (intent or "").strip()
+        action = (action or "").strip()
+        outcome = (outcome or "").strip()
+        if not (intent and action and outcome):
+            return {
+                "status": "error",
+                "message": "intent, action, and outcome are all required",
+            }
+
+        entry_id = self._compute_entry_hash(intent, action, outcome)
+
+        os.makedirs(os.path.dirname(self.history_path) or ".", exist_ok=True)
+
+        # Open in append+read mode so we can scan the tail under the lock.
+        # Every write + header + dedup + rotation happens INSIDE the lock so
+        # concurrent writers (cross-process: e.g. Claude Desktop + VS Code
+        # attached to the same repo) cannot interleave and corrupt the file.
+        rotated_to: Optional[str] = None
+        with open(self.history_path, "a+", encoding="utf-8") as fh:
+            try:
+                _lock_exclusive(fh)
+
+                # Re-check size under the lock — a concurrent writer may have
+                # created the file between our os.makedirs and open().
+                fh.seek(0, os.SEEK_END)
+                if fh.tell() == 0:
+                    fh.write(self._render_header())
+                    fh.flush()
+
+                if self._is_duplicate(entry_id):
+                    return {
+                        "status": "duplicate",
+                        "entry_id": entry_id,
+                        "path": self.history_path,
+                    }
+
+                timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+                block = self._render_entry(
+                    entry_id, timestamp, intent, action, outcome, files, tags, metadata
+                )
+                fh.write(block)
+                fh.flush()
+                os.fsync(fh.fileno())
+
+                # Rotate inside the lock — if we cross the threshold mid-write,
+                # the move/merge must not race a second writer.
+                rotated_to = self._maybe_rotate_locked()
+            finally:
+                _unlock(fh)
+
+        result: Dict[str, Any] = {
+            "status": "recorded",
+            "entry_id": entry_id,
+            "path": self.history_path,
+            "timestamp": timestamp,
+        }
+        if rotated_to:
+            result["rotated_to"] = rotated_to
+        return result
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _compute_entry_hash(intent: str, action: str, outcome: str) -> str:
+        h = hashlib.sha256()
+        h.update(intent.encode("utf-8"))
+        h.update(b"\x1f")
+        h.update(action.encode("utf-8"))
+        h.update(b"\x1f")
+        h.update(outcome.encode("utf-8"))
+        return h.hexdigest()[:12]
+
+    def _render_header(self) -> str:
+        repo_name = os.path.basename(os.path.dirname(os.path.abspath(self.history_path))) or "repo"
+        timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+        return (
+            "---\n"
+            f"repo: {repo_name}\n"
+            f"created: {timestamp}\n"
+            f"format_version: {HISTORY_FORMAT_VERSION}\n"
+            "---\n"
+        )
+
+    @staticmethod
+    def _render_entry(
+        entry_id: str,
+        timestamp: str,
+        intent: str,
+        action: str,
+        outcome: str,
+        files: Optional[List[str]],
+        tags: Optional[List[str]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> str:
+        lines = [
+            "",  # blank separator before the heading
+            f"## {timestamp} | {entry_id}",
+            f"**Intent:** {intent}",
+            f"**Action:** {action}",
+            f"**Outcome:** {outcome}",
+        ]
+        if files:
+            lines.append(f"**Files:** {', '.join(files)}")
+        if tags:
+            normalized = [t if t.startswith("#") else f"#{t}" for t in tags]
+            lines.append(f"**Tags:** {' '.join(normalized)}")
+        if metadata:
+            lines.append(f"**Meta:** {json.dumps(metadata, ensure_ascii=False, sort_keys=True)}")
+        lines.append("")  # trailing newline
+        return "\n".join(lines) + "\n"
+
+    def _is_duplicate(self, entry_id: str) -> bool:
+        """Tail-scan the last ``self.dedup_tail`` entry IDs."""
+        try:
+            with open(self.history_path, "r", encoding="utf-8") as fh:
+                content = fh.read()
+        except FileNotFoundError:
+            return False
+        ids = _HEADER_RE.findall(content)
+        recent = [match[1] for match in ids[-self.dedup_tail:]]
+        return entry_id in recent
+
+    def _maybe_rotate_locked(self) -> Optional[str]:
+        """Move ``history.md`` to ``history/YYYY-MM.md`` if it is too large.
+
+        MUST be called while the caller still holds the exclusive lock on
+        ``history.md`` — otherwise concurrent writers could race with the
+        move/merge step.
+
+        Returns the archive path if rotation happened, else ``None``.
+        """
+        if not os.path.exists(self.history_path):
+            return None
+        size_kb = os.path.getsize(self.history_path) / 1024
+        if size_kb < self.rotation_kb:
+            return None
+
+        # Use the timestamp of the last entry for the archive month.
+        last_ts = self._read_last_timestamp() or _dt.datetime.now(_dt.timezone.utc).isoformat()
+        month = last_ts[:7]  # YYYY-MM
+        os.makedirs(self.archive_dir, exist_ok=True)
+        archive_path = os.path.join(self.archive_dir, f"{month}.md")
+
+        # If a file for this month already exists, append-merge with a separator
+        # so multi-rotation months stay in one archive file.
+        if os.path.exists(archive_path):
+            with open(self.history_path, "r", encoding="utf-8") as src:
+                payload = src.read()
+            with open(archive_path, "a", encoding="utf-8") as dst:
+                dst.write("\n\n<!-- merged on rotation -->\n\n")
+                dst.write(payload)
+            os.unlink(self.history_path)
+        else:
+            shutil.move(self.history_path, archive_path)
+
+        # Recreate fresh history.md with header pointing at the archive.
+        with open(self.history_path, "w", encoding="utf-8") as fh:
+            fh.write(self._render_header())
+            fh.write(
+                f"\n> Previous entries archived to "
+                f"`{os.path.relpath(archive_path, os.path.dirname(self.history_path))}` "
+                f"on {_dt.datetime.now(_dt.timezone.utc).isoformat(timespec='seconds')}.\n"
+            )
+
+        return archive_path
+
+    def _read_last_timestamp(self) -> Optional[str]:
+        try:
+            with open(self.history_path, "r", encoding="utf-8") as fh:
+                content = fh.read()
+        except FileNotFoundError:
+            return None
+        matches = _HEADER_RE.findall(content)
+        if not matches:
+            return None
+        return matches[-1][0]
+
+
+# --- Reader ------------------------------------------------------------------
+
+class HistoryReader:
+    """Parses ``history.md`` and serves recency/since/tag queries."""
+
+    def __init__(self, history_path: Optional[str] = None):
+        self.history_path = history_path or HISTORY_FILE
+
+    def read_all(self) -> List[HistoryEntry]:
+        if not os.path.exists(self.history_path):
+            return []
+        with open(self.history_path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+        return self._parse(content)
+
+    def read_recent(
+        self,
+        limit: int = 20,
+        since: Optional[str] = None,
+    ) -> List[HistoryEntry]:
+        """Newest-first list, optionally filtered by ``since`` (ISO timestamp prefix)."""
+        entries = self.read_all()
+        entries.sort(key=lambda e: e.timestamp, reverse=True)
+        if since:
+            entries = [e for e in entries if e.timestamp >= since]
+        return entries[:limit]
+
+    # ------------------------------------------------------------------ parser
+    @staticmethod
+    def _parse(content: str) -> List[HistoryEntry]:
+        # Split content on heading boundaries while keeping the headings.
+        positions = [m.start() for m in _HEADER_RE.finditer(content)]
+        if not positions:
+            return []
+        positions.append(len(content))
+        out: List[HistoryEntry] = []
+        for i in range(len(positions) - 1):
+            block = content[positions[i] : positions[i + 1]]
+            entry = HistoryReader._parse_block(block)
+            if entry:
+                out.append(entry)
+        return out
+
+    @staticmethod
+    def _parse_block(block: str) -> Optional[HistoryEntry]:
+        lines = block.splitlines()
+        if not lines:
+            return None
+        header = _HEADER_RE.match(lines[0])
+        if not header:
+            return None
+        ts = header.group("ts")
+        eid = header.group("id")
+        fields: Dict[str, str] = {}
+        for line in lines[1:]:
+            m = _FIELD_RE.match(line)
+            if m:
+                fields[m.group("name").lower()] = m.group("value").strip()
+        intent = fields.get("intent", "")
+        action = fields.get("action", "")
+        outcome = fields.get("outcome", "")
+        files_raw = fields.get("files", "")
+        files = [f.strip() for f in files_raw.split(",") if f.strip()] if files_raw else []
+        tags_raw = fields.get("tags", "")
+        tags = [t.strip() for t in tags_raw.split() if t.strip()] if tags_raw else []
+        meta_raw = fields.get("meta", "")
+        metadata = None
+        if meta_raw:
+            try:
+                metadata = json.loads(meta_raw)
+            except json.JSONDecodeError:
+                metadata = {"_raw": meta_raw}
+        return HistoryEntry(
+            id=eid,
+            timestamp=ts,
+            intent=intent,
+            action=action,
+            outcome=outcome,
+            files=files,
+            tags=tags,
+            metadata=metadata,
+        )
+
+
+# --- Lazy semantic store -----------------------------------------------------
+
+class HistoryStore:
+    """Lazy semantic recall over history entries.
+
+    Wrapping ``NumpyVectorStore`` so callers don't pay numpy/embedder import
+    costs unless they actually run a semantic query.
+    """
+
+    def __init__(
+        self,
+        history_path: Optional[str] = None,
+        data_dir: Optional[str] = None,
+        store_name: str = HISTORY_VECTOR_STORE_NAME,
+    ):
+        self.history_path = history_path or HISTORY_FILE
+        self.data_dir = data_dir or MEMORY_DATA_DIR
+        self.store_name = store_name
+        self._store = None  # lazy
+
+    # ------------------------------------------------------------------ public
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        embed_query=None,
+        embed_texts=None,
+    ) -> List[Dict[str, Any]]:
+        """Return top-``limit`` entries with semantic distance.
+
+        ``embed_query`` / ``embed_texts`` are injectable so tests can swap in
+        deterministic fakes; production callers leave them None and the
+        FastEmbed-backed defaults are loaded lazily.
+        """
+        store = self.ensure_index(embed_texts=embed_texts)
+        if store.count() == 0:
+            return []
+        if embed_query is None:
+            from src.engine.embedder import embed_query as _eq
+            embed_query = _eq
+
+        vec = embed_query(query)
+        result = store.query(vec, n_results=limit)
+        out: List[Dict[str, Any]] = []
+        for i, eid in enumerate(result.ids):
+            meta = result.metadatas[i] or {}
+            out.append({
+                "id": eid,
+                "distance": float(result.distances[i]),
+                "document": result.documents[i],
+                "timestamp": meta.get("timestamp", ""),
+                "intent": meta.get("intent", ""),
+                "tags": meta.get("tags", []),
+            })
+        return out
+
+    def ensure_index(self, embed_texts=None):
+        """Build / refresh the vector index if the markdown file is newer.
+
+        Returns the underlying ``NumpyVectorStore``.
+        """
+        from src.engine.vector_store import NumpyVectorStore  # heavy import — defer
+        if self._store is None:
+            self._store = NumpyVectorStore(name=self.store_name, data_dir=self.data_dir)
+
+        # Refresh if file is newer than the store's npz.
+        npz_path = os.path.join(self.data_dir, f"{self.store_name}.npz")
+        history_mtime = os.path.getmtime(self.history_path) if os.path.exists(self.history_path) else 0
+        store_mtime = os.path.getmtime(npz_path) if os.path.exists(npz_path) else 0
+        if history_mtime <= store_mtime and self._store.count() > 0:
+            return self._store
+
+        self._rebuild(embed_texts=embed_texts)
+        return self._store
+
+    # ------------------------------------------------------------------ helpers
+    def _rebuild(self, embed_texts=None) -> None:
+        reader = HistoryReader(self.history_path)
+        entries = reader.read_all()
+        if not entries:
+            self._store.clear()
+            self._store.save()
+            return
+
+        if embed_texts is None:
+            from src.engine.embedder import embed_texts as _et
+            embed_texts = _et
+
+        documents = [self._format_for_embedding(e) for e in entries]
+        embeddings = embed_texts(documents)
+
+        ids = [e.id for e in entries]
+        metadatas = [
+            {
+                "timestamp": e.timestamp,
+                "intent": e.intent,
+                "tags": e.tags,
+                "files": e.files,
+            }
+            for e in entries
+        ]
+        self._store.replace(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+        self._store.save()
+
+    @staticmethod
+    def _format_for_embedding(entry: HistoryEntry) -> str:
+        parts = [
+            f"Intent: {entry.intent}",
+            f"Action: {entry.action}",
+            f"Outcome: {entry.outcome}",
+        ]
+        if entry.tags:
+            parts.append("Tags: " + " ".join(entry.tags))
+        return "\n".join(parts)
+
+
+__all__ = [
+    "HistoryEntry",
+    "HistoryReader",
+    "HistoryStore",
+    "HistoryWriter",
+]

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -25,6 +25,7 @@ import logging
 import os
 import re
 import shutil
+import threading
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -58,6 +59,10 @@ except ImportError:  # pragma: no cover - Windows
 
     def _unlock(fh) -> None:
         return None
+
+# Process-local mutex — fcntl.flock is advisory and per-process on Linux,
+# so concurrent threads (e.g. multiple run_in_executor calls) can bypass it.
+_WRITE_LOCK = threading.Lock()
 
 
 _HEADER_RE = re.compile(
@@ -129,7 +134,7 @@ class HistoryWriter:
         # concurrent writers (cross-process: e.g. Claude Desktop + VS Code
         # attached to the same repo) cannot interleave and corrupt the file.
         rotated_to: Optional[str] = None
-        with open(self.history_path, "a+", encoding="utf-8", newline="") as fh:
+        with _WRITE_LOCK, open(self.history_path, "a+", encoding="utf-8", newline="") as fh:
             try:
                 _lock_exclusive(fh)
 
@@ -140,7 +145,7 @@ class HistoryWriter:
                     fh.write(self._render_header())
                     fh.flush()
 
-                if self._is_duplicate(entry_id):
+                if self._is_duplicate_from_handle(fh, entry_id):
                     return {
                         "status": "duplicate",
                         "entry_id": entry_id,
@@ -226,13 +231,13 @@ class HistoryWriter:
         lines.append("")  # trailing newline
         return "\n".join(lines) + "\n"
 
-    def _is_duplicate(self, entry_id: str) -> bool:
-        """Tail-scan the last ``self.dedup_tail`` entry IDs."""
-        try:
-            with open(self.history_path, "r", encoding="utf-8") as fh:
-                content = fh.read()
-        except FileNotFoundError:
-            return False
+    def _is_duplicate_from_handle(self, fh, entry_id: str) -> bool:
+        """Tail-scan the last ``self.dedup_tail`` entry IDs using the
+        already-open file handle (avoids opening a second fd under the lock)."""
+        pos = fh.tell()
+        fh.seek(0)
+        content = fh.read()
+        fh.seek(pos)
         ids = _HEADER_RE.findall(content)
         recent = [match[1] for match in ids[-self.dedup_tail:]]
         return entry_id in recent

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -465,7 +465,7 @@ class HistoryStore:
             npz_path = os.path.join(self.data_dir, f"{self.store_name}.npz")
             history_mtime = os.path.getmtime(self.history_path)
             store_mtime = os.path.getmtime(npz_path) if os.path.exists(npz_path) else 0
-            if history_mtime <= store_mtime and self._store.count() > 0:
+            if history_mtime < store_mtime and self._store.count() > 0:
                 return self._store
 
             self._rebuild(embed_texts=embed_texts)

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -122,7 +122,7 @@ class HistoryWriter:
         if not (intent and action and outcome):
             return {
                 "status": "error",
-                "message": "intent, action, and outcome are all required",
+                "error": "intent, action, and outcome are all required",
             }
 
         entry_id = self._compute_entry_hash(intent, action, outcome)

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -402,6 +402,7 @@ class HistoryStore:
         self.data_dir = data_dir or MEMORY_DATA_DIR
         self.store_name = store_name
         self._store = None  # lazy
+        self._index_lock = threading.Lock()
 
     # ------------------------------------------------------------------ public
     def search(
@@ -442,29 +443,33 @@ class HistoryStore:
     def ensure_index(self, embed_texts=None):
         """Build / refresh the vector index if the markdown file is newer.
 
+        Thread-safe: serialized via ``_index_lock`` so concurrent
+        ``read_history(query=...)`` calls don't race on rebuild.
+
         Returns the underlying ``NumpyVectorStore``.
         """
-        from src.engine.vector_store import NumpyVectorStore  # heavy import — defer
-        if self._store is None:
-            self._store = NumpyVectorStore(name=self.store_name, data_dir=self.data_dir)
+        with self._index_lock:
+            from src.engine.vector_store import NumpyVectorStore  # heavy import — defer
+            if self._store is None:
+                self._store = NumpyVectorStore(name=self.store_name, data_dir=self.data_dir)
 
-        # If the history file was deleted/moved, clear the store so semantic
-        # search doesn't return stale entries.
-        if not os.path.exists(self.history_path):
-            if self._store.count() > 0:
-                self._store.clear()
-                self._store.save()
+            # If the history file was deleted/moved, clear the store so semantic
+            # search doesn't return stale entries.
+            if not os.path.exists(self.history_path):
+                if self._store.count() > 0:
+                    self._store.clear()
+                    self._store.save()
+                return self._store
+
+            # Refresh if file is newer than the store's npz.
+            npz_path = os.path.join(self.data_dir, f"{self.store_name}.npz")
+            history_mtime = os.path.getmtime(self.history_path)
+            store_mtime = os.path.getmtime(npz_path) if os.path.exists(npz_path) else 0
+            if history_mtime <= store_mtime and self._store.count() > 0:
+                return self._store
+
+            self._rebuild(embed_texts=embed_texts)
             return self._store
-
-        # Refresh if file is newer than the store's npz.
-        npz_path = os.path.join(self.data_dir, f"{self.store_name}.npz")
-        history_mtime = os.path.getmtime(self.history_path)
-        store_mtime = os.path.getmtime(npz_path) if os.path.exists(npz_path) else 0
-        if history_mtime <= store_mtime and self._store.count() > 0:
-            return self._store
-
-        self._rebuild(embed_texts=embed_texts)
-        return self._store
 
     # ------------------------------------------------------------------ helpers
     def _rebuild(self, embed_texts=None) -> None:

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -130,7 +130,7 @@ class HistoryWriter:
         # concurrent writers (cross-process: e.g. Claude Desktop + VS Code
         # attached to the same repo) cannot interleave and corrupt the file.
         rotated_to: Optional[str] = None
-        with open(self.history_path, "a+", encoding="utf-8") as fh:
+        with open(self.history_path, "a+", encoding="utf-8", newline="") as fh:
             try:
                 _lock_exclusive(fh)
 
@@ -267,7 +267,7 @@ class HistoryWriter:
             shutil.move(self.history_path, archive_path)
 
         # Recreate fresh history.md with header pointing at the archive.
-        with open(self.history_path, "w", encoding="utf-8") as fh:
+        with open(self.history_path, "w", encoding="utf-8", newline="") as fh:
             fh.write(self._render_header())
             fh.write(
                 f"\n> Previous entries archived to "
@@ -438,9 +438,17 @@ class HistoryStore:
         if self._store is None:
             self._store = NumpyVectorStore(name=self.store_name, data_dir=self.data_dir)
 
+        # If the history file was deleted/moved, clear the store so semantic
+        # search doesn't return stale entries.
+        if not os.path.exists(self.history_path):
+            if self._store.count() > 0:
+                self._store.clear()
+                self._store.save()
+            return self._store
+
         # Refresh if file is newer than the store's npz.
         npz_path = os.path.join(self.data_dir, f"{self.store_name}.npz")
-        history_mtime = os.path.getmtime(self.history_path) if os.path.exists(self.history_path) else 0
+        history_mtime = os.path.getmtime(self.history_path)
         store_mtime = os.path.getmtime(npz_path) if os.path.exists(npz_path) else 0
         if history_mtime <= store_mtime and self._store.count() > 0:
             return self._store
@@ -460,6 +468,14 @@ class HistoryStore:
         if embed_texts is None:
             from src.engine.embedder import embed_texts as _et
             embed_texts = _et
+
+        # Deduplicate by id — entries outside the dedup_tail window can share
+        # the same content hash. Keep the latest (last) entry for each id.
+        seen: dict[str, int] = {}
+        for i, e in enumerate(entries):
+            seen[e.id] = i
+        unique_indices = sorted(seen.values())
+        entries = [entries[i] for i in unique_indices]
 
         documents = [self._format_for_embedding(e) for e in entries]
         embeddings = embed_texts(documents)

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -462,11 +462,14 @@ class HistoryStore:
                 return self._store
 
             # Refresh if file is newer than the store's npz.
+            # Use npz existence + mtime as the staleness signal (not count),
+            # so a legitimately empty store doesn't trigger redundant rebuilds.
             npz_path = os.path.join(self.data_dir, f"{self.store_name}.npz")
             history_mtime = os.path.getmtime(self.history_path)
-            store_mtime = os.path.getmtime(npz_path) if os.path.exists(npz_path) else 0
-            if history_mtime < store_mtime and self._store.count() > 0:
-                return self._store
+            if os.path.exists(npz_path):
+                store_mtime = os.path.getmtime(npz_path)
+                if history_mtime < store_mtime:
+                    return self._store
 
             self._rebuild(embed_texts=embed_texts)
             return self._store

--- a/src/memory/managed_section.py
+++ b/src/memory/managed_section.py
@@ -47,7 +47,7 @@ class InvertedMarkersError(ManagedSectionError):
     """The end marker appears before the begin marker."""
 
 
-def _atomic_write(path: str, content: str) -> None:
+def atomic_write(path: str, content: str) -> None:
     """Write ``content`` to ``path`` atomically.
 
     The temporary file is created in the same directory so ``os.replace`` is
@@ -132,7 +132,7 @@ def upsert_section(
     block = _format_block(marker_begin, marker_end, section_content)
 
     if not os.path.exists(file_path):
-        _atomic_write(file_path, block)
+        atomic_write(file_path, block)
         return "created"
 
     with open(file_path, "r", encoding="utf-8") as f:
@@ -148,7 +148,7 @@ def upsert_section(
         if not prefix.endswith("\n\n"):
             prefix += "\n"
         new_content = prefix + block
-        _atomic_write(file_path, new_content)
+        atomic_write(file_path, new_content)
         return "appended"
 
     # Replace existing block. Consume trailing newlines so we don't accumulate
@@ -157,7 +157,7 @@ def upsert_section(
     while trailing < len(original) and original[trailing] == "\n":
         trailing += 1
     new_content = original[:begin_idx] + block + original[trailing:]
-    _atomic_write(file_path, new_content)
+    atomic_write(file_path, new_content)
     return "replaced"
 
 
@@ -220,5 +220,5 @@ def remove_section(
         leading += 1
 
     new_content = original[:leading] + original[trailing:]
-    _atomic_write(file_path, new_content)
+    atomic_write(file_path, new_content)
     return True

--- a/src/memory/managed_section.py
+++ b/src/memory/managed_section.py
@@ -1,0 +1,221 @@
+"""Idempotent, marker-bounded edits of CLAUDE.md (and friends).
+
+Single source of truth for the marker-section editor previously inlined in
+``scripts/init_repo.sh:636-672``. The bash installer can shell out to this
+module via subprocess, and the MCP ``describe_repo`` tool calls it directly,
+so both paths share identical behavior.
+
+Contract for a managed section::
+
+    {marker_begin}\n
+    \n
+    {section_content}\n
+    \n
+    {marker_end}\n
+
+Behavior:
+    - File missing            → create the file containing only the section.
+    - File present, no markers → append section to the end (one blank line gap).
+    - File present, both markers → replace content between markers in-place.
+    - File present, only one marker → raise ``PartialMarkerError`` (do not guess).
+    - File present, duplicate marker → raise ``DuplicateMarkerError``.
+
+All writes are atomic (``tempfile`` in the same directory + ``os.replace``) so a
+crash mid-write cannot leave a half-written CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Optional
+
+
+class ManagedSectionError(Exception):
+    """Base class for managed-section editing errors."""
+
+
+class PartialMarkerError(ManagedSectionError):
+    """Only one of ``begin``/``end`` markers is present."""
+
+
+class DuplicateMarkerError(ManagedSectionError):
+    """One of the markers appears more than once."""
+
+
+class InvertedMarkersError(ManagedSectionError):
+    """The end marker appears before the begin marker."""
+
+
+def _atomic_write(path: str, content: str) -> None:
+    """Write ``content`` to ``path`` atomically.
+
+    The temporary file is created in the same directory so ``os.replace`` is
+    a same-filesystem rename (atomic on POSIX). Newline translation is
+    disabled — we want the exact bytes to land on disk regardless of platform
+    locale.
+    """
+    target_dir = os.path.dirname(os.path.abspath(path)) or "."
+    os.makedirs(target_dir, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=target_dir, prefix=".managed_section.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        # Best-effort cleanup if replace never happened.
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        raise
+
+
+def _validate_markers(content: str, marker_begin: str, marker_end: str) -> tuple[int, int]:
+    """Return ``(begin_idx, end_idx)`` or raise on ambiguity.
+
+    ``begin_idx`` points at the first character of ``marker_begin`` in the
+    file; ``end_idx`` points one past the last character of ``marker_end``.
+    Both are -1 if neither marker is present.
+    """
+    begin_count = content.count(marker_begin)
+    end_count = content.count(marker_end)
+
+    if begin_count == 0 and end_count == 0:
+        return -1, -1
+
+    if begin_count > 1 or end_count > 1:
+        raise DuplicateMarkerError(
+            f"Expected exactly one begin/end marker, "
+            f"found {begin_count} begin and {end_count} end"
+        )
+
+    if begin_count != end_count:
+        raise PartialMarkerError(
+            f"Incomplete markers: begin={begin_count}, end={end_count}. "
+            "Remove the orphaned marker manually before retrying."
+        )
+
+    begin_idx = content.find(marker_begin)
+    end_anchor = content.find(marker_end, begin_idx)
+    if end_anchor < 0:
+        # end marker appears, but before begin
+        raise InvertedMarkersError(
+            "End marker appears before begin marker"
+        )
+    end_idx = end_anchor + len(marker_end)
+    return begin_idx, end_idx
+
+
+def _format_block(marker_begin: str, marker_end: str, section_content: str) -> str:
+    """Compose a marker block with a single blank line padding either side."""
+    body = section_content.strip("\n")
+    return f"{marker_begin}\n\n{body}\n\n{marker_end}\n"
+
+
+def upsert_section(
+    file_path: str,
+    marker_begin: str,
+    marker_end: str,
+    section_content: str,
+) -> str:
+    """Create, replace, or append a managed section.
+
+    Returns the action taken: ``"created"``, ``"replaced"``, or ``"appended"``.
+    """
+    block = _format_block(marker_begin, marker_end, section_content)
+
+    if not os.path.exists(file_path):
+        _atomic_write(file_path, block)
+        return "created"
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        original = f.read()
+
+    begin_idx, end_idx = _validate_markers(original, marker_begin, marker_end)
+
+    if begin_idx < 0:
+        # No managed section yet — append, separated by exactly one blank line.
+        prefix = original
+        if not prefix.endswith("\n"):
+            prefix += "\n"
+        if not prefix.endswith("\n\n"):
+            prefix += "\n"
+        new_content = prefix + block
+        _atomic_write(file_path, new_content)
+        return "appended"
+
+    # Replace existing block. Consume trailing newlines so we don't accumulate
+    # blank lines on every refresh.
+    trailing = end_idx
+    while trailing < len(original) and original[trailing] == "\n":
+        trailing += 1
+    new_content = original[:begin_idx] + block + original[trailing:]
+    _atomic_write(file_path, new_content)
+    return "replaced"
+
+
+def read_section(
+    file_path: str,
+    marker_begin: str,
+    marker_end: str,
+) -> Optional[str]:
+    """Return the content between markers, or ``None`` if no managed section.
+
+    Whitespace immediately inside the markers is trimmed so callers see exactly
+    the body they passed in (modulo intentional inner blank lines).
+    """
+    if not os.path.exists(file_path):
+        return None
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    begin_idx, end_idx = _validate_markers(content, marker_begin, marker_end)
+    if begin_idx < 0:
+        return None
+
+    inner_start = begin_idx + len(marker_begin)
+    inner_end = end_idx - len(marker_end)
+    body = content[inner_start:inner_end]
+    return body.strip("\n")
+
+
+def remove_section(
+    file_path: str,
+    marker_begin: str,
+    marker_end: str,
+) -> bool:
+    """Delete the managed section if present. Returns ``True`` if anything was
+    removed; ``False`` if the file or the section did not exist."""
+    if not os.path.exists(file_path):
+        return False
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        original = f.read()
+
+    begin_idx, end_idx = _validate_markers(original, marker_begin, marker_end)
+    if begin_idx < 0:
+        return False
+
+    # Consume trailing newlines after end marker.
+    trailing = end_idx
+    while trailing < len(original) and original[trailing] == "\n":
+        trailing += 1
+
+    # Also consume blank lines immediately preceding the begin marker so we
+    # don't leave a widening gap each time a section is created and removed.
+    leading = begin_idx
+    while leading > 0 and original[leading - 1] == "\n":
+        leading -= 1
+    # Preserve the line break that ends the previous content (if any).
+    if leading > 0:
+        leading += 1
+
+    new_content = original[:leading] + original[trailing:]
+    _atomic_write(file_path, new_content)
+    return True

--- a/src/memory/managed_section.py
+++ b/src/memory/managed_section.py
@@ -212,8 +212,9 @@ def remove_section(
     leading = begin_idx
     while leading > 0 and original[leading - 1] == "\n":
         leading -= 1
-    # Preserve the line break that ends the previous content (if any).
-    if leading > 0:
+    # Preserve the line break that ends the previous content (if any),
+    # but only if we actually consumed at least one blank line.
+    if leading > 0 and leading < begin_idx:
         leading += 1
 
     new_content = original[:leading] + original[trailing:]

--- a/src/memory/managed_section.py
+++ b/src/memory/managed_section.py
@@ -51,9 +51,11 @@ def _atomic_write(path: str, content: str) -> None:
     """Write ``content`` to ``path`` atomically.
 
     The temporary file is created in the same directory so ``os.replace`` is
-    a same-filesystem rename (atomic on POSIX). Newline translation is
-    disabled — we want the exact bytes to land on disk regardless of platform
-    locale.
+    a same-filesystem rename (atomic on POSIX). Writes use ``newline=""`` to
+    disable translation and produce ``\\n`` endings. Reads use default newline
+    mode, which normalizes ``\\r\\n`` → ``\\n``, so existing CRLF files are
+    converted to LF on first edit. This is intentional — CLAUDE.md and
+    history.md are always ``\\n``.
     """
     target_dir = os.path.dirname(os.path.abspath(path)) or "."
     os.makedirs(target_dir, exist_ok=True)

--- a/src/server.py
+++ b/src/server.py
@@ -63,7 +63,7 @@ SESSION_CACHE: TTLCache = TTLCache(
     ttl=SESSION_CACHE_TTL_SECONDS,
 )
 
-from src.utils.langfuse_compat import observe, get_langfuse
+from src.utils.langfuse_compat import observe, get_langfuse, is_langfuse_configured
 langfuse = get_langfuse()
 atexit.register(langfuse.flush)
 
@@ -621,10 +621,12 @@ async def log_interaction(
 
     loop = asyncio.get_running_loop()
 
-    # --- Langfuse trace (best-effort, no-op when keys absent) ---
+    # --- Langfuse trace (best-effort, skipped when keys absent) ---
     # Run the sync Langfuse SDK off the event loop so a slow network
     # round-trip doesn't stall the MCP handler.
     def _send_langfuse() -> dict:
+        if not is_langfuse_configured():
+            return {"status": "skipped"}
         try:
             trace_id = langfuse.create_trace_id(seed=request_id)
             with langfuse.start_as_current_observation(
@@ -646,24 +648,25 @@ async def log_interaction(
             logger.error("Langfuse logging failed: %s", e, exc_info=True)
             return {"status": "error", "error": str(e)}
 
-    langfuse_payload = await loop.run_in_executor(None, _send_langfuse)
-
     # --- History append (always; defaults to raw query/response) ---
-    history_payload: dict
-    try:
-        writer = HistoryWriter()
-        eff_intent = (intent or query or "").strip()
-        eff_action = (action or f"Agent: {agent_name}").strip()
-        eff_outcome = (outcome or response_content or "").strip()
-        history_payload = await loop.run_in_executor(
-            None,
-            lambda: writer.append_entry(
+    def _send_history() -> dict:
+        try:
+            writer = HistoryWriter()
+            eff_intent = (intent or query or "").strip()
+            eff_action = (action or f"Agent: {agent_name}").strip()
+            eff_outcome = (outcome or response_content or "").strip()
+            return writer.append_entry(
                 eff_intent, eff_action, eff_outcome, files, tags, None
-            ),
-        )
-    except Exception as e:
-        logger.error("History append failed: %s", e, exc_info=True)
-        history_payload = {"status": "error", "error": str(e)}
+            )
+        except Exception as e:
+            logger.error("History append failed: %s", e, exc_info=True)
+            return {"status": "error", "error": str(e)}
+
+    # Both sinks are independent — run them concurrently.
+    langfuse_payload, history_payload = await asyncio.gather(
+        loop.run_in_executor(None, _send_langfuse),
+        loop.run_in_executor(None, _send_history),
+    )
 
     payload = {
         "request_id": request_id,
@@ -747,9 +750,12 @@ async def read_history(
       semantically nearest entries with cosine distance.
 
     Returns JSON:
-      {entries: [{id, timestamp, intent, action?, outcome?, files, tags,
-                  distance? }], total, mode}
+      {entries: [...], total, mode}
       mode ∈ {"recency", "semantic"}.
+
+    Entry shape depends on mode:
+    - recency: {id, timestamp, intent, action, outcome, files, tags, metadata}.
+    - semantic: {id, distance, document, timestamp, intent, tags}.
     """
     try:
         debug_log("read_history", "req", {"limit": limit, "since": since, "query": query})

--- a/src/server.py
+++ b/src/server.py
@@ -38,6 +38,10 @@ from src.utils.debug_logger import debug_log
 from src.memory.describer import RepoDescriber
 from src.memory.history import HistoryReader, HistoryStore, HistoryWriter
 
+# Cached instance — avoids reloading .npz from disk on every read_history call.
+# HistoryStore.ensure_index() handles mtime-based staleness internally.
+_history_store = HistoryStore()
+
 mcp = FastMCP(
     "Agents-Core",
     instructions=(
@@ -783,10 +787,9 @@ async def read_history(
         loop = asyncio.get_running_loop()
 
         if query:
-            store = HistoryStore()
             results = await loop.run_in_executor(
                 None,
-                lambda: store.search(query, limit=limit),
+                lambda: _history_store.search(query, limit=limit),
             )
             payload = {"mode": "semantic", "total": len(results), "entries": results}
         else:

--- a/src/server.py
+++ b/src/server.py
@@ -881,12 +881,12 @@ _register_agent_prompts()
 
 
 def _register_memory_prompts():
-    """Register slash commands that drive the memory tools.
+    """Register the slash prompt that drives the repository memory tool.
 
-    Tool names (``describe_repo``, ``read_history``) already occupy those
-    Python identifiers in this module, so each prompt function is defined
-    under a distinct local name and renamed via ``__name__`` before being
-    passed to ``mcp.prompt()`` — same trick used in ``_register_agent_prompts``.
+    The tool name ``describe_repo`` already occupies that Python identifier
+    in this module, so the prompt function is defined under a distinct local
+    name and renamed via ``__name__`` before being passed to ``mcp.prompt()``
+    — same trick used in ``_register_agent_prompts``.
     """
 
     def _truthy(arg: str) -> bool:

--- a/src/server.py
+++ b/src/server.py
@@ -726,6 +726,9 @@ async def describe_repo(
                     "message": f"repo_path is not an existing directory: {repo_path}",
                 }
                 return json.dumps(payload, ensure_ascii=False)
+            # Use the canonicalized path for all downstream work so symlink
+            # TOCTOU can't bypass the sandbox after validation.
+            repo_path = resolved
 
         debug_log("describe_repo", "req", {
             "repo_path": repo_path,

--- a/src/server.py
+++ b/src/server.py
@@ -720,6 +720,12 @@ async def describe_repo(
                     "message": f"repo_path must be within {REPO_ROOT}",
                 }
                 return json.dumps(payload, ensure_ascii=False)
+            if not os.path.isdir(resolved):
+                payload = {
+                    "status": "error",
+                    "message": f"repo_path is not an existing directory: {repo_path}",
+                }
+                return json.dumps(payload, ensure_ascii=False)
 
         debug_log("describe_repo", "req", {
             "repo_path": repo_path,

--- a/src/server.py
+++ b/src/server.py
@@ -717,13 +717,13 @@ async def describe_repo(
             if resolved != repo_root_resolved.rstrip(os.sep) and not resolved.startswith(repo_root_resolved):
                 payload = {
                     "status": "error",
-                    "message": f"repo_path must be within {REPO_ROOT}",
+                    "error": f"repo_path must be within {REPO_ROOT}",
                 }
                 return json.dumps(payload, ensure_ascii=False)
             if not os.path.isdir(resolved):
                 payload = {
                     "status": "error",
-                    "message": f"repo_path is not an existing directory: {repo_path}",
+                    "error": f"repo_path is not an existing directory: {repo_path}",
                 }
                 return json.dumps(payload, ensure_ascii=False)
             # Use the canonicalized path for all downstream work so symlink
@@ -746,8 +746,8 @@ async def describe_repo(
         if ctx is None:
             payload = {
                 "status": "error",
-                "message": "MCP context is required for sampling — describe_repo "
-                           "must be called over a sampling-capable client.",
+                "error": "MCP context is required for sampling — describe_repo "
+                         "must be called over a sampling-capable client.",
             }
             debug_log("describe_repo", "error", payload)
             return json.dumps(payload, ensure_ascii=False)
@@ -761,7 +761,7 @@ async def describe_repo(
         return json.dumps(payload, ensure_ascii=False)
     except Exception as e:
         logger.error("describe_repo failed: %s", e, exc_info=True)
-        payload = {"status": "error", "message": str(e)}
+        payload = {"status": "error", "error": str(e)}
         debug_log("describe_repo", "error", payload)
         return json.dumps(payload, ensure_ascii=False)
 
@@ -817,7 +817,7 @@ async def read_history(
         return json.dumps(payload, ensure_ascii=False)
     except Exception as e:
         logger.error("read_history failed: %s", e, exc_info=True)
-        payload = {"status": "error", "message": str(e)}
+        payload = {"status": "error", "error": str(e)}
         debug_log("read_history", "error", payload)
         return json.dumps(payload, ensure_ascii=False)
 

--- a/src/server.py
+++ b/src/server.py
@@ -700,8 +700,8 @@ async def describe_repo(
         # Restrict repo_path to REPO_ROOT to prevent arbitrary filesystem access.
         if repo_path is not None:
             resolved = os.path.realpath(repo_path)
-            repo_root_resolved = os.path.realpath(REPO_ROOT)
-            if not resolved.startswith(repo_root_resolved):
+            repo_root_resolved = os.path.realpath(REPO_ROOT) + os.sep
+            if resolved != repo_root_resolved.rstrip(os.sep) and not resolved.startswith(repo_root_resolved):
                 payload = {
                     "status": "error",
                     "message": f"repo_path must be within {REPO_ROOT}",

--- a/src/server.py
+++ b/src/server.py
@@ -783,6 +783,7 @@ async def read_history(
     """
     try:
         limit = max(1, min(limit, 500))
+        query = (query or "").strip() or None
         debug_log("read_history", "req", {"limit": limit, "since": since, "query": query})
         loop = asyncio.get_running_loop()
 

--- a/src/server.py
+++ b/src/server.py
@@ -681,7 +681,7 @@ async def log_interaction(
 @mcp.tool()
 @observe(name="describe_repo")
 async def describe_repo(
-    ctx: Context,
+    ctx: Context | None = None,
     repo_path: Optional[str] = None,
     force_refresh: bool = False,
 ) -> str:

--- a/src/server.py
+++ b/src/server.py
@@ -35,6 +35,8 @@ from src.engine.enrichment import (
 from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD, ROUTER_SIMILARITY_THRESHOLD
 from src.utils.prompt_loader import load_agent_prompt, get_agent_metadata
 from src.utils.debug_logger import debug_log
+from src.memory.describer import RepoDescriber
+from src.memory.history import HistoryReader, HistoryStore, HistoryWriter
 
 mcp = FastMCP(
     "Agents-Core",
@@ -575,36 +577,210 @@ async def list_agents(include_metadata: bool = True) -> str:
     return json.dumps({"agents": catalog}, ensure_ascii=False, indent=2)
 
 @mcp.tool()
-async def log_interaction(agent_name: str, query: str, response_content: str, request_id: Optional[str] = None, reasoning: Optional[str] = None) -> str:
-    """
-    Logs the full agent interaction turn to LangFuse as a generation trace.
-    ALWAYS call this at the end of a turn to ensure observability.
+async def log_interaction(
+    agent_name: str,
+    query: str,
+    response_content: str,
+    request_id: Optional[str] = None,
+    reasoning: Optional[str] = None,
+    intent: Optional[str] = None,
+    action: Optional[str] = None,
+    outcome: Optional[str] = None,
+    files: Optional[List[str]] = None,
+    tags: Optional[List[str]] = None,
+) -> str:
+    """End-of-turn logger. ALWAYS call at the end of every turn.
+
+    Two sinks, independent of each other:
+
+    * **history.md** — always written via ``HistoryWriter`` (append-only,
+      content-hash deduped). Defaults: ``intent=query``, ``action="Agent: {agent_name}"``,
+      ``outcome=response_content``. Pass ``intent``/``action``/``outcome``/``files``/``tags``
+      to curate the entry; otherwise raw query/response are used.
+
+    * **Langfuse** — generation trace recorded only when ``LANGFUSE_PUBLIC_KEY`` /
+      ``LANGFUSE_SECRET_KEY`` are configured; otherwise the call is a no-op via
+      ``langfuse_compat``.
+
+    Returns JSON: ``{request_id, langfuse: {status, trace_id?, error?},
+    history: {status, entry_id?, path?, error?}}``. A failure in one sink does
+    not prevent the other.
     """
     if not request_id:
         request_id = str(uuid.uuid4())
 
-    try:
-        trace_id = langfuse.create_trace_id(seed=request_id)
-        
-        with langfuse.start_as_current_observation(
-            as_type="span",
-            name="agent_interaction",
-            trace_context={"trace_id": trace_id},
-            metadata={"agent": agent_name, "source": "mcp-server"}
-        ) as trace:
+    debug_log("log_interaction", "req", {
+        "agent_name": agent_name,
+        "request_id": request_id,
+        "query_len": len(query or ""),
+        "response_len": len(response_content or ""),
+        "curated": bool(intent or action or outcome),
+        "files": files or [],
+        "tags": tags or [],
+    })
+
+    loop = asyncio.get_running_loop()
+
+    # --- Langfuse trace (best-effort, no-op when keys absent) ---
+    # Run the sync Langfuse SDK off the event loop so a slow network
+    # round-trip doesn't stall the MCP handler.
+    def _send_langfuse() -> dict:
+        try:
+            trace_id = langfuse.create_trace_id(seed=request_id)
             with langfuse.start_as_current_observation(
-                as_type="generation",
-                name="response",
-                input=query[:2000],
-                metadata={"agent": agent_name, "reasoning": reasoning or ""}
-            ) as gen:
-                gen.update(output=response_content[:5000])
-                
-        langfuse.flush()
-        return f"Interaction logged. Trace ID: {request_id}"
+                as_type="span",
+                name="agent_interaction",
+                trace_context={"trace_id": trace_id},
+                metadata={"agent": agent_name, "source": "mcp-server"},
+            ):
+                with langfuse.start_as_current_observation(
+                    as_type="generation",
+                    name="response",
+                    input=query[:2000],
+                    metadata={"agent": agent_name, "reasoning": reasoning or ""},
+                ) as gen:
+                    gen.update(output=response_content[:5000])
+            langfuse.flush()
+            return {"status": "logged", "trace_id": trace_id}
+        except Exception as e:
+            logger.error("Langfuse logging failed: %s", e, exc_info=True)
+            return {"status": "error", "error": str(e)}
+
+    langfuse_payload = await loop.run_in_executor(None, _send_langfuse)
+
+    # --- History append (always; defaults to raw query/response) ---
+    history_payload: dict
+    try:
+        writer = HistoryWriter()
+        eff_intent = (intent or query or "").strip()
+        eff_action = (action or f"Agent: {agent_name}").strip()
+        eff_outcome = (outcome or response_content or "").strip()
+        history_payload = await loop.run_in_executor(
+            None,
+            lambda: writer.append_entry(
+                eff_intent, eff_action, eff_outcome, files, tags, None
+            ),
+        )
     except Exception as e:
-        logger.error(f"Failed to log interaction: {e}")
-        return f"Logging failed (non-critical): {e}"
+        logger.error("History append failed: %s", e, exc_info=True)
+        history_payload = {"status": "error", "error": str(e)}
+
+    payload = {
+        "request_id": request_id,
+        "langfuse": langfuse_payload,
+        "history": history_payload,
+    }
+    debug_log("log_interaction", "res", payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+# --- Memory tools (describe + history) ---
+
+@mcp.tool()
+@observe(name="describe_repo")
+async def describe_repo(
+    ctx: Context,
+    repo_path: Optional[str] = None,
+    force_refresh: bool = False,
+) -> str:
+    """One-shot repo bootstrap.
+
+    Builds a deterministic context bundle from the repo, asks the calling
+    LLM (via MCP sampling) to distill it into a structured summary, and
+    writes the result into the managed Repository Memory section of
+    CLAUDE.md. Future Claude sessions read that section automatically and
+    skip re-exploring the codebase.
+
+    Returns JSON: {status, path, hash, word_count, in_word_budget, summary_preview}.
+    status ∈ {"refreshed", "up-to-date", "error"}.
+    """
+    try:
+        debug_log("describe_repo", "req", {
+            "repo_path": repo_path,
+            "force_refresh": force_refresh,
+        })
+        loop = asyncio.get_running_loop()
+        describer = RepoDescriber(repo_path=repo_path)
+
+        decision = await loop.run_in_executor(None, describer.plan, force_refresh)
+        if not decision.needs_refresh:
+            payload = describer.up_to_date_response(decision)
+            debug_log("describe_repo", "res", payload)
+            return json.dumps(payload, ensure_ascii=False)
+
+        if ctx is None:
+            payload = {
+                "status": "error",
+                "message": "MCP context is required for sampling — describe_repo "
+                           "must be called over a sampling-capable client.",
+            }
+            debug_log("describe_repo", "error", payload)
+            return json.dumps(payload, ensure_ascii=False)
+
+        prompt = await loop.run_in_executor(None, describer.build_prompt)
+        summary = await _sample_with_agent(ctx, prompt, "Generate the repository overview.")
+        payload = await loop.run_in_executor(
+            None, describer.write_summary, summary, decision.current_hash
+        )
+        debug_log("describe_repo", "res", payload)
+        return json.dumps(payload, ensure_ascii=False)
+    except Exception as e:
+        logger.error("describe_repo failed: %s", e, exc_info=True)
+        payload = {"status": "error", "message": str(e)}
+        debug_log("describe_repo", "error", payload)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+@mcp.tool()
+@observe(name="read_history")
+async def read_history(
+    limit: int = 20,
+    since: Optional[str] = None,
+    query: Optional[str] = None,
+) -> str:
+    """Read recent history entries or run a lazy semantic search.
+
+    - Without ``query``: returns up to ``limit`` newest entries; ``since``
+      (ISO8601 prefix) optionally filters for entries at or after that
+      timestamp.
+    - With ``query``: builds the vector index on first use (or refreshes
+      it if history.md is newer than the stored embeddings), then returns
+      semantically nearest entries with cosine distance.
+
+    Returns JSON:
+      {entries: [{id, timestamp, intent, action?, outcome?, files, tags,
+                  distance? }], total, mode}
+      mode ∈ {"recency", "semantic"}.
+    """
+    try:
+        debug_log("read_history", "req", {"limit": limit, "since": since, "query": query})
+        loop = asyncio.get_running_loop()
+
+        if query:
+            store = HistoryStore()
+            results = await loop.run_in_executor(
+                None,
+                lambda: store.search(query, limit=limit),
+            )
+            payload = {"mode": "semantic", "total": len(results), "entries": results}
+        else:
+            reader = HistoryReader()
+            entries = await loop.run_in_executor(
+                None,
+                lambda: reader.read_recent(limit=limit, since=since),
+            )
+            payload = {
+                "mode": "recency",
+                "total": len(entries),
+                "entries": [e.to_dict() for e in entries],
+            }
+        debug_log("read_history", "res", {"mode": payload["mode"], "total": payload["total"]})
+        return json.dumps(payload, ensure_ascii=False)
+    except Exception as e:
+        logger.error("read_history failed: %s", e, exc_info=True)
+        payload = {"status": "error", "message": str(e)}
+        debug_log("read_history", "error", payload)
+        return json.dumps(payload, ensure_ascii=False)
+
 
 # --- MCP Prompts (slash commands for Claude Desktop) ---
 
@@ -671,6 +847,37 @@ def _register_agent_prompts():
 
 
 _register_agent_prompts()
+
+
+def _register_memory_prompts():
+    """Register slash commands that drive the memory tools.
+
+    Tool names (``describe_repo``, ``read_history``) already occupy those
+    Python identifiers in this module, so each prompt function is defined
+    under a distinct local name and renamed via ``__name__`` before being
+    passed to ``mcp.prompt()`` — same trick used in ``_register_agent_prompts``.
+    """
+
+    def _truthy(arg: str) -> bool:
+        return arg.strip().lower() in ("1", "true", "force", "yes", "y", "on")
+
+    async def describe_cmd(force: str = "") -> list:
+        force_arg = "True" if _truthy(force) else "False"
+        return [UserMessage(
+            "Call the `describe_repo("
+            f"force_refresh={force_arg})` MCP tool now as your only next action. "
+            "Then report the resulting status, hash, word count, and the summary "
+            "preview. Do not call any other tools first."
+        )]
+    describe_cmd.__name__ = "describe_repo"
+    describe_cmd.__doc__ = (
+        "Bootstrap or refresh the Repository Memory section in CLAUDE.md. "
+        "Optional arg: `force=true` to regenerate even if the repo hash is unchanged."
+    )
+    mcp.prompt()(describe_cmd)
+
+
+_register_memory_prompts()
 
 
 def _warmup_embedding_model():

--- a/src/server.py
+++ b/src/server.py
@@ -694,7 +694,7 @@ async def describe_repo(
     skip re-exploring the codebase.
 
     Returns JSON: {status, path, hash, word_count, in_word_budget, summary_preview}.
-    status ∈ {"refreshed", "up-to-date", "error"}.
+    status ∈ {"refreshed", "up-to-date", "rejected", "error"}.
     """
     try:
         debug_log("describe_repo", "req", {

--- a/src/server.py
+++ b/src/server.py
@@ -663,10 +663,14 @@ async def log_interaction(
             return {"status": "error", "error": str(e)}
 
     # Both sinks are independent — run them concurrently.
-    langfuse_payload, history_payload = await asyncio.gather(
-        loop.run_in_executor(None, _send_langfuse),
-        loop.run_in_executor(None, _send_history),
-    )
+    # Bound Langfuse to 10s so a hanging SDK doesn't block the tool response.
+    langfuse_future = loop.run_in_executor(None, _send_langfuse)
+    history_future = loop.run_in_executor(None, _send_history)
+    try:
+        langfuse_payload = await asyncio.wait_for(langfuse_future, timeout=10.0)
+    except asyncio.TimeoutError:
+        langfuse_payload = {"status": "error", "error": "timeout (10s)"}
+    history_payload = await history_future
 
     payload = {
         "request_id": request_id,

--- a/src/server.py
+++ b/src/server.py
@@ -618,7 +618,7 @@ async def log_interaction(
         "request_id": request_id,
         "query_len": len(query or ""),
         "response_len": len(response_content or ""),
-        "curated": bool(intent or action or outcome),
+        "curated": bool(intent or action or outcome or files or tags),
         "files": files or [],
         "tags": tags or [],
     })

--- a/src/server.py
+++ b/src/server.py
@@ -702,7 +702,10 @@ async def describe_repo(
     """
     try:
         # Restrict repo_path to REPO_ROOT to prevent arbitrary filesystem access.
+        # Resolve relative paths against REPO_ROOT (not CWD) for stable behavior.
         if repo_path is not None:
+            if not os.path.isabs(repo_path):
+                repo_path = os.path.join(REPO_ROOT, repo_path)
             resolved = os.path.realpath(repo_path)
             repo_root_resolved = os.path.realpath(REPO_ROOT) + os.sep
             if resolved != repo_root_resolved.rstrip(os.sep) and not resolved.startswith(repo_root_resolved):

--- a/src/server.py
+++ b/src/server.py
@@ -670,10 +670,9 @@ async def log_interaction(
         langfuse_payload = await asyncio.wait_for(langfuse_future, timeout=10.0)
     except asyncio.TimeoutError:
         langfuse_payload = {"status": "error", "error": "timeout (10s)"}
-    try:
-        history_payload = await asyncio.wait_for(history_future, timeout=10.0)
-    except asyncio.TimeoutError:
-        history_payload = {"status": "error", "error": "timeout (10s)"}
+    # History is the critical sink — no timeout, so we never report a false
+    # failure while the thread silently succeeds in the background.
+    history_payload = await history_future
 
     payload = {
         "request_id": request_id,

--- a/src/server.py
+++ b/src/server.py
@@ -32,7 +32,7 @@ from src.engine.enrichment import (
     infer_tier,
     implant_retriever,
 )
-from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD, ROUTER_SIMILARITY_THRESHOLD
+from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD, ROUTER_SIMILARITY_THRESHOLD, REPO_ROOT
 from src.utils.prompt_loader import load_agent_prompt, get_agent_metadata
 from src.utils.debug_logger import debug_log
 from src.memory.describer import RepoDescriber
@@ -697,6 +697,17 @@ async def describe_repo(
     status ∈ {"refreshed", "up-to-date", "rejected", "error"}.
     """
     try:
+        # Restrict repo_path to REPO_ROOT to prevent arbitrary filesystem access.
+        if repo_path is not None:
+            resolved = os.path.realpath(repo_path)
+            repo_root_resolved = os.path.realpath(REPO_ROOT)
+            if not resolved.startswith(repo_root_resolved):
+                payload = {
+                    "status": "error",
+                    "message": f"repo_path must be within {REPO_ROOT}",
+                }
+                return json.dumps(payload, ensure_ascii=False)
+
         debug_log("describe_repo", "req", {
             "repo_path": repo_path,
             "force_refresh": force_refresh,
@@ -758,6 +769,7 @@ async def read_history(
     - semantic: {id, distance, document, timestamp, intent, tags}.
     """
     try:
+        limit = max(1, min(limit, 500))
         debug_log("read_history", "req", {"limit": limit, "since": since, "query": query})
         loop = asyncio.get_running_loop()
 

--- a/src/server.py
+++ b/src/server.py
@@ -670,7 +670,10 @@ async def log_interaction(
         langfuse_payload = await asyncio.wait_for(langfuse_future, timeout=10.0)
     except asyncio.TimeoutError:
         langfuse_payload = {"status": "error", "error": "timeout (10s)"}
-    history_payload = await history_future
+    try:
+        history_payload = await asyncio.wait_for(history_future, timeout=10.0)
+    except asyncio.TimeoutError:
+        history_payload = {"status": "error", "error": "timeout (10s)"}
 
     payload = {
         "request_id": request_id,

--- a/src/utils/langfuse_compat.py
+++ b/src/utils/langfuse_compat.py
@@ -80,6 +80,8 @@ def get_langfuse():
             _langfuse_instance = _RealLangfuse()
             logger.info("Langfuse client initialized")
         except Exception as e:
+            global _langfuse_available
+            _langfuse_available = False
             logger.warning(f"Langfuse init failed, using no-op: {e}")
             _langfuse_instance = _NoopLangfuse()
     else:

--- a/src/utils/langfuse_compat.py
+++ b/src/utils/langfuse_compat.py
@@ -71,7 +71,7 @@ def is_langfuse_configured() -> bool:
 
 def get_langfuse():
     """Returns a real Langfuse client if configured, otherwise a no-op stub."""
-    global _langfuse_instance
+    global _langfuse_instance, _langfuse_available
     if _langfuse_instance is not None:
         return _langfuse_instance
 
@@ -80,7 +80,6 @@ def get_langfuse():
             _langfuse_instance = _RealLangfuse()
             logger.info("Langfuse client initialized")
         except Exception as e:
-            global _langfuse_available
             _langfuse_available = False
             logger.warning(f"Langfuse init failed, using no-op: {e}")
             _langfuse_instance = _NoopLangfuse()

--- a/src/utils/langfuse_compat.py
+++ b/src/utils/langfuse_compat.py
@@ -58,11 +58,9 @@ try:
         logger.info("Langfuse enabled (keys found)")
     else:
         _real_observe_ref = None
-        observe = _noop_decorator
         logger.info("Langfuse disabled (keys not configured)")
 except ImportError:
     _real_observe_ref = None
-    observe = _noop_decorator
     logger.info("Langfuse disabled (library not installed)")
 
 
@@ -74,7 +72,8 @@ def observe(*args, **kwargs):
 
 
 def is_langfuse_configured() -> bool:
-    """True when Langfuse keys are present and the library is importable."""
+    """True when Langfuse keys are present, the library is importable,
+    and client initialization has not failed."""
     return _langfuse_available
 
 

--- a/src/utils/langfuse_compat.py
+++ b/src/utils/langfuse_compat.py
@@ -64,6 +64,11 @@ except ImportError:
     logger.info("Langfuse disabled (library not installed)")
 
 
+def is_langfuse_configured() -> bool:
+    """True when Langfuse keys are present and the library is importable."""
+    return _langfuse_available
+
+
 def get_langfuse():
     """Returns a real Langfuse client if configured, otherwise a no-op stub."""
     global _langfuse_instance

--- a/src/utils/langfuse_compat.py
+++ b/src/utils/langfuse_compat.py
@@ -54,14 +54,23 @@ try:
 
     if has_keys:
         _langfuse_available = True
-        observe = _real_observe
+        _real_observe_ref = _real_observe
         logger.info("Langfuse enabled (keys found)")
     else:
+        _real_observe_ref = None
         observe = _noop_decorator
         logger.info("Langfuse disabled (keys not configured)")
 except ImportError:
+    _real_observe_ref = None
     observe = _noop_decorator
     logger.info("Langfuse disabled (library not installed)")
+
+
+def observe(*args, **kwargs):
+    """Dynamic observe — falls back to no-op if Langfuse init failed at runtime."""
+    if _langfuse_available and _real_observe_ref is not None:
+        return _real_observe_ref(*args, **kwargs)
+    return _noop_decorator(*args, **kwargs)
 
 
 def is_langfuse_configured() -> bool:

--- a/tests/test_describer.py
+++ b/tests/test_describer.py
@@ -1,0 +1,231 @@
+"""Tests for the RepoDescriber: hashing, refresh logic, prompt rendering, write_summary."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.memory import managed_section
+from src.memory.config import DESCRIBE_MARKER_BEGIN, DESCRIBE_MARKER_END
+from src.memory.describer import (
+    DESCRIBE_PROMPT_TEMPLATE,
+    DescribeDecision,
+    RepoDescriber,
+)
+
+
+def _seed_repo(root: Path) -> None:
+    """Minimal but realistic repo structure."""
+    (root / "src").mkdir()
+    (root / "src" / "main.py").write_text("print('hi')\n")
+    (root / "tests").mkdir()
+    (root / "tests" / "test_main.py").write_text("def test(): pass\n")
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n"
+    )
+    (root / "README.md").write_text(
+        "# Demo\n\nA tiny demo repo for tests.\n" + ("line\n" * 10)
+    )
+
+
+@pytest.fixture
+def describer(tmp_path):
+    _seed_repo(tmp_path)
+    return RepoDescriber(repo_path=str(tmp_path))
+
+
+def _valid_summary(marker: str = "v1") -> str:
+    """Build a summary that passes write_summary's sanity gate (>=200 words + ##)."""
+    words = " ".join(["demo"] * 250)
+    return f"## Project Identity\n\n{marker} {words}"
+
+
+class TestHash:
+    def test_deterministic(self, describer):
+        h1 = describer.compute_repo_hash()
+        h2 = describer.compute_repo_hash()
+        assert h1 == h2 and len(h1) == 32
+
+    def test_changes_on_new_top_level_file(self, describer, tmp_path):
+        before = describer.compute_repo_hash()
+        (tmp_path / "Makefile").write_text("all:\n\techo hi\n")
+        after = describer.compute_repo_hash()
+        assert before != after
+
+    def test_changes_on_manifest_edit(self, describer, tmp_path):
+        before = describer.compute_repo_hash()
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = \"demo\"\nversion = \"0.2.0\"\n"
+        )
+        after = describer.compute_repo_hash()
+        assert before != after
+
+    def test_excluded_dirs_dont_affect_hash(self, describer, tmp_path):
+        before = describer.compute_repo_hash()
+        # Adding files inside an excluded dir must not bust the hash
+        excluded = tmp_path / "data"
+        excluded.mkdir()
+        (excluded / "anything.bin").write_text("noise")
+        after = describer.compute_repo_hash()
+        assert before == after
+
+
+class TestPlan:
+    def test_first_run_needs_refresh(self, describer):
+        decision = describer.plan()
+        assert decision.needs_refresh is True
+        assert decision.cached_hash is None
+        assert decision.cached_summary is None
+
+    def test_cached_after_write(self, describer):
+        decision1 = describer.plan()
+        describer.write_summary(_valid_summary(), decision1.current_hash)
+        decision2 = describer.plan()
+        assert decision2.needs_refresh is False
+        assert decision2.cached_hash == decision1.current_hash
+        assert decision2.cached_summary is not None
+
+    def test_force_refresh_overrides_cache(self, describer):
+        decision1 = describer.plan()
+        describer.write_summary(_valid_summary(), decision1.current_hash)
+        decision2 = describer.plan(force_refresh=True)
+        assert decision2.needs_refresh is True
+
+    def test_refresh_when_section_manually_deleted(self, describer):
+        decision1 = describer.plan()
+        describer.write_summary(_valid_summary(), decision1.current_hash)
+        # User wipes the managed section by hand
+        managed_section.remove_section(
+            describer.claude_md_path, DESCRIBE_MARKER_BEGIN, DESCRIBE_MARKER_END
+        )
+        decision2 = describer.plan()
+        assert decision2.needs_refresh is True
+        assert decision2.cached_hash is not None  # hash file still present
+
+
+class TestPromptRendering:
+    def test_prompt_contains_repo_name_and_bundle(self, describer, tmp_path):
+        prompt = describer.build_prompt()
+        assert tmp_path.name in prompt
+        # CONTEXT_BUNDLE expansion includes the manifest content
+        assert "demo" in prompt
+        # And the tree
+        assert "src/" in prompt or "src\n" in prompt
+        # And the README header
+        assert "# Demo" in prompt
+        # No leftover placeholders
+        assert "{CONTEXT_BUNDLE}" not in prompt
+        assert "{REPO_NAME}" not in prompt
+        assert "{WORD_MIN}" not in prompt
+
+    def test_prompt_template_is_a_const_string(self):
+        # Sanity: keep the template string immutable so callers can introspect it
+        assert "{CONTEXT_BUNDLE}" in DESCRIBE_PROMPT_TEMPLATE
+        assert "{REPO_NAME}" in DESCRIBE_PROMPT_TEMPLATE
+
+    def test_excluded_dirs_pruned_from_tree(self, describer, tmp_path):
+        # Add a vendor-ish dir; make sure it does NOT appear in the tree
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "junk.js").write_text("x")
+        prompt = describer.build_prompt()
+        assert "node_modules" not in prompt
+
+
+class TestWriteSummary:
+    def test_writes_managed_section_with_header(self, describer):
+        decision = describer.plan()
+        result = describer.write_summary(_valid_summary(), decision.current_hash)
+        assert result["status"] == "refreshed"
+        assert result["action"] in ("created", "appended", "replaced")
+
+        section = managed_section.read_section(
+            describer.claude_md_path, DESCRIBE_MARKER_BEGIN, DESCRIBE_MARKER_END
+        )
+        assert section is not None
+        # Header injected by write_summary
+        assert "Auto-generated by `describe_repo`" in section
+        assert "Hash:" in section
+        # Body preserved
+        assert "## Project Identity" in section
+
+    def test_word_count_reported(self, describer):
+        decision = describer.plan()
+        body = "## Project Identity\n\n" + " ".join(["word"] * 1000)
+        result = describer.write_summary(body, decision.current_hash)
+        # Heading ("##", "Project", "Identity" = 3 tokens) + 1000 body words
+        assert result["word_count"] == 1003
+        # 1003 ∈ [DESCRIBE_WORD_MIN=800, DESCRIBE_WORD_MAX=1500]
+        assert result["in_word_budget"] is True
+
+    def test_word_count_below_budget_still_persists(self, describer):
+        # 200-799 words: below DESCRIBE_WORD_MIN but above the persistence floor,
+        # so we still write and flag via in_word_budget.
+        decision = describer.plan()
+        body = "## Project Identity\n\n" + " ".join(["ok"] * 250)
+        result = describer.write_summary(body, decision.current_hash)
+        assert result["status"] == "refreshed"
+        assert result["in_word_budget"] is False
+
+    def test_short_summary_rejected(self, describer):
+        """Summaries below MIN_PERSIST_WORD_COUNT must not overwrite CLAUDE.md."""
+        decision = describer.plan()
+        # Has a heading but only a handful of words — likely a failed sample.
+        result = describer.write_summary("## Heading\n\nonly a few words", decision.current_hash)
+        assert result["status"] == "rejected"
+        assert result["word_count"] < RepoDescriber.MIN_PERSIST_WORD_COUNT
+
+    def test_summary_without_heading_rejected(self, describer):
+        """Missing any ## heading => looks like a refusal/garbage, do not persist."""
+        decision = describer.plan()
+        body = " ".join(["word"] * 500)  # enough words but no structure
+        result = describer.write_summary(body, decision.current_hash)
+        assert result["status"] == "rejected"
+        assert result["has_heading"] is False
+
+    def test_rejected_summary_does_not_touch_cache(self, describer):
+        """Sanity check failure must leave any existing cache intact."""
+        decision = describer.plan()
+        # Seed a good summary first.
+        describer.write_summary(_valid_summary("good"), decision.current_hash)
+        # Attempt a bad overwrite.
+        describer.write_summary("trash", decision.current_hash)
+        # Managed section still carries the good summary.
+        section = managed_section.read_section(
+            describer.claude_md_path, DESCRIBE_MARKER_BEGIN, DESCRIBE_MARKER_END
+        )
+        assert section is not None and "good" in section
+
+    def test_idempotent_replace(self, describer):
+        decision = describer.plan()
+        describer.write_summary(_valid_summary("one"), decision.current_hash)
+        describer.write_summary(_valid_summary("two"), decision.current_hash)
+        # Exactly one managed section after the second write
+        with open(describer.claude_md_path) as f:
+            content = f.read()
+        assert content.count(DESCRIBE_MARKER_BEGIN) == 1
+        assert content.count(DESCRIBE_MARKER_END) == 1
+        # Old body gone
+        assert "one demo" not in content
+        assert "two demo" in content
+
+
+class TestUpToDateResponse:
+    def test_includes_preview(self, describer):
+        decision = describer.plan()
+        describer.write_summary(_valid_summary(), decision.current_hash)
+        decision2 = describer.plan()
+        payload = describer.up_to_date_response(decision2)
+        assert payload["status"] == "up-to-date"
+        # First heading line of _valid_summary()
+        assert "Project Identity" in payload["summary_preview"]
+
+
+class TestPathOverrideSafety:
+    def test_does_not_clobber_global_claude_md(self, tmp_path):
+        """When repo_path is overridden, CLAUDE.md/hash default to that subtree."""
+        _seed_repo(tmp_path)
+        d = RepoDescriber(repo_path=str(tmp_path))
+        assert d.claude_md_path.startswith(str(tmp_path))
+        assert d.hash_file.startswith(str(tmp_path))

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -225,7 +225,7 @@ def _numpy_available() -> bool:
     try:
         import numpy  # noqa: F401
         return True
-    except ImportError:
+    except Exception:
         return False
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -187,8 +187,9 @@ class TestRotation:
 class FakeEmbedder:
     """Maps each known phrase to a unit vector pointing along a unique axis.
 
-    Provides deterministic, numpy-free-during-collection embedding for tests.
-    Only imports numpy when actually called.
+    Provides deterministic embedding for tests. Imports numpy in __init__
+    so the ``skipif`` guard can exclude the entire test class when numpy
+    is unavailable.
     """
 
     def __init__(self, vocabulary: list[str], dim: int = 8):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,297 @@
+"""Tests for the history.md writer/reader and the lazy semantic store."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from src.memory.history import (
+    HistoryEntry,
+    HistoryReader,
+    HistoryStore,
+    HistoryWriter,
+)
+
+
+@pytest.fixture
+def history_path(tmp_path):
+    return str(tmp_path / "history.md")
+
+
+@pytest.fixture
+def writer(tmp_path, history_path):
+    return HistoryWriter(
+        history_path=history_path,
+        archive_dir=str(tmp_path / "history"),
+        rotation_kb=512,
+    )
+
+
+# --- Writer ------------------------------------------------------------------
+
+class TestAppend:
+    def test_creates_file_with_header(self, writer, history_path):
+        result = writer.append_entry("intent A", "did A", "ok A")
+        assert result["status"] == "recorded"
+        assert os.path.exists(history_path)
+        with open(history_path) as f:
+            content = f.read()
+        # YAML frontmatter
+        assert content.startswith("---\n")
+        assert "format_version:" in content
+        # Record
+        assert "intent A" in content
+        assert "## " in content
+
+    def test_validation_rejects_empty_fields(self, writer):
+        result = writer.append_entry("", "x", "y")
+        assert result["status"] == "error"
+
+    def test_returns_entry_id(self, writer):
+        r1 = writer.append_entry("intent", "action", "outcome")
+        r2 = writer.append_entry("intent", "action", "outcome2")
+        assert r1["entry_id"] != r2["entry_id"]
+        assert len(r1["entry_id"]) == 12
+
+    def test_entry_id_is_deterministic(self, writer):
+        r1 = writer.append_entry("intent X", "act X", "out X")
+        # Re-instantiate writer to bypass dedup tail-scan
+        os.unlink(writer.history_path)
+        r2 = writer.append_entry("intent X", "act X", "out X")
+        assert r1["entry_id"] == r2["entry_id"]
+
+
+class TestDedup:
+    def test_duplicate_short_circuits(self, writer):
+        r1 = writer.append_entry("same", "same", "same")
+        r2 = writer.append_entry("same", "same", "same")
+        assert r1["status"] == "recorded"
+        assert r2["status"] == "duplicate"
+        assert r2["entry_id"] == r1["entry_id"]
+
+    def test_outside_dedup_window_rerecords(self, tmp_path, history_path):
+        # Tighten window to 1 so the second identical entry slips in once we
+        # have appended a different entry between them.
+        w = HistoryWriter(history_path=history_path, dedup_tail=1)
+        w.append_entry("a", "a", "a")
+        w.append_entry("b", "b", "b")
+        # 'a' is now outside the 1-entry tail window, so it can be re-recorded
+        r = w.append_entry("a", "a", "a")
+        assert r["status"] == "recorded"
+
+
+class TestFormatRoundtrip:
+    def test_files_tags_metadata_roundtrip(self, writer):
+        writer.append_entry(
+            intent="add HistoryStore",
+            action="implemented HistoryStore class",
+            outcome="tests pass",
+            files=["src/memory/history.py", "tests/test_history.py"],
+            tags=["feature", "#memory"],
+            metadata={"phase": 3, "loc": 250},
+        )
+        reader = HistoryReader(writer.history_path)
+        entries = reader.read_recent(limit=10)
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.intent == "add HistoryStore"
+        assert e.files == ["src/memory/history.py", "tests/test_history.py"]
+        # Both tag forms ("feature" and "#memory") are stored as #-prefixed
+        assert any("memory" in t for t in e.tags)
+        assert e.metadata == {"phase": 3, "loc": 250}
+
+
+class TestRecency:
+    def test_recent_order_newest_first(self, writer):
+        writer.append_entry("first", "a", "b")
+        time.sleep(1.05)  # ISO timestamp resolution is seconds
+        writer.append_entry("second", "a", "b")
+        time.sleep(1.05)
+        writer.append_entry("third", "a", "b")
+        reader = HistoryReader(writer.history_path)
+        entries = reader.read_recent(limit=10)
+        assert [e.intent for e in entries] == ["third", "second", "first"]
+
+    def test_limit_caps_results(self, writer):
+        for i in range(5):
+            writer.append_entry(f"intent {i}", "a", "b")
+            time.sleep(0.01)
+        reader = HistoryReader(writer.history_path)
+        assert len(reader.read_recent(limit=3)) == 3
+
+    def test_since_filter(self, writer):
+        writer.append_entry("old", "a", "b")
+        time.sleep(1.05)
+        cutoff = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+        time.sleep(1.05)
+        writer.append_entry("new", "a", "b")
+        reader = HistoryReader(writer.history_path)
+        entries = reader.read_recent(limit=10, since=cutoff)
+        assert [e.intent for e in entries] == ["new"]
+
+
+class TestRotation:
+    def test_triggers_when_threshold_exceeded(self, tmp_path, history_path):
+        archive_dir = str(tmp_path / "history")
+        # 1 KB threshold so the test stays fast
+        w = HistoryWriter(
+            history_path=history_path,
+            archive_dir=archive_dir,
+            rotation_kb=1,
+        )
+        # Each entry adds ~150 bytes; ~10 entries should trip the 1 KB threshold.
+        rotated_to = None
+        for i in range(15):
+            r = w.append_entry(f"intent {i}", "action " * 10, "outcome " * 10)
+            if "rotated_to" in r:
+                rotated_to = r["rotated_to"]
+                break
+        assert rotated_to is not None
+        assert os.path.exists(rotated_to)
+        # Fresh history.md exists and contains a pointer to the archive
+        assert os.path.exists(history_path)
+        with open(history_path) as f:
+            content = f.read()
+        assert "archived to" in content
+        # Archive contains the prior content
+        with open(rotated_to) as f:
+            archived = f.read()
+        assert "intent 0" in archived
+
+    def test_rotation_filename_uses_yyyy_mm(self, tmp_path, history_path):
+        w = HistoryWriter(
+            history_path=history_path,
+            archive_dir=str(tmp_path / "history"),
+            rotation_kb=1,
+        )
+        for i in range(20):
+            r = w.append_entry(f"i{i}", "a" * 200, "o" * 200)
+            if "rotated_to" in r:
+                fname = os.path.basename(r["rotated_to"])
+                # YYYY-MM.md
+                assert len(fname) == 10
+                assert fname[4] == "-"
+                assert fname.endswith(".md")
+                break
+        else:
+            pytest.fail("rotation never triggered")
+
+
+# --- Lazy semantic recall ----------------------------------------------------
+
+class FakeEmbedder:
+    """Maps each known phrase to a unit vector pointing along a unique axis.
+
+    Provides deterministic, numpy-free-during-collection embedding for tests.
+    Only imports numpy when actually called.
+    """
+
+    def __init__(self, vocabulary: list[str], dim: int = 8):
+        import numpy as np
+        self.np = np
+        self.dim = dim
+        # Deterministic axis assignment by hash so the same phrase always
+        # maps to the same axis between embed_texts and embed_query.
+        self._axis = {phrase: hash(phrase) % dim for phrase in vocabulary}
+
+    def _vec(self, text: str):
+        v = self.np.zeros(self.dim, dtype=self.np.float32)
+        # Anchor on whichever vocabulary phrase appears in the text; otherwise
+        # use the text hash directly.
+        for phrase, axis in self._axis.items():
+            if phrase.lower() in text.lower():
+                v[axis] = 1.0
+                return v
+        v[hash(text) % self.dim] = 1.0
+        return v
+
+    def embed_texts(self, texts):
+        return self.np.array([self._vec(t) for t in texts])
+
+    def embed_query(self, text):
+        return self._vec(text)
+
+
+def _numpy_available() -> bool:
+    try:
+        import numpy  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# Skip semantic tests when numpy can't load (NixOS-without-nix-ld scenario);
+# the writer/reader tests above stay valid.
+@pytest.mark.skipif(not _numpy_available(), reason="numpy unavailable in this env")
+class TestSemanticStore:
+    def test_index_lazy_until_search(self, tmp_path, writer):
+        writer.append_entry("first", "a", "b")
+        writer.append_entry("second", "x", "y")
+        store_dir = str(tmp_path / "memory_data")
+        # No file on disk yet
+        assert not os.path.exists(os.path.join(store_dir, "history_store.npz"))
+        # Construct without searching — still nothing on disk
+        store = HistoryStore(history_path=writer.history_path, data_dir=store_dir)
+        assert not os.path.exists(os.path.join(store_dir, "history_store.npz"))
+
+    def test_search_returns_relevant(self, tmp_path, writer):
+        writer.append_entry(
+            intent="add semantic recall",
+            action="wired NumpyVectorStore",
+            outcome="search returns relevant entries",
+        )
+        time.sleep(0.05)
+        writer.append_entry(
+            intent="bake bread",
+            action="kneaded the dough",
+            outcome="loaf was tasty",
+        )
+        store_dir = str(tmp_path / "memory_data")
+        store = HistoryStore(history_path=writer.history_path, data_dir=store_dir)
+
+        embedder = FakeEmbedder(["semantic recall", "bake bread"])
+        results = store.search(
+            "semantic recall",
+            limit=2,
+            embed_query=embedder.embed_query,
+            embed_texts=embedder.embed_texts,
+        )
+        assert len(results) >= 1
+        # Top hit must be the semantic-recall entry
+        assert "semantic recall" in results[0]["intent"].lower()
+
+    def test_index_rebuilds_on_file_change(self, tmp_path, writer):
+        writer.append_entry("seed", "a", "b")
+        store_dir = str(tmp_path / "memory_data")
+        store = HistoryStore(history_path=writer.history_path, data_dir=store_dir)
+        embedder = FakeEmbedder(["seed", "fresh"])
+        store.search(
+            "seed",
+            limit=1,
+            embed_query=embedder.embed_query,
+            embed_texts=embedder.embed_texts,
+        )
+        npz_path = os.path.join(store_dir, "history_store.npz")
+        assert os.path.exists(npz_path)
+        first_mtime = os.path.getmtime(npz_path)
+
+        # Append new entry; ensure history.md mtime is strictly newer
+        time.sleep(1.05)
+        writer.append_entry("fresh", "x", "y")
+        os.utime(writer.history_path, None)
+
+        results = store.search(
+            "fresh",
+            limit=1,
+            embed_query=embedder.embed_query,
+            embed_texts=embedder.embed_texts,
+        )
+        assert results
+        assert "fresh" in results[0]["intent"].lower()
+        # Store file was rewritten
+        assert os.path.getmtime(npz_path) >= first_mtime

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -194,10 +194,13 @@ class FakeEmbedder:
     def __init__(self, vocabulary: list[str], dim: int = 8):
         import numpy as np
         self.np = np
-        self.dim = dim
-        # Deterministic axis assignment by hash so the same phrase always
-        # maps to the same axis between embed_texts and embed_query.
-        self._axis = {phrase: hash(phrase) % dim for phrase in vocabulary}
+        unique_vocabulary = list(dict.fromkeys(vocabulary))
+        # Ensure dimension is large enough to give each phrase its own axis.
+        self.dim = max(dim, len(unique_vocabulary))
+        # Deterministic, collision-free axis assignment by enumeration.
+        self._axis = {
+            phrase: axis for axis, phrase in enumerate(unique_vocabulary)
+        }
 
     def _vec(self, text: str):
         v = self.np.zeros(self.dim, dtype=self.np.float32)

--- a/tests/test_managed_section.py
+++ b/tests/test_managed_section.py
@@ -1,0 +1,138 @@
+"""Tests for the managed-section editor used by describe_repo and init_repo.sh."""
+
+import os
+
+import pytest
+
+from src.memory.managed_section import (
+    DuplicateMarkerError,
+    InvertedMarkersError,
+    PartialMarkerError,
+    read_section,
+    remove_section,
+    upsert_section,
+)
+
+BEGIN = "# >>> TEST SECTION >>>"
+END = "# <<< TEST SECTION <<<"
+
+
+@pytest.fixture
+def md_path(tmp_path):
+    return str(tmp_path / "CLAUDE.md")
+
+
+class TestUpsert:
+    def test_creates_file_when_missing(self, md_path):
+        action = upsert_section(md_path, BEGIN, END, "hello world")
+        assert action == "created"
+        with open(md_path) as f:
+            content = f.read()
+        assert BEGIN in content
+        assert END in content
+        assert "hello world" in content
+
+    def test_appends_when_no_markers(self, md_path):
+        with open(md_path, "w") as f:
+            f.write("# Existing content\n\nLine two\n")
+        action = upsert_section(md_path, BEGIN, END, "added")
+        assert action == "appended"
+        with open(md_path) as f:
+            content = f.read()
+        assert content.startswith("# Existing content")
+        assert "added" in content
+        # Existing content preserved verbatim
+        assert "Line two" in content
+
+    def test_replaces_existing_section(self, md_path):
+        upsert_section(md_path, BEGIN, END, "first version")
+        action = upsert_section(md_path, BEGIN, END, "second version")
+        assert action == "replaced"
+        body = read_section(md_path, BEGIN, END)
+        assert body == "second version"
+        # Exactly one begin and one end marker after replace
+        with open(md_path) as f:
+            content = f.read()
+        assert content.count(BEGIN) == 1
+        assert content.count(END) == 1
+
+    def test_replace_preserves_outside_content(self, md_path):
+        with open(md_path, "w") as f:
+            f.write("# Routing protocol\n\nRouting body\n\n")
+        upsert_section(md_path, BEGIN, END, "memory body v1")
+        upsert_section(md_path, BEGIN, END, "memory body v2")
+        with open(md_path) as f:
+            content = f.read()
+        assert "Routing body" in content
+        assert "memory body v2" in content
+        assert "memory body v1" not in content
+
+    def test_partial_marker_raises(self, md_path):
+        with open(md_path, "w") as f:
+            f.write(f"some text\n{BEGIN}\nbody without end marker\n")
+        with pytest.raises(PartialMarkerError):
+            upsert_section(md_path, BEGIN, END, "new body")
+
+    def test_duplicate_marker_raises(self, md_path):
+        with open(md_path, "w") as f:
+            f.write(f"{BEGIN}\nbody\n{END}\n{BEGIN}\nbody2\n{END}\n")
+        with pytest.raises(DuplicateMarkerError):
+            upsert_section(md_path, BEGIN, END, "new body")
+
+    def test_inverted_markers_raise(self, md_path):
+        with open(md_path, "w") as f:
+            f.write(f"{END}\nbody\n{BEGIN}\n")
+        with pytest.raises(InvertedMarkersError):
+            upsert_section(md_path, BEGIN, END, "new body")
+
+    def test_replace_does_not_grow_blank_lines(self, md_path):
+        upsert_section(md_path, BEGIN, END, "body")
+        for _ in range(5):
+            upsert_section(md_path, BEGIN, END, "body")
+        with open(md_path) as f:
+            content = f.read()
+        # No runs of 3+ consecutive newlines accumulated
+        assert "\n\n\n\n" not in content
+
+    def test_atomic_write_no_temp_left_behind(self, md_path):
+        upsert_section(md_path, BEGIN, END, "body")
+        files_in_dir = os.listdir(os.path.dirname(md_path))
+        assert not any(f.startswith(".managed_section.") for f in files_in_dir)
+
+
+class TestRead:
+    def test_returns_none_when_missing_file(self, tmp_path):
+        result = read_section(str(tmp_path / "nope.md"), BEGIN, END)
+        assert result is None
+
+    def test_returns_none_when_no_section(self, md_path):
+        with open(md_path, "w") as f:
+            f.write("just text\n")
+        assert read_section(md_path, BEGIN, END) is None
+
+    def test_roundtrip_preserves_body(self, md_path):
+        body = "## Section\n\nSome **markdown** with *emphasis*."
+        upsert_section(md_path, BEGIN, END, body)
+        assert read_section(md_path, BEGIN, END) == body
+
+
+class TestRemove:
+    def test_removes_existing_section(self, md_path):
+        with open(md_path, "w") as f:
+            f.write("prefix line\n")
+        upsert_section(md_path, BEGIN, END, "body")
+        removed = remove_section(md_path, BEGIN, END)
+        assert removed is True
+        with open(md_path) as f:
+            content = f.read()
+        assert BEGIN not in content
+        assert END not in content
+        assert "prefix line" in content
+
+    def test_returns_false_when_no_section(self, md_path):
+        with open(md_path, "w") as f:
+            f.write("plain content\n")
+        assert remove_section(md_path, BEGIN, END) is False
+
+    def test_returns_false_when_file_missing(self, tmp_path):
+        assert remove_section(str(tmp_path / "nope.md"), BEGIN, END) is False


### PR DESCRIPTION
## Summary

Adds a **per-repository memory subsystem** to Agents-Core with three MCP tools and a new `src/memory/` package (2,757 lines across 13 files):

- **`describe_repo(force_refresh=False)`** — one-shot repo bootstrap. Builds a deterministic context bundle (tree, manifests, README head), asks the calling LLM via MCP sampling to distill it into a structured summary, and writes the result into a managed *Repository Memory* section of `CLAUDE.md`. Idempotent: re-runs are no-ops unless the repo manifest changes or `force_refresh=True`. Includes sandbox validation (`REPO_ROOT`-scoped, symlink-safe, directory-checked, TOCTOU-resistant).

- **`log_interaction(...)`** — end-of-turn logger (extended from the existing Langfuse-only tool). Always appends a deduped, rotatable action-log entry to `history.md`; optionally sends a Langfuse generation trace. Both sinks run concurrently with independent error handling (Langfuse has a 10s timeout; history is the critical sink with no timeout). Multi-line query/response is collapsed to single-line fields. Thread-safe via `threading.Lock` + `fcntl.flock`.

- **`read_history(limit?, since?, query?)`** — returns recent entries by recency or runs lazy semantic search backed by `NumpyVectorStore`. Module-level cached `HistoryStore` with `threading.Lock`-protected `ensure_index` for concurrent safety.

### New module: `src/memory/`

| File | Purpose |
|---|---|
| `__init__.py` | Package marker with tool inventory docstring |
| `config.py` | Constants: paths, markers, thresholds (env-overridable rotation threshold) |
| `managed_section.py` | Atomic, marker-bounded section upsert/read/remove for `CLAUDE.md` (public `atomic_write` helper) |
| `describer.py` | `RepoDescriber`: hash → bundle → prompt → sampling → upsert. Symlink-safe, dotfile-filtered, `str.replace`-based prompt rendering |
| `history.py` | `HistoryWriter` (append, dedup via open handle, rotate) + `HistoryReader` (recent, since) + `HistoryStore` (lazy semantic, thread-safe, npz-mtime staleness) |

### Review hardening (24 rounds, ~65 comments from Copilot + Cursor Bugbot)

**Security**: path traversal guard with `os.sep` suffix + `os.path.realpath` + `os.path.isdir` + TOCTOU-resistant canonicalized path passthrough; symlink skipping in tree walk, manifest reads, and README reads; `repo_path` relative resolution against `REPO_ROOT`.

**Correctness**: heading sanity gate accepts `##` and `###`; `str.format` → `str.replace` (curly braces in file contents); `_is_duplicate_from_handle` reads via open fd; dedup IDs in `_rebuild`; `remove_section` leading-line guard; multiline field collapse; `newline=""` for cross-platform `\n`; `limit` clamping and `query` stripping.

**Concurrency**: `threading.Lock` on `HistoryWriter` (intra-process) + `fcntl.flock` (cross-process); `threading.Lock` on `HistoryStore.ensure_index`; `asyncio.wait_for` timeout on Langfuse executor; no timeout on history (critical sink).

**Observability**: `is_langfuse_configured()` tracks init failure; dynamic `observe()` wrapper falls back to no-op; `_langfuse_available` set to `False` on `_RealLangfuse()` exception; `SyntaxWarning`-free global declaration.

**API consistency**: all error responses use `{status: "error", error: ...}`; `describe_repo` status set includes `"rejected"`; `up_to_date_response` includes `word_count`/`in_word_budget`; `read_history` docstring documents both entry shapes; `response_content` param name in README.

**Docs**: full English translation of `docs/memory-subsystem-spec.md`; updated decision table, tool signatures, data-flow diagram; portable paths; spec matches implementation.

### Test coverage

47 tests pass (3 numpy-dependent skipped on hosts without `nix-ld`):
- `tests/test_managed_section.py` — 15 tests: create, replace, append, partial/duplicate/inverted markers, atomic write
- `tests/test_describer.py` — 20 tests: hash, refresh logic, prompt rendering, summary persistence, word count, sanity gate
- `tests/test_history.py` — 12+3 tests: append, dedup, format roundtrip, recency, rotation, semantic store (skipped without numpy)

### Privacy

`history.md` + `history/` are **gitignored by default** to keep raw prompts/responses out of git.

## Test plan

- [x] `pytest tests/test_managed_section.py tests/test_describer.py tests/test_history.py` — 47 passed, 3 skipped
- [x] Import smoke: all new modules import cleanly
- [x] 24 rounds of automated review (Copilot + Cursor Bugbot) — all comments addressed
- [ ] Manual: `describe_repo()` on fresh repo → managed section inserted; re-run → `status: "up-to-date"`
- [ ] Manual: `log_interaction(...)` → entry in `history.md`; duplicate → `status: "duplicate"`
- [ ] Manual: `read_history(query="...")` → semantic match

Generated with [Claude Code](https://claude.com/claude-code)