### PR TITLE
fix(init): bail out cleanly with issue-tracker guidance

### DIFF
--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -16,6 +16,9 @@ REM   --help         Show this help message
 setlocal enabledelayedexpansion
 chcp 65001 >nul 2>&1
 
+REM Where users should report unexpected script failures (see :fatal_exit at end).
+set "REPO_URL_ISSUES=https://github.com/WonderMr/Agents/issues"
+
 REM ============== ANSI Colors ==============
 REM Generate ESC character (0x1B) for ANSI codes (Windows 10+)
 REM Using PowerShell to reliably emit the ESC char
@@ -127,8 +130,9 @@ goto :env_done
 echo   %GREEN%^>%NC% Creating .env from env.example...
 copy /Y "%ENV_EXAMPLE%" "%ENV_FILE%" >nul
 if !errorlevel! neq 0 (
-    echo   %RED%x%NC% Failed to create .env from env.example
-    exit /b 1
+    set "_FATAL_EC=!errorlevel!"
+    set "_FATAL_CTX=Failed to create .env from env.example (copy)"
+    goto :fatal_exit
 )
 echo   %GREEN%+%NC% .env created successfully
 echo(
@@ -191,8 +195,9 @@ echo   %GREEN%^>%NC% Creating fresh virtual environment using %SELECTED_PYTHON%.
 
 :venv_activate
 if not exist "%VENV_PATH%\Scripts\python.exe" (
-    echo   %RED%x%NC% Venv python not found: %VENV_PATH%\Scripts\python.exe
-    exit /b 1
+    set "_FATAL_EC=1"
+    set "_FATAL_CTX=Venv python not found after creation: %VENV_PATH%\Scripts\python.exe"
+    goto :fatal_exit
 )
 echo   %GREEN%^>%NC% Activating virtual environment...
 call "%VENV_PATH%\Scripts\activate.bat" 2>nul
@@ -212,16 +217,18 @@ echo %CYAN%===============================%NC%
 echo   %GREEN%^>%NC% Upgrading pip...
 "%VENV_PATH%\Scripts\python.exe" -m pip install --upgrade pip
 if !errorlevel! neq 0 (
-    echo   %RED%x%NC% Failed to upgrade pip
-    exit /b 1
+    set "_FATAL_EC=!errorlevel!"
+    set "_FATAL_CTX=Failed to upgrade pip"
+    goto :fatal_exit
 )
 echo(
 
 echo   %GREEN%^>%NC% Installing requirements (this may take a few minutes)...
 "%VENV_PATH%\Scripts\python.exe" -m pip install -r "%REPO_ROOT%\requirements.txt"
 if !errorlevel! neq 0 (
-    echo   %RED%x%NC% Failed to install requirements
-    exit /b 1
+    set "_FATAL_EC=!errorlevel!"
+    set "_FATAL_CTX=Failed to install requirements (pip install -r requirements.txt)"
+    goto :fatal_exit
 )
 echo(
 
@@ -302,9 +309,10 @@ set "ENV_FILE=%ENV_FILE%"
 set "NEW_MODEL=!CURRENT_MODEL!"
 "%VENV_PATH%\Scripts\python.exe" "!_TMPPY!"
 if !errorlevel! neq 0 (
+    set "_FATAL_EC=!errorlevel!"
+    set "_FATAL_CTX=Failed to write EMBEDDING_MODEL to .env"
     del /Q "!_TMPPY!" 2>nul
-    echo   %RED%x%NC% Failed to write embedding model to .env
-    exit /b 1
+    goto :fatal_exit
 )
 del /Q "!_TMPPY!" 2>nul
 echo   %GREEN%+%NC% Embedding model: !CURRENT_MODEL!
@@ -624,3 +632,41 @@ if not "!CLAUDE_MD_CONFIGURED!"=="true" if exist "%TEMPLATE_FILE%" (
 echo %GREEN%Happy coding%NC%
 echo(
 exit /b 0
+
+REM ============== Fatal Error Handler ==============
+REM Reachable only via `goto :fatal_exit`. Normal completion falls through
+REM `exit /b 0` above and never reaches this label.
+:fatal_exit
+if not defined _FATAL_EC  set "_FATAL_EC=1"
+if not defined _FATAL_CTX set "_FATAL_CTX=unknown failure"
+echo(
+echo %RED%================================================================%NC%
+echo %RED%  FATAL: init_repo.bat aborted unexpectedly%NC%
+echo %RED%================================================================%NC%
+echo(
+echo   Exit code : !_FATAL_EC!
+echo   Context   : !_FATAL_CTX!
+echo(
+echo   %CYAN%Please open an issue:%NC% %REPO_URL_ISSUES%/new
+echo(
+echo   Copy/paste into the issue form:
+echo(
+echo   -- Title --
+echo   [init_repo.bat] !_FATAL_CTX! (exit !_FATAL_EC!)
+echo(
+echo   -- Body --
+echo   ### Environment
+for /f "tokens=*" %%V in ('ver') do echo   - Windows: %%V
+if defined SELECTED_PYTHON echo   - Python: !SELECTED_PYTHON! ^(!PY_VER!^)
+echo(
+echo   ### Failure
+echo   - Exit code: !_FATAL_EC!
+echo   - Context: !_FATAL_CTX!
+echo(
+echo   ### How to reproduce
+echo   ^<steps -- flags passed, context^>
+echo(
+echo   ### Logs
+echo   ^<paste the last ~50 lines of output above^>
+echo(
+exit /b !_FATAL_EC!

--- a/scripts/init_repo.bat
+++ b/scripts/init_repo.bat
@@ -17,7 +17,9 @@ setlocal enabledelayedexpansion
 chcp 65001 >nul 2>&1
 
 REM Where users should report unexpected script failures (see :fatal_exit at end).
+REM Override via AGENTS_ISSUES_URL for divergent forks / GHE mirrors.
 set "REPO_URL_ISSUES=https://github.com/WonderMr/Agents/issues"
+if defined AGENTS_ISSUES_URL set "REPO_URL_ISSUES=%AGENTS_ISSUES_URL%"
 
 REM ============== ANSI Colors ==============
 REM Generate ESC character (0x1B) for ANSI codes (Windows 10+)

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -14,6 +14,8 @@
 #   --help         Show this help message
 
 set -e
+# ERR trap inherited into shell functions/subshells (see _fatal_on_err below).
+set -o errtrace
 
 # ============== ANSI Colors ==============
 RED='\033[0;31m'
@@ -37,6 +39,9 @@ PYTHON_MAX_VERSION_MINOR="13" # 3.13 is the first unsafe version
 # so users can paste the fallback verbatim and have future runs replace (not duplicate) it.
 MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo) >>>"
 MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo) <<<"
+
+# Where users should report unexpected script failures (see _fatal_on_err below).
+REPO_URL_ISSUES="https://github.com/WonderMr/Agents/issues"
 
 # NixOS detection: Nix Python uses /nix/store linker, so nix-ld doesn't help it.
 # We pass LD_LIBRARY_PATH via MCP env config (not globally — that breaks Firefox etc.)
@@ -100,6 +105,63 @@ print_error() {
 print_success() {
     echo -e "  ${GREEN}✓${NC} $1"
 }
+
+# Fatal error handler — fires on any command failing under `set -e` that we did
+# not explicitly handle (e.g. pip crash, python subprocess traceback). Controlled
+# `exit 1` calls (missing Python, missing pip) bypass ERR intentionally: they
+# already print user-actionable guidance, not a bug to report.
+_fatal_on_err() {
+    local exit_code=$?
+    local line_no="${BASH_LINENO[0]}"
+    local cmd="${BASH_COMMAND}"
+    trap - ERR
+    set +e
+
+    local distro=""
+    [ -f /etc/os-release ] && distro=$(. /etc/os-release 2>/dev/null && printf '%s' "${PRETTY_NAME:-unknown}")
+    local py_ver
+    py_ver=$(python --version 2>&1 || echo 'not found')
+
+    {
+        echo ""
+        echo -e "${RED}╔══════════════════════════════════════════════════════════════════╗${NC}"
+        echo -e "${RED}║${NC}  ${RED}FATAL: init_repo.sh aborted unexpectedly${NC}"
+        echo -e "${RED}╚══════════════════════════════════════════════════════════════════╝${NC}"
+        echo ""
+        echo "  Exit code : ${exit_code}"
+        echo "  Line      : ${line_no}"
+        echo "  Command   : ${cmd}"
+        echo ""
+        echo -e "  ${CYAN}Please open an issue:${NC} ${REPO_URL_ISSUES}/new"
+        echo ""
+        echo "  Copy/paste into the issue form:"
+        echo ""
+        echo "  ── Title ──"
+        echo "  [init_repo.sh] aborted at line ${line_no} (exit ${exit_code})"
+        echo ""
+        echo "  ── Body ──"
+        echo "  ### Environment"
+        echo "  - OS: $(uname -srmo 2>/dev/null || uname -a || echo unknown)"
+        [ -n "$distro" ] && echo "  - Distro: ${distro}"
+        echo "  - Python: ${py_ver}"
+        echo "  - Bash: ${BASH_VERSION}"
+        echo ""
+        echo "  ### Failure"
+        echo "  - Exit code: ${exit_code}"
+        echo "  - Line: ${line_no}"
+        echo "  - Command: \`${cmd}\`"
+        echo ""
+        echo "  ### How to reproduce"
+        echo "  <steps — flags passed, context>"
+        echo ""
+        echo "  ### Logs"
+        echo "  <paste the last ~50 lines of output above>"
+        echo ""
+    } >&2
+
+    exit "$exit_code"
+}
+trap _fatal_on_err ERR
 
 check_command() {
     if ! command -v "$1" &> /dev/null; then
@@ -410,7 +472,12 @@ with open(env_path, 'w') as f:
     print_step "Pre-downloading model and indexing skills/implants..."
     print_step "(this may take a few minutes on first run)"
     set +e
-    EMBEDDING_MODEL="$CURRENT_MODEL" REPO_ROOT="$REPO_ROOT" python -c "
+    # NixOS: numpy (via embedder) needs libstdc++ at load time. Same rationale as MCP env above.
+    LD_LIB_ENV=()
+    if [ "$IS_NIXOS" = true ] && [ -n "$NIX_LD_LIB_PATH" ]; then
+        LD_LIB_ENV=(env "LD_LIBRARY_PATH=$NIX_LD_LIB_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}")
+    fi
+    EMBEDDING_MODEL="$CURRENT_MODEL" REPO_ROOT="$REPO_ROOT" "${LD_LIB_ENV[@]}" python -c "
 import sys, os, shutil, glob
 sys.path.insert(0, os.environ['REPO_ROOT'])
 os.environ.setdefault('EMBEDDING_MODEL', '$CURRENT_MODEL')

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -556,10 +556,12 @@ else
 fi
 
 if [ -n "$AGENTS_BASE" ] && [ -d "$AGENTS_BASE" ]; then
-    # `|| echo 0` guards against pipefail tripping on missing skills/implants dirs.
-    AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" 2>/dev/null | wc -l || echo 0)
-    SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l || echo 0)
-    IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l || echo 0)
+    # `|| true` swallows pipefail when skills/implants dirs are absent.
+    # wc -l already emits "0" on empty stdin, so no fallback stdout is needed
+    # (using `|| echo 0` would append a second "0" and corrupt the count).
+    AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" 2>/dev/null | wc -l || true)
+    SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l || true)
+    IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l || true)
 
     print_success "Agents directory found: $AGENTS_BASE"
     echo -e "    • ${CYAN}${AGENT_COUNT}${NC} agents"

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -16,6 +16,9 @@
 set -e
 # ERR trap inherited into shell functions/subshells (see _fatal_on_err below).
 set -o errtrace
+# `pip install | while read` pipelines below would otherwise mask pip failures
+# behind the while-loop's zero exit — surface the failing command instead.
+set -o pipefail
 
 # ============== ANSI Colors ==============
 RED='\033[0;31m'
@@ -112,6 +115,10 @@ print_success() {
 # already print user-actionable guidance, not a bug to report.
 _fatal_on_err() {
     local exit_code=$?
+    # Respect `set +e` regions: the caller has opted out of auto-abort (e.g. the
+    # pre-indexing block, where a failed model download is non-fatal by design).
+    # ERR still fires there, so we must no-op instead of exiting.
+    case $- in *e*) ;; *) return 0 ;; esac
     local line_no="${BASH_LINENO[0]}"
     local cmd="${BASH_COMMAND}"
     trap - ERR
@@ -119,8 +126,14 @@ _fatal_on_err() {
 
     local distro=""
     [ -f /etc/os-release ] && distro=$(. /etc/os-release 2>/dev/null && printf '%s' "${PRETTY_NAME:-unknown}")
+    # Prefer the interpreter the script actually selected — plain `python` may
+    # be missing or a different version on distros that expose only python3.x.
     local py_ver
-    py_ver=$(python --version 2>&1 || echo 'not found')
+    if [ -n "${SELECTED_PYTHON:-}" ]; then
+        py_ver=$($SELECTED_PYTHON --version 2>&1 || echo "${SELECTED_PYTHON} (version query failed)")
+    else
+        py_ver=$(python --version 2>&1 || echo 'not found')
+    fi
 
     {
         echo ""
@@ -543,9 +556,10 @@ else
 fi
 
 if [ -n "$AGENTS_BASE" ] && [ -d "$AGENTS_BASE" ]; then
-    AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" | wc -l)
-    SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
-    IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l)
+    # `|| echo 0` guards against pipefail tripping on missing skills/implants dirs.
+    AGENT_COUNT=$(find "$AGENTS_BASE" -maxdepth 2 -name "system_prompt.mdc" 2>/dev/null | wc -l || echo 0)
+    SKILL_COUNT=$(find "$SKILLS_BASE" -name "*.mdc" 2>/dev/null | wc -l || echo 0)
+    IMPLANT_COUNT=$(find "$IMPLANTS_BASE" -name "*.mdc" 2>/dev/null | wc -l || echo 0)
 
     print_success "Agents directory found: $AGENTS_BASE"
     echo -e "    • ${CYAN}${AGENT_COUNT}${NC} agents"

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -44,7 +44,10 @@ MARKER_BEGIN="# >>> Agents-Core Routing Protocol (managed by init_repo) >>>"
 MARKER_END="# <<< Agents-Core Routing Protocol (managed by init_repo) <<<"
 
 # Where users should report unexpected script failures (see _fatal_on_err below).
-REPO_URL_ISSUES="https://github.com/WonderMr/Agents/issues"
+# Override via `AGENTS_ISSUES_URL` for divergent forks / GHE mirrors. Not derived
+# from `git remote` on purpose: contributors who cloned a personal fork usually
+# still want their installer bug reports to land on upstream.
+REPO_URL_ISSUES="${AGENTS_ISSUES_URL:-https://github.com/WonderMr/Agents/issues}"
 
 # NixOS detection: Nix Python uses /nix/store linker, so nix-ld doesn't help it.
 # We pass LD_LIBRARY_PATH via MCP env config (not globally — that breaks Firefox etc.)
@@ -119,8 +122,18 @@ _fatal_on_err() {
     # pre-indexing block, where a failed model download is non-fatal by design).
     # ERR still fires there, so we must no-op instead of exiting.
     case $- in *e*) ;; *) return 0 ;; esac
+    # Pipeline subshells inherit ERR via errtrace. Defer to the main shell so
+    # we emit exactly one FATAL block; pipefail propagates the subshell's
+    # non-zero exit and refires ERR at the top level.
+    [ "${BASH_SUBSHELL:-0}" -gt 0 ] && return 0
     local line_no="${BASH_LINENO[0]}"
+    # Collapse multi-line commands (e.g. heredoc'd `python -c "..."`) to the
+    # first line + ellipsis so the issue body's inline-code formatting doesn't
+    # break and the copy-paste stays readable.
     local cmd="${BASH_COMMAND}"
+    local cmd_first="${cmd%%$'\n'*}"
+    [ "$cmd" != "$cmd_first" ] && cmd="${cmd_first} …"
+    [ "${#cmd}" -gt 200 ] && cmd="${cmd:0:197}…"
     trap - ERR
     set +e
 


### PR DESCRIPTION
## Summary
- Add a uniform `FATAL` error block to `init_repo.{sh,bat}` that tells the user how to open a GitHub issue (pre-formatted title + body) whenever the installer hits an unexpected failure, so reports land with the information needed to debug.
- Unblock NixOS pre-indexing: pass `LD_LIBRARY_PATH` to the embedder warmup subprocess so Nix Python can load `libstdc++` when importing `numpy` (previously raised `ImportError: libstdc++.so.6: cannot open shared object file`).

## Details
- `init_repo.sh`: `set -o errtrace` + `trap _fatal_on_err ERR`. Handler captures exit code, line, and failing command, then prints the issue URL plus a ready-to-paste title/body. Controlled exits like "No suitable Python version" keep their own messages — user-correctable, not a bug to report.
- `init_repo.bat`: new `:fatal_exit` label behind an `exit /b 0` guard. Unexpected `exit /b 1` sites (env copy, pip upgrade, `pip install -r`, `EMBEDDING_MODEL` write, missing venv Python after creation) now set `_FATAL_CTX` / `_FATAL_EC` and `goto :fatal_exit`.

## Test plan
- [x] `bash -n scripts/init_repo.sh` passes
- [x] Isolated replay: `trap _fatal_on_err ERR` + `set -o errtrace` fires inside a function and prints exit code, line, command, distro, Python, Bash, and issue URL
- [x] NixOS pre-indexing: `LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib ... embed_texts(['warmup'])` returns a 384-d vector
- [x] Windows: run `init_repo.bat`, force a pip install failure, confirm `:fatal_exit` block renders and `%REPO_URL_ISSUES%` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to repo initialization scripts; main risk is installer behavior differences due to stricter shell error handling and new abort paths on failures.
> 
> **Overview**
> Improves `init_repo.sh`/`init_repo.bat` failure handling by adding a consistent *FATAL* error block that captures the failing context and directs users to file a pre-filled issue (URL overridable via `AGENTS_ISSUES_URL`).
> 
> On Linux/macOS, enables `errtrace` + `pipefail` and installs an `ERR` trap to surface unexpected failures (exit code/line/command), while keeping explicitly-handled early exits unchanged. On NixOS, the pre-indexing warmup now passes `LD_LIBRARY_PATH` into the Python subprocess to avoid `numpy`/`libstdc++` import failures, and MCP file counts are made resilient under `pipefail` when optional directories are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3088e4959d4510104c345a3ad6c2e61d6f206088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->