### PR TITLE
Establishes core routing; enhances repo summarization

### DIFF
--- a/scripts/templates/routing-protocol-core.md
+++ b/scripts/templates/routing-protocol-core.md
@@ -1,0 +1,133 @@
+# CRITICAL: Agents-Core Routing Protocol
+
+IMPORTANT: These instructions OVERRIDE any default behavior. You MUST follow them exactly.
+
+## BLOCKING REQUIREMENT — MCP Routing
+
+**Before answering ANY user query, you MUST call `route_and_load(query)` from the Agents-Core MCP server.** This is not optional. Do NOT answer directly — always route first.
+
+This applies to ALL queries: coding, research, questions, documentation, debugging — everything.
+
+### Routing Flow
+
+1. **ALWAYS call `route_and_load(query)` FIRST** with the user's message.
+   - On multi-turn: pass previous `context_hash` for delta mode.
+
+2. **Handle the response based on status:**
+   - `SUCCESS_SAMPLED` → Display `response` to the user as-is.
+   - `SUCCESS` → Use `system_prompt` as context for your answer.
+   - `ROUTE_REQUIRED` → **STOP all other actions.** Do NOT call any other tools in parallel.
+     Pick best agent from `candidates`, call `get_agent_context(agent_name, query)` as your ONLY next action.
+     Wait for its response before doing anything else.
+   - `NO_CHANGE` → Context unchanged. Keep current persona.
+   - `ERROR` → Answer directly (only in this case).
+
+3. **Post-flight (after EVERY response):**
+   - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
+   - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
+   - Call `log_interaction(agent_name, query, response_content)`.
+
+## Available MCP Tools
+
+| Tool | Purpose |
+|---|---|
+| `route_and_load(query)` | **MUST call first** — routes to best specialist agent |
+| `get_agent_context(agent_name, query)` | Load a specific agent (after ROUTE_REQUIRED) |
+| `load_implants(task_type)` | Load reasoning strategies (debugging/analysis/creative/planning) |
+| `list_agents()` | List all available agents |
+| `log_interaction(...)` | End-of-turn observability logger (Langfuse) |
+| `clear_session_cache()` | Clear routing cache (use when switching contexts) |
+
+## Environment
+
+- MCP server: `Agents-Core` (stdio transport, Python/FastMCP)
+- Agents: `agents/[name]/system_prompt.mdc`
+- Skills: `skills/skill-*.mdc`
+- Implants: `implants/implant-*.mdc`
+- Capabilities: `agents/capabilities/registry.yaml`
+- Config: `.env` (LANGFUSE_* optional, ANTHROPIC_API_KEY for document OCR)
+
+## Fallback (if MCP is unavailable)
+
+If `route_and_load` fails or Agents-Core MCP is not connected:
+1. Read `agents/` to find the right agent directory
+2. Read `agents/[name]/system_prompt.mdc`
+3. Follow the prompt manually
+
+---
+
+## Repository Structure
+
+```
+src/
+  server.py            — MCP server: route_and_load(), get_agent_context(), clear_session_cache()
+  engine/
+    router.py          — SemanticRouter: cache lookup, keyword matching, agent catalog
+    vector_store.py    — NumpyVectorStore: numpy-based cosine similarity store
+    embedder.py        — FastEmbed wrapper (model configurable via EMBEDDING_MODEL env var)
+    config.py          — Thresholds, paths, env-based configuration
+    enrichment.py      — Prompt enrichment with skills/implants by tier (lite/standard/deep)
+    skills.py          — Skill retrieval from vector store
+    implants.py        — Implant retrieval from vector store
+    capabilities.py    — Capability -> skill resolution via registry.yaml
+    language.py        — Language detection (langdetect, 24 languages)
+    context.py         — Context management
+  utils/
+    prompt_loader.py   — Frontmatter parsing, agent metadata, @import resolution
+    debug_logger.py    — JSON debug logging (AGENTS_DEBUG=1)
+    langfuse_compat.py — Optional Langfuse observability
+  schemas/
+    protocol.py        — RouterDecision, AgentRequest, EnrichmentResult
+agents/
+  [name]/system_prompt.mdc — Agent persona with YAML frontmatter (identity, routing, skills)
+  common/agent-schema.json — Frontmatter JSON schema
+  capabilities/registry.yaml — Capability -> skill mapping
+skills/skill-*.mdc         — Compiled skill prompts
+implants/implant-*.mdc     — Cognitive reasoning implants
+tests/
+  test_routing.py      — Routing logic, sticky routing, keyword boosting tests
+  test_vector_store.py — NumpyVectorStore correctness tests
+  test_language.py     — Language detection tests
+```
+
+## Routing Flow (Internal)
+
+```
+Query -> route_and_load()
+  |-- Sticky agent? -> query_nearest() -> distance-based decisions
+  |     |-- d < 0.02 + keyword check: auto-switch (validate with keywords)
+  |     |-- d < 0.05 & same agent + keyword check: confirm or override
+  |     |-- d >= 0.05: ROUTE_REQUIRED (topic change)
+  |     +-- else: keep sticky (stability)
+  +-- No sticky -> lookup_cache() (threshold: d < 0.05)
+        |-- Hit + keyword_veto() confirms -> SUCCESS
+        |-- Hit + keyword_veto() overrides -> use keyword winner
+        |-- Hit + keyword_veto() ambiguous -> ROUTE_REQUIRED
+        |-- Meta-query -> universal_agent (lite tier)
+        +-- Miss -> ROUTE_REQUIRED (LLM picks from candidates)
+```
+
+## Key Thresholds (config.py)
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `ROUTER_SIMILARITY_THRESHOLD` | 0.95 | Cache hit if cosine distance < 0.05 |
+| `STICKY_SWITCH_THRESHOLD` | 0.02 | Auto-switch only for near-duplicate queries |
+| `KEYWORD_OVERRIDE_MIN_HITS` | 1 | Min keyword hits to consider cache override |
+| `KEYWORD_UNIQUENESS_RATIO` | 2.0 | Top agent must have >= 2x hits vs second-best |
+| `SKILLS_RELEVANCE_THRESHOLD` | 0.75 | Cosine distance cutoff for skill retrieval |
+| `IMPLANTS_RELEVANCE_THRESHOLD` | 0.85 | Cosine distance cutoff for implant retrieval |
+| `SESSION_CACHE_MAX_SIZE` | 128 | Max enriched prompt cache entries |
+| `SESSION_CACHE_TTL_SECONDS` | 600 | Prompt cache TTL (10 min) |
+| `ROUTER_CACHE_MAX_SIZE` | 500 | Max routing decisions in vector store (router.py) |
+
+## Cache Storage (data/)
+
+- `router_cache.npz` + `.json` — Semantic routing cache (500 entries max, atomic writes)
+- `skills_store.npz` + `.json` — Skills vector store
+- `implants_store.npz` + `.json` — Implants vector store
+- `.router_cache_model` — Embedding model hash (auto-invalidates cache on model change)
+
+## Debug Logging
+
+Set `AGENTS_DEBUG=1` in `.env` -> JSON logs written to `logs/{date}/` per call.

--- a/src/server.py
+++ b/src/server.py
@@ -743,26 +743,94 @@ async def describe_repo(
             debug_log("describe_repo", "res", payload)
             return json.dumps(payload, ensure_ascii=False)
 
-        if ctx is None:
-            payload = {
-                "status": "error",
-                "error": "MCP context is required for sampling — describe_repo "
-                         "must be called over a sampling-capable client.",
-            }
-            debug_log("describe_repo", "error", payload)
-            return json.dumps(payload, ensure_ascii=False)
-
         prompt = await loop.run_in_executor(None, describer.build_prompt)
-        summary = await _sample_with_agent(ctx, prompt, "Generate the repository overview.")
-        payload = await loop.run_in_executor(
-            None, describer.write_summary, summary, decision.current_hash
-        )
+
+        # Try MCP sampling if context is available.
+        if ctx is not None:
+            try:
+                summary = await _sample_with_agent(ctx, prompt, "Generate the repository overview.")
+                payload = await loop.run_in_executor(
+                    None, describer.write_summary, summary, decision.current_hash
+                )
+                debug_log("describe_repo", "res", payload)
+                return json.dumps(payload, ensure_ascii=False)
+            except Exception as sampling_err:
+                logger.debug("describe_repo: sampling unavailable, returning prompt: %s", sampling_err)
+                debug_log("describe_repo", "sampling_fallback", {"error": str(sampling_err)})
+
+        # Fallback: return the prompt for the calling model to process.
+        payload = {
+            "status": "needs_summary",
+            "repo_hash": decision.current_hash,
+            "repo_path": describer.repo_path,
+            "prompt": prompt,
+            "instruction": (
+                "Sampling is not available. Generate the repository overview by "
+                "following the prompt above, then call write_repo_summary("
+                f'summary=<your output>, repo_hash="{decision.current_hash}"'
+                ") to persist it."
+            ),
+        }
         debug_log("describe_repo", "res", payload)
         return json.dumps(payload, ensure_ascii=False)
     except Exception as e:
         logger.error("describe_repo failed: %s", e, exc_info=True)
         payload = {"status": "error", "error": str(e)}
         debug_log("describe_repo", "error", payload)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+@mcp.tool()
+@observe(name="write_repo_summary")
+async def write_repo_summary(
+    summary: str,
+    repo_hash: str,
+    repo_path: Optional[str] = None,
+) -> str:
+    """Persist a repository summary after describe_repo returned status='needs_summary'.
+
+    Call this with the summary you generated from the prompt and the
+    repo_hash value from the describe_repo response.
+
+    Returns JSON: {status, path, hash, word_count, in_word_budget, summary_preview}.
+    status ∈ {"refreshed", "rejected", "error"}.
+    """
+    try:
+        if repo_path is not None:
+            if not os.path.isabs(repo_path):
+                repo_path = os.path.join(REPO_ROOT, repo_path)
+            resolved = os.path.realpath(repo_path)
+            repo_root_resolved = os.path.realpath(REPO_ROOT) + os.sep
+            if resolved != repo_root_resolved.rstrip(os.sep) and not resolved.startswith(repo_root_resolved):
+                payload = {
+                    "status": "error",
+                    "error": f"repo_path must be within {REPO_ROOT}",
+                }
+                return json.dumps(payload, ensure_ascii=False)
+            if not os.path.isdir(resolved):
+                payload = {
+                    "status": "error",
+                    "error": f"repo_path is not an existing directory: {repo_path}",
+                }
+                return json.dumps(payload, ensure_ascii=False)
+            repo_path = resolved
+
+        debug_log("write_repo_summary", "req", {
+            "repo_path": repo_path,
+            "repo_hash": repo_hash,
+            "summary_len": len(summary),
+        })
+        loop = asyncio.get_running_loop()
+        describer = RepoDescriber(repo_path=repo_path)
+        payload = await loop.run_in_executor(
+            None, describer.write_summary, summary, repo_hash
+        )
+        debug_log("write_repo_summary", "res", payload)
+        return json.dumps(payload, ensure_ascii=False)
+    except Exception as e:
+        logger.error("write_repo_summary failed: %s", e, exc_info=True)
+        payload = {"status": "error", "error": str(e)}
+        debug_log("write_repo_summary", "error", payload)
         return json.dumps(payload, ensure_ascii=False)
 
 


### PR DESCRIPTION
Introduces the Agents-Core routing protocol template to guide agent behavior and tool usage.

Refactors repository description generation to include a robust fallback mechanism, enabling calling models to generate summaries when direct sampling is unavailable. Adds a new `write_repo_summary` tool to persist these externally-generated repository overviews, improving agent context and knowledge management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tool that writes repository memory to disk and changes the `describe_repo` contract to support a non-sampling fallback; incorrect validation or caller usage could lead to unexpected file writes or stale/invalid repo summaries.
> 
> **Overview**
> Adds a new `scripts/templates/routing-protocol-core.md` template that codifies the **mandatory** Agents-Core MCP routing flow (`route_and_load` first, `ROUTE_REQUIRED` handling, and post-flight logging/language rules) for use in agent instructions.
> 
> Updates `describe_repo` in `src/server.py` to no longer hard-fail when MCP sampling context is missing; it now attempts sampling when available, otherwise returns `status: "needs_summary"` with the generated prompt and an instruction for the caller to persist results. Introduces a new MCP tool `write_repo_summary` to accept an externally-generated summary (with repo-path sandbox validation) and persist it via `RepoDescriber.write_summary`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a94ac5a8b10c632749a555e739e2e1af4befc1db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->