### PR TITLE
fix(embedder): move fastembed cache out of /tmp

### DIFF
--- a/env.example
+++ b/env.example
@@ -7,3 +7,7 @@ AGENTS_DEBUG=0                # Set to 1 for JSON debug logging in logs/
 # Embedding model — set interactively during setup (scripts/init_repo.sh)
 # Options: intfloat/multilingual-e5-large (1.1GB), sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 (120MB), sentence-transformers/all-MiniLM-L6-v2 (22MB)
 # EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+
+# Optional: override fastembed model cache directory (default: ~/.cache/fastembed)
+# Must be persistent — avoid /tmp on macOS (launchd auto-cleans it).
+# FASTEMBED_CACHE_DIR=

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -9,6 +9,9 @@ REPO_ROOT = os.path.abspath(os.path.join(ENGINE_DIR, "../.."))
 # Embedding model (set via .env or init_repo.sh)
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
 
+# fastembed cache — persistent by default (macOS launchd wipes /tmp during long downloads).
+FASTEMBED_CACHE_DIR = os.path.expanduser(os.getenv("FASTEMBED_CACHE_DIR", "~/.cache/fastembed"))
+
 # Persistent storage for vector stores
 DATA_DIR = os.path.join(REPO_ROOT, "data")
 

--- a/src/engine/embedder.py
+++ b/src/engine/embedder.py
@@ -12,12 +12,13 @@ import glob
 import logging
 import os
 import shutil
-import tempfile
 import threading
 import warnings
 from typing import List
 
 import numpy as np
+
+from src.engine.config import EMBEDDING_MODEL, FASTEMBED_CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -27,11 +28,10 @@ _model = None
 
 def clear_model_cache(model_name: str) -> None:
     """Remove fastembed's cached files for *model_name* so the next load re-downloads."""
-    cache_dir = os.path.join(tempfile.gettempdir(), "fastembed_cache")
-    if not os.path.isdir(cache_dir):
+    if not os.path.isdir(FASTEMBED_CACHE_DIR):
         return
     suffix = model_name.split("/")[-1]
-    for d in glob.glob(os.path.join(cache_dir, f"models--*{suffix}*")):
+    for d in glob.glob(os.path.join(FASTEMBED_CACHE_DIR, f"models--*{suffix}*")):
         logger.warning("Removing corrupted model cache: %s", d)
         shutil.rmtree(d, ignore_errors=True)
 
@@ -51,14 +51,15 @@ def _get_model():
         with _lock:
             if _model is None:
                 from fastembed import TextEmbedding
-                from src.engine.config import EMBEDDING_MODEL
+
+                os.makedirs(FASTEMBED_CACHE_DIR, exist_ok=True)
 
                 for attempt in range(_MAX_LOAD_RETRIES):
                     try:
                         logger.info("Loading embedding model: %s (attempt %d)", EMBEDDING_MODEL, attempt + 1)
                         with warnings.catch_warnings():
                             warnings.filterwarnings("ignore", message=".*now uses mean pooling.*")
-                            _model = TextEmbedding(model_name=EMBEDDING_MODEL)
+                            _model = TextEmbedding(model_name=EMBEDDING_MODEL, cache_dir=FASTEMBED_CACHE_DIR)
                         logger.info("Embedding model loaded")
                         break
                     except Exception:


### PR DESCRIPTION
macOS launchd periodically wipes /tmp, which corrupts in-flight model
downloads — on the next MCP initialize the server found a partial cache,
tried to re-download, and blew past Claude Desktop's ~60s handshake timeout.

Cache now defaults to ~/.cache/fastembed and is overridable via the
FASTEMBED_CACHE_DIR env var. Both _get_model() and clear_model_cache()
read from the same config constant, so self-healing on corrupt cache
still works.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where embedding models are downloaded/cached and how cache cleanup is performed, which could impact startup in environments with unusual filesystem permissions or disk constraints.
> 
> **Overview**
> Makes FastEmbed’s model cache **persistent by default** by introducing `FASTEMBED_CACHE_DIR` (default `~/.cache/fastembed`) and documenting it in `env.example`.
> 
> Updates the embedder to create and use this directory for `TextEmbedding(..., cache_dir=...)`, and to clear corrupted caches from the same location instead of `/tmp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb4f5034fd04ca3ac8426759dae8a79e8dd8280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->