### PR TITLE
Adds user consent for LLM instruction injection

### DIFF
--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -497,10 +497,20 @@ if !errorlevel! equ 0 (
 
 REM 2. Global CLAUDE.md with routing instructions
 set "CLAUDE_CODE_MD=%CLAUDE_CODE_DIR%\CLAUDE.md"
-set "CLAUDE_MD_SRC=%REPO_ROOT%\CLAUDE.md"
-echo   %GREEN%^>%NC% Configuring global CLAUDE.md...
+set "CLAUDE_MD_SRC=%REPO_ROOT%\scripts\templates\routing-protocol-core.md"
+
+echo(
+echo   %CYAN%Agents-Core wants to add routing instructions to:%NC%
+echo     %CLAUDE_CODE_MD%
+echo(
+set /p "_ALLOW_MD=  Allow? [Y/n]: "
+if /i "!_ALLOW_MD!"=="n" (
+    echo   %YELLOW%WARNING:%NC% Skipped CLAUDE.md injection — instructions will be printed at the end
+    goto :skip_claude_code
+)
+
 if not exist "%CLAUDE_MD_SRC%" (
-    echo   %YELLOW%WARNING:%NC% CLAUDE.md not found in repo root, skipping
+    echo   %YELLOW%WARNING:%NC% Template not found at %CLAUDE_MD_SRC%, skipping
     goto :skip_claude_code
 )
 
@@ -568,6 +578,26 @@ if exist "%ENV_FILE%" (
     )
 )
 if "!_API_KEY_OK!"=="false" echo   %YELLOW%WARNING:%NC% ANTHROPIC_API_KEY not configured - document OCR will be unavailable
+
+echo   To enable repository memory ^& history in a project:
+echo      Run %CYAN%describe_repo()%NC% in your first Claude session.
+echo      This generates a compressed repo overview in CLAUDE.md.
+echo      History logging (history.md) is configured automatically via log_interaction.
+echo(
+
+REM ============== LLM Instructions Block ==============
+set "TEMPLATE_FILE=%REPO_ROOT%\scripts\templates\routing-protocol-core.md"
+if exist "%TEMPLATE_FILE%" (
+    echo %CYAN%=========================================%NC%
+    echo(
+    echo   %GREEN%Add the following to your LLM's instruction file%NC%
+    echo   (CLAUDE.md for Claude, .cursorrules for Cursor, etc.^):
+    echo(
+    echo %CYAN%-----------------------------------------%NC%
+    type "%TEMPLATE_FILE%"
+    echo %CYAN%-----------------------------------------%NC%
+    echo(
+)
 
 echo %GREEN%Happy coding%NC%
 echo(

--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -422,6 +422,9 @@ echo   %GREEN%+%NC% Claude Desktop detected
 :detect_claude_code
 REM --- Detect Claude Code ---
 set "CLAUDE_CODE_DETECTED=false"
+REM Tracks whether the routing section was successfully injected into Claude Code's
+REM global CLAUDE.md — gates the final fallback "LLM Instructions Block".
+set "CLAUDE_MD_CONFIGURED=false"
 where claude >nul 2>&1
 if !errorlevel! equ 0 set "CLAUDE_CODE_DETECTED=true"
 if exist "%USERPROFILE%\.claude.json" set "CLAUDE_CODE_DETECTED=true"
@@ -523,6 +526,7 @@ if exist "%CLAUDE_CODE_MD%" (
 "%PYTHON_ABS%" "%HELPERS%\inject_claude_md.py" "%CLAUDE_CODE_MD%" "%CLAUDE_MD_SRC%"
 if !errorlevel! equ 0 (
     echo   %GREEN%+%NC% Global CLAUDE.md configured
+    set "CLAUDE_MD_CONFIGURED=true"
 ) else (
     echo   %RED%x%NC% Failed to configure CLAUDE.md
 )
@@ -582,12 +586,16 @@ if "!_API_KEY_OK!"=="false" echo   %YELLOW%WARNING:%NC% ANTHROPIC_API_KEY not co
 echo   To enable repository memory ^& history in a project:
 echo      Run %CYAN%describe_repo()%NC% in your first Claude session.
 echo      This generates a compressed repo overview in CLAUDE.md.
-echo      History logging (history.md) is configured automatically via log_interaction.
+echo      History is appended to history.md each turn via log_interaction(...) (called by Claude per the routing protocol).
 echo(
 
 REM ============== LLM Instructions Block ==============
+REM Printed only as a fallback — when the routing section could not be injected
+REM into Claude Code's global CLAUDE.md (Claude Code not detected, consent denied,
+REM template missing, or injection failed). When injection succeeded, the user
+REM already has these instructions in place and does not need to paste them manually.
 set "TEMPLATE_FILE=%REPO_ROOT%\scripts\templates\routing-protocol-core.md"
-if exist "%TEMPLATE_FILE%" (
+if not "!CLAUDE_MD_CONFIGURED!"=="true" if exist "%TEMPLATE_FILE%" (
     echo %CYAN%=========================================%NC%
     echo(
     echo   %GREEN%Add the following to your LLM's instruction file%NC%

--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -506,6 +506,9 @@ echo(
 echo   %CYAN%Agents-Core wants to add routing instructions to:%NC%
 echo     %CLAUDE_CODE_MD%
 echo(
+REM Default to Y so an empty Enter (or an inherited env var) doesn't flip the
+REM decision — set /p leaves the variable unchanged on empty input.
+set "_ALLOW_MD=Y"
 set /p "_ALLOW_MD=  Allow? [Y/n]: "
 REM Accept any input starting with n/N as denial ("n", "no", "NO", "No", etc.).
 if /i "!_ALLOW_MD:~0,1!"=="n" (

--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -599,11 +599,18 @@ set "TEMPLATE_FILE=%REPO_ROOT%\scripts\templates\routing-protocol-core.md"
 if not "!CLAUDE_MD_CONFIGURED!"=="true" if exist "%TEMPLATE_FILE%" (
     echo %CYAN%=========================================%NC%
     echo(
-    echo   %GREEN%Add the following to your LLM's instruction file%NC%
-    echo   (CLAUDE.md for Claude, .cursorrules for Cursor, etc.^):
+    echo   %GREEN%Add the following block to your LLM's instruction file%NC%
+    echo   (CLAUDE.md for Claude, .cursorrules for Cursor, etc.^).
+    echo   %YELLOW%Keep the BEGIN/END marker lines intact%NC% so a later script
+    echo   run can replace the section instead of appending a duplicate.
     echo(
     echo %CYAN%-----------------------------------------%NC%
+    REM Markers must match scripts\_helpers\inject_claude_md.py (MARKER_BEGIN/MARKER_END).
+    echo # ^>^>^> Agents-Core Routing Protocol (managed by init_repo) ^>^>^>
+    echo(
     type "%TEMPLATE_FILE%"
+    echo(
+    echo # ^<^<^< Agents-Core Routing Protocol (managed by init_repo) ^<^<^<
     echo %CYAN%-----------------------------------------%NC%
     echo(
 )

--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -585,8 +585,11 @@ if exist "%ENV_FILE%" (
 if "!_API_KEY_OK!"=="false" echo   %YELLOW%WARNING:%NC% ANTHROPIC_API_KEY not configured - document OCR will be unavailable
 
 echo   To enable repository memory ^& history in a project:
-echo      Run %CYAN%describe_repo()%NC% in your first Claude session.
-echo      This generates a compressed repo overview in CLAUDE.md.
+echo      Run %CYAN%describe_repo()%NC% in your first Claude session inside that repo.
+echo      It writes a compressed overview into the repo's own CLAUDE.md
+echo      (managed section -- not the global %%USERPROFILE%%\.claude\CLAUDE.md^).
+echo      If MCP sampling is unavailable it returns %CYAN%status="needs_summary"%NC%
+echo      and you finalize the write with %CYAN%write_repo_summary(...)%NC%.
 echo      History is appended to history.md each turn via log_interaction(...) (called by Claude per the routing protocol).
 echo(
 

--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -507,7 +507,8 @@ echo   %CYAN%Agents-Core wants to add routing instructions to:%NC%
 echo     %CLAUDE_CODE_MD%
 echo(
 set /p "_ALLOW_MD=  Allow? [Y/n]: "
-if /i "!_ALLOW_MD!"=="n" (
+REM Accept any input starting with n/N as denial ("n", "no", "NO", "No", etc.).
+if /i "!_ALLOW_MD:~0,1!"=="n" (
     echo   %YELLOW%WARNING:%NC% Skipped CLAUDE.md injection — instructions will be printed at the end
     goto :skip_claude_code
 )

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -32,6 +32,12 @@ PYTHON_MIN_VERSION="3.10"
 PYTHON_MAX_VERSION_MAJOR="3"
 PYTHON_MAX_VERSION_MINOR="13" # 3.13 is the first unsafe version
 
+# Canonical managed-section markers — must match scripts/_helpers/inject_claude_md.py.
+# Referenced both by the CLAUDE.md injector and by the fallback instructions block
+# so users can paste the fallback verbatim and have future runs replace (not duplicate) it.
+MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo) >>>"
+MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo) <<<"
+
 # NixOS detection: Nix Python uses /nix/store linker, so nix-ld doesn't help it.
 # We pass LD_LIBRARY_PATH via MCP env config (not globally — that breaks Firefox etc.)
 IS_NIXOS=false
@@ -301,7 +307,7 @@ if [ -d "$VENV_PATH" ]; then
     print_warn "Do you want to recreate it and reinstall all packages?"
     read -p "  Reinstall? [y/N]: " -r
     echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [[ $REPLY =~ ^[Yy] ]]; then
         print_step "Removing existing venv..."
         rm -rf "$VENV_PATH"
         print_step "Creating fresh virtual environment using $SELECTED_PYTHON..."
@@ -596,10 +602,7 @@ else
         # 2. Global CLAUDE.md with routing instructions (append, not overwrite)
         CLAUDE_CODE_MD="$CLAUDE_CODE_DIR/CLAUDE.md"
         CLAUDE_MD_SRC="$REPO_ROOT/scripts/templates/routing-protocol-core.md"
-        # Markers to delimit managed section (platform-agnostic)
-        MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo) >>>"
-        MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo) <<<"
-        # Legacy markers — recognized for backward compat
+        # Legacy markers — recognized for backward compat (current markers live at the top of this script)
         LEGACY_MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo.sh) >>>"
         LEGACY_MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo.sh) <<<"
 
@@ -879,11 +882,17 @@ TEMPLATE_FILE="$REPO_ROOT/scripts/templates/routing-protocol-core.md"
 if [ "${CLAUDE_MD_CONFIGURED:-false}" != "true" ] && [ -f "$TEMPLATE_FILE" ]; then
     echo -e "${CYAN}════════════════════════════════════════════════════════════${NC}"
     echo ""
-    echo -e "  ${GREEN}Add the following to your LLM's instruction file${NC}"
-    echo -e "  (CLAUDE.md for Claude, .cursorrules for Cursor, etc.):"
+    echo -e "  ${GREEN}Add the following block to your LLM's instruction file${NC}"
+    echo -e "  (CLAUDE.md for Claude, .cursorrules for Cursor, etc.)."
+    echo -e "  ${YELLOW}Keep the BEGIN/END marker lines intact${NC} so a later script"
+    echo -e "  run can replace the section instead of appending a duplicate."
     echo ""
     echo -e "${CYAN}────────────────────────────────────────────────────────────${NC}"
+    echo "$MARKER_BEGIN"
+    echo ""
     cat "$TEMPLATE_FILE"
+    echo ""
+    echo "$MARKER_END"
     echo -e "${CYAN}────────────────────────────────────────────────────────────${NC}"
     echo ""
 fi

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -608,7 +608,7 @@ else
         echo -e "  ${CYAN}Agents-Core wants to add routing instructions to:${NC}"
         echo "    $CLAUDE_CODE_MD"
         echo ""
-        read -p "  Allow? [Y/n]: " -n 1 -r
+        read -p "  Allow? [Y/n]: " -r
         echo ""
 
         CLAUDE_MD_CONFIGURED=false
@@ -732,7 +732,7 @@ with open(md_path, 'w') as f:
             echo -e "  ${CYAN}Agents-Core wants to add a routing reminder to Claude Code memory:${NC}"
             echo "    $MEMORY_FILE"
             echo ""
-            read -p "  Allow? [Y/n]: " -n 1 -r
+            read -p "  Allow? [Y/n]: " -r
             echo ""
             if [[ $REPLY =~ ^[Nn]$ ]]; then
                 print_warn "Skipped memory file"
@@ -866,13 +866,17 @@ STEP=$((STEP + 1))
 echo "  $STEP. To enable repository memory & history in a project:"
 echo -e "     Run ${CYAN}describe_repo()${NC} in your first Claude session."
 echo "     This generates a compressed repo overview in CLAUDE.md."
-echo "     History logging (history.md) is configured automatically via log_interaction."
+echo "     History is appended to history.md each turn via log_interaction(...) (called by Claude per the routing protocol)."
 echo ""
 
 # ============== LLM Instructions Block ==============
+# Printed only as a fallback — when the routing section could not be injected
+# into Claude Code's global CLAUDE.md (Claude Code not detected, consent denied,
+# template missing, or injection failed). When injection succeeded, the user
+# already has these instructions in place and does not need to paste them manually.
 
 TEMPLATE_FILE="$REPO_ROOT/scripts/templates/routing-protocol-core.md"
-if [ -f "$TEMPLATE_FILE" ]; then
+if [ "${CLAUDE_MD_CONFIGURED:-false}" != "true" ] && [ -f "$TEMPLATE_FILE" ]; then
     echo -e "${CYAN}════════════════════════════════════════════════════════════${NC}"
     echo ""
     echo -e "  ${GREEN}Add the following to your LLM's instruction file${NC}"

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -595,7 +595,7 @@ else
 
         # 2. Global CLAUDE.md with routing instructions (append, not overwrite)
         CLAUDE_CODE_MD="$CLAUDE_CODE_DIR/CLAUDE.md"
-        CLAUDE_MD_SRC="$REPO_ROOT/CLAUDE.md"
+        CLAUDE_MD_SRC="$REPO_ROOT/scripts/templates/routing-protocol-core.md"
         # Markers to delimit managed section (platform-agnostic)
         MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo) >>>"
         MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo) <<<"
@@ -603,10 +603,19 @@ else
         LEGACY_MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo.sh) >>>"
         LEGACY_MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo.sh) <<<"
 
-        print_step "Configuring global CLAUDE.md ($CLAUDE_CODE_MD)..."
+        # --- Ask permission before modifying instruction files ---
+        echo ""
+        echo -e "  ${CYAN}Agents-Core wants to add routing instructions to:${NC}"
+        echo "    $CLAUDE_CODE_MD"
+        echo ""
+        read -p "  Allow? [Y/n]: " -n 1 -r
+        echo ""
 
         CLAUDE_MD_CONFIGURED=false
-        if [ -f "$CLAUDE_MD_SRC" ]; then
+        if [[ $REPLY =~ ^[Nn]$ ]]; then
+            print_warn "Skipped CLAUDE.md injection — instructions will be printed at the end"
+        elif [ -f "$CLAUDE_MD_SRC" ]; then
+            print_step "Configuring global CLAUDE.md ($CLAUDE_CODE_MD)..."
             SECTION_CONTENT=$(cat "$CLAUDE_MD_SRC")
 
             if [ -f "$CLAUDE_CODE_MD" ]; then
@@ -709,7 +718,7 @@ with open(md_path, 'w') as f:
                 CLAUDE_MD_CONFIGURED=true
             fi
         else
-            print_warn "CLAUDE.md not found in repo root, skipping"
+            print_warn "Template not found at $CLAUDE_MD_SRC, skipping"
         fi
 
         # 3. Global memory — persistent reminder to always call route_and_load
@@ -719,6 +728,15 @@ with open(md_path, 'w') as f:
 
         # Only configure memory if the global CLAUDE.md routing section was successfully written
         if [ "$CLAUDE_MD_CONFIGURED" = true ]; then
+            echo ""
+            echo -e "  ${CYAN}Agents-Core wants to add a routing reminder to Claude Code memory:${NC}"
+            echo "    $MEMORY_FILE"
+            echo ""
+            read -p "  Allow? [Y/n]: " -n 1 -r
+            echo ""
+            if [[ $REPLY =~ ^[Nn]$ ]]; then
+                print_warn "Skipped memory file"
+            else
             print_step "Configuring global Claude Code memory ($CLAUDE_MEMORY_DIR)..."
 
             mkdir -p "$CLAUDE_MEMORY_DIR"
@@ -759,6 +777,7 @@ MEMORY_EOF
                 echo "$MEMORY_ENTRY" > "$MEMORY_INDEX"
                 print_success "MEMORY.md index created"
             fi
+            fi  # end: memory consent
         else
             print_warn "Skipping memory setup — global CLAUDE.md routing section was not configured"
         fi
@@ -841,6 +860,28 @@ if [ -f "$ENV_FILE" ]; then
     if [ -z "$ANTHROPIC_API_KEY" ] || [ "$ANTHROPIC_API_KEY" = "sk-ant-..." ]; then
         print_warn "ANTHROPIC_API_KEY not configured — document OCR will be unavailable"
     fi
+fi
+
+STEP=$((STEP + 1))
+echo "  $STEP. To enable repository memory & history in a project:"
+echo -e "     Run ${CYAN}describe_repo()${NC} in your first Claude session."
+echo "     This generates a compressed repo overview in CLAUDE.md."
+echo "     History logging (history.md) is configured automatically via log_interaction."
+echo ""
+
+# ============== LLM Instructions Block ==============
+
+TEMPLATE_FILE="$REPO_ROOT/scripts/templates/routing-protocol-core.md"
+if [ -f "$TEMPLATE_FILE" ]; then
+    echo -e "${CYAN}════════════════════════════════════════════════════════════${NC}"
+    echo ""
+    echo -e "  ${GREEN}Add the following to your LLM's instruction file${NC}"
+    echo -e "  (CLAUDE.md for Claude, .cursorrules for Cursor, etc.):"
+    echo ""
+    echo -e "${CYAN}────────────────────────────────────────────────────────────${NC}"
+    cat "$TEMPLATE_FILE"
+    echo -e "${CYAN}────────────────────────────────────────────────────────────${NC}"
+    echo ""
 fi
 
 echo -e "${GREEN}Happy coding! 🚀${NC}"

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -299,7 +299,7 @@ if [ -d "$VENV_PATH" ]; then
 
     echo ""
     print_warn "Do you want to recreate it and reinstall all packages?"
-    read -p "  Reinstall? [y/N]: " -n 1 -r
+    read -p "  Reinstall? [y/N]: " -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         print_step "Removing existing venv..."
@@ -612,7 +612,7 @@ else
         echo ""
 
         CLAUDE_MD_CONFIGURED=false
-        if [[ $REPLY =~ ^[Nn]$ ]]; then
+        if [[ $REPLY =~ ^[Nn] ]]; then
             print_warn "Skipped CLAUDE.md injection — instructions will be printed at the end"
         elif [ -f "$CLAUDE_MD_SRC" ]; then
             print_step "Configuring global CLAUDE.md ($CLAUDE_CODE_MD)..."
@@ -734,7 +734,7 @@ with open(md_path, 'w') as f:
             echo ""
             read -p "  Allow? [Y/n]: " -r
             echo ""
-            if [[ $REPLY =~ ^[Nn]$ ]]; then
+            if [[ $REPLY =~ ^[Nn] ]]; then
                 print_warn "Skipped memory file"
             else
             print_step "Configuring global Claude Code memory ($CLAUDE_MEMORY_DIR)..."

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -298,9 +298,6 @@ if [ -d "$VENV_PATH" ]; then
 
     if [ "$VENV_PYTHON_VER" != "unknown" ] && [ "$VENV_PYTHON_VER" != "$(get_python_version $SELECTED_PYTHON)" ]; then
          print_warn "Venv python version ($VENV_PYTHON_VER) differs from selected ($SELECTED_PYTHON)"
-         RECREATE_DEFAULT="y"
-    else
-         RECREATE_DEFAULT="N"
     fi
 
     echo ""
@@ -867,8 +864,11 @@ fi
 
 STEP=$((STEP + 1))
 echo "  $STEP. To enable repository memory & history in a project:"
-echo -e "     Run ${CYAN}describe_repo()${NC} in your first Claude session."
-echo "     This generates a compressed repo overview in CLAUDE.md."
+echo -e "     Run ${CYAN}describe_repo()${NC} in your first Claude session inside that repo."
+echo "     It writes a compressed overview into the repo's own CLAUDE.md"
+echo "     (managed section — not the global ~/.claude/CLAUDE.md)."
+echo -e "     If MCP sampling is unavailable it returns ${CYAN}status=\"needs_summary\"${NC}"
+echo -e "     and you finalize the write with ${CYAN}write_repo_summary(...)${NC}."
 echo "     History is appended to history.md each turn via log_interaction(...) (called by Claude per the routing protocol)."
 echo ""
 


### PR DESCRIPTION
Prompts users before modifying global CLAUDE.md with routing instructions and configuring Claude Code memory.

If consent is denied, skips automatic injection and instead prints the relevant LLM instructions to the console, allowing for manual configuration and greater user control. Updates the source of these instructions to a dedicated template file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes repository init scripts that modify user-scoped Claude Code config/memory files and alters the injection flow, which could affect developer onboarding and local environment setup if the new prompts or fallback logic misbehave.
> 
> **Overview**
> Adds explicit user consent prompts in `init_repo.sh` and `init_repo.bat` before injecting the Agents-Core routing section into Claude Code’s global `CLAUDE.md`, and (on Unix) before writing the Claude Code memory reminder file.
> 
> Switches the injected content source from the repo-root `CLAUDE.md` to a dedicated template `scripts/templates/routing-protocol-core.md`, standardizes the managed-section markers, and prints a **fallback “LLM Instructions Block”** to the console when injection is skipped or fails so users can manually paste the managed section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445030f3de07cf69ef7535777940c2112e170b51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->