### PR TITLE
fix(memory): scope history.md/CLAUDE.md/data to client repo (#36)

### DIFF
--- a/docs/memory-subsystem-spec.md
+++ b/docs/memory-subsystem-spec.md
@@ -97,7 +97,7 @@ read_history(limit=20, since?, query?)
 | New file | Role |
 |---|---|
 | `src/memory/__init__.py` | Package marker |
-| `src/memory/config.py` | Constants: paths, markers, thresholds; imports `REPO_ROOT`/`DATA_DIR` from `src/engine/config.py:7-8` |
+| `src/memory/config.py` | Constants: markers, thresholds; path constants (`HISTORY_FILE`, `CLAUDE_MD_FILE`, `MEMORY_DATA_DIR`, `DESCRIBE_HASH_FILE`, `HISTORY_ARCHIVE_DIR`) are exposed via PEP 562 `__getattr__` so they resolve lazily against `get_client_repo_root()` / `get_client_data_dir()` — see issue #36. |
 | `src/memory/managed_section.py` | Pure Python port of the marker editor from `scripts/init_repo.sh:636-672`. Functions: `upsert_section`, `read_section`, `remove_section`. Atomic writes via `tempfile` + `os.replace`. |
 | `src/memory/describer.py` | `RepoDescriber`: hash → bundle → prompt → sampling → upsert |
 | `src/memory/history.py` | `HistoryWriter` (append, dedup, rotate) + `HistoryReader` (recent + lazy semantic) + `HistoryStore` (wrapper around NumpyVectorStore) |
@@ -124,7 +124,7 @@ read_history(limit=20, since?, query?)
 | `LanguageDetector` | `src/engine/language.py:39` | Language tagging of entries |
 | `debug_log` | `src/utils/debug_logger.py:18` | Instrumentation of all tools |
 | `@observe` from `langfuse_compat` | `src/utils/langfuse_compat.py` | Optional observability |
-| `REPO_ROOT`, `DATA_DIR` | `src/engine/config.py:7-8` | Base paths |
+| `INSTALL_ROOT`, `INSTALL_DATA_DIR`, `get_client_repo_root()`, `get_client_data_dir()` | `src/engine/config.py` | Two-root model: install-scoped (shipped assets + shared indexes) vs client-scoped (per-repo memory). Deprecated aliases `REPO_ROOT`/`DATA_DIR` map to the install-scoped values via PEP 562 `__getattr__`. |
 | pytest fixtures (`tmp_path`, `populated_store`) | `tests/test_vector_store.py:12-31` | Mirrored for new tests |
 
 ---

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -58,17 +58,19 @@ def get_client_repo_root() -> str:
     override = os.environ.get("AGENTS_CLIENT_REPO_ROOT")
     if override:
         resolved = os.path.realpath(os.path.expanduser(override))
-        logger.info("client-repo-root: env override -> %s", resolved)
+        # Debug-level so the server's INFO-configured root logger stays quiet
+        # on normal startup; AGENTS_DEBUG=1 surfaces these when diagnosing.
+        logger.debug("client-repo-root: env override -> %s", resolved)
         return resolved
 
     cwd = Path(os.getcwd())
     marker = _find_marker_upwards(cwd)
     if marker is not None:
-        logger.info("client-repo-root: walk-up marker -> %s", marker)
+        logger.debug("client-repo-root: walk-up marker -> %s", marker)
         return str(marker)
 
     fallback = str(cwd.resolve())
-    logger.info("client-repo-root: fallback cwd -> %s", fallback)
+    logger.debug("client-repo-root: fallback cwd -> %s", fallback)
     return fallback
 
 

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -63,13 +63,33 @@ def get_client_repo_root() -> str:
         logger.debug("client-repo-root: env override -> %s", resolved)
         return resolved
 
-    cwd = Path(os.getcwd())
+    # `os.getcwd()` raises FileNotFoundError when the process' cwd has been
+    # deleted (long-running daemons started from ephemeral dirs). Without
+    # this guard the first memory-tool call would crash the whole session.
+    # Fall back to INSTALL_ROOT and warn loudly so the anomaly is visible.
+    try:
+        cwd = Path(os.getcwd())
+    except (FileNotFoundError, OSError) as err:
+        logger.warning(
+            "client-repo-root: cwd unavailable (%s); falling back to INSTALL_ROOT. "
+            "Set AGENTS_CLIENT_REPO_ROOT to pin the per-session memory target.",
+            err,
+        )
+        return INSTALL_ROOT
+
     marker = _find_marker_upwards(cwd)
     if marker is not None:
         logger.debug("client-repo-root: walk-up marker -> %s", marker)
         return str(marker)
 
-    fallback = str(cwd.resolve())
+    try:
+        fallback = str(cwd.resolve())
+    except OSError as err:
+        logger.warning(
+            "client-repo-root: cwd resolve failed (%s); falling back to INSTALL_ROOT.",
+            err,
+        )
+        return INSTALL_ROOT
     logger.debug("client-repo-root: fallback cwd -> %s", fallback)
     return fallback
 

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -1,24 +1,98 @@
 import logging
 import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 ENGINE_DIR = os.path.dirname(__file__)
-REPO_ROOT = os.path.abspath(os.path.join(ENGINE_DIR, "../.."))
 
-# Embedding model (set via .env or init_repo.sh)
+# --- Install root ------------------------------------------------------------
+# Where the Agents-Core source ships: agents/, skills/, implants/, capabilities/
+# registry, and vector indexes keyed against those files (router_cache,
+# skills_store, implants_store, .router_cache_model). Shared across all client
+# repos that reach this install through a global MCP registration.
+INSTALL_ROOT = os.path.abspath(os.path.join(ENGINE_DIR, "../.."))
+INSTALL_DATA_DIR = os.path.join(INSTALL_ROOT, "data")
+AGENTS_DIR = os.path.join(INSTALL_ROOT, "agents")
+SKILLS_DIR = os.path.join(INSTALL_ROOT, "skills")
+IMPLANTS_DIR = os.path.join(INSTALL_ROOT, "implants")
+CAPABILITIES_FILE = os.path.join(INSTALL_ROOT, "agents", "capabilities", "registry.yaml")
+
+# --- Client repo root (per-session, per-repo memory artifacts) ---------------
+# Where the serving MCP session's journal lives: history.md, history/ archive,
+# managed CLAUDE.md section, describe_hash, history_store vector index, and
+# AGENTS_DEBUG logs. Resolved lazily so a single install serving many client
+# repos keeps their memory isolated (issue #36).
+
+_CLIENT_ROOT_MARKERS = (".git", "CLAUDE.md")
+
+
+def _find_marker_upwards(start: Path) -> Optional[Path]:
+    """Walk up from *start* until a directory containing any of
+    `_CLIENT_ROOT_MARKERS` is found. Returns that directory, or None."""
+    try:
+        current = start.resolve(strict=False)
+    except OSError:
+        return None
+    for candidate in (current, *current.parents):
+        if any((candidate / marker).exists() for marker in _CLIENT_ROOT_MARKERS):
+            return candidate
+    return None
+
+
+@lru_cache(maxsize=1)
+def get_client_repo_root() -> str:
+    """Resolve the client repo that owns this MCP session's per-repo memory.
+
+    Resolution order:
+      1. `AGENTS_CLIENT_REPO_ROOT` env var — authoritative override.
+      2. Walk up from `os.getcwd()` to the nearest directory containing
+         `.git` or `CLAUDE.md`.
+      3. Fallback: `os.getcwd()`.
+
+    Memoized for the process lifetime. Tests reset via
+    `_reset_client_repo_root_cache()`.
+    """
+    override = os.environ.get("AGENTS_CLIENT_REPO_ROOT")
+    if override:
+        resolved = os.path.realpath(os.path.expanduser(override))
+        logger.info("client-repo-root: env override -> %s", resolved)
+        return resolved
+
+    cwd = Path(os.getcwd())
+    marker = _find_marker_upwards(cwd)
+    if marker is not None:
+        logger.info("client-repo-root: walk-up marker -> %s", marker)
+        return str(marker)
+
+    fallback = str(cwd.resolve())
+    logger.info("client-repo-root: fallback cwd -> %s", fallback)
+    return fallback
+
+
+def _reset_client_repo_root_cache() -> None:
+    """Clear the memoization of `get_client_repo_root()`. Test-only."""
+    get_client_repo_root.cache_clear()
+
+
+def get_client_data_dir() -> str:
+    """`{client_repo_root}/data` — per-repo `history_store` and `.describe_hash`."""
+    return os.path.join(get_client_repo_root(), "data")
+
+
+def get_debug_log_dir() -> str:
+    """`{client_repo_root}/logs` — per-call JSON debug logs (when `AGENTS_DEBUG=1`)."""
+    return os.path.join(get_client_repo_root(), "logs")
+
+
+# --- Embedding / model config ------------------------------------------------
+
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
 
 # fastembed cache — persistent by default (macOS launchd wipes /tmp during long downloads).
 FASTEMBED_CACHE_DIR = os.path.expanduser(os.getenv("FASTEMBED_CACHE_DIR", "~/.cache/fastembed"))
-
-# Persistent storage for vector stores
-DATA_DIR = os.path.join(REPO_ROOT, "data")
-
-AGENTS_DIR = os.path.join(REPO_ROOT, "agents")
-SKILLS_DIR = os.path.join(REPO_ROOT, "skills")
-IMPLANTS_DIR = os.path.join(REPO_ROOT, "implants")
-CAPABILITIES_FILE = os.path.join(REPO_ROOT, "agents", "capabilities", "registry.yaml")
 
 
 def _float_env(name: str, default: float, lo: float = 0.0, hi: float = 1.0) -> float:
@@ -65,4 +139,19 @@ SESSION_CACHE_TTL_SECONDS = 600
 
 # Debug logging — set AGENTS_DEBUG=1 in .env to write per-call JSON files to logs/
 AGENTS_DEBUG = os.getenv("AGENTS_DEBUG", "").lower() in ("1", "true")
-DEBUG_LOG_DIR = os.path.join(REPO_ROOT, "logs")
+
+
+# --- Deprecated name aliases (PEP 562) ---------------------------------------
+# Issue #36: `REPO_ROOT`/`DATA_DIR`/`DEBUG_LOG_DIR` used to conflate the Agents
+# install directory with the client repo whose memory we write to. They now
+# split into INSTALL_ROOT + get_client_repo_root()/get_debug_log_dir(). These
+# aliases keep external `from src.engine.config import REPO_ROOT` callsites
+# working without churn; prefer the explicit names in new code.
+def __getattr__(name: str):
+    if name == "REPO_ROOT":
+        return INSTALL_ROOT
+    if name == "DATA_DIR":
+        return INSTALL_DATA_DIR
+    if name == "DEBUG_LOG_DIR":
+        return get_debug_log_dir()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -6,7 +6,7 @@ import traceback
 from dataclasses import dataclass, field
 from typing import List, Literal, Optional
 
-from src.engine.config import AGENTS_DEBUG, DEBUG_LOG_DIR
+from src.engine.config import AGENTS_DEBUG, get_debug_log_dir
 from src.engine.skills import SkillRetriever
 from src.engine.implants import ImplantRetriever
 from src.engine.capabilities import resolve_capabilities
@@ -124,8 +124,9 @@ async def get_dynamic_context_string(
             if AGENTS_DEBUG:
                 try:
                     import datetime
-                    os.makedirs(DEBUG_LOG_DIR, exist_ok=True)
-                    with open(os.path.join(DEBUG_LOG_DIR, "implant_enrichment_error.log"), "a") as f:
+                    debug_dir = get_debug_log_dir()
+                    os.makedirs(debug_dir, exist_ok=True)
+                    with open(os.path.join(debug_dir, "implant_enrichment_error.log"), "a") as f:
                         f.write(f"\n--- {datetime.datetime.now().isoformat()} ---\n")
                         f.write(traceback.format_exc())
                 except Exception:

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -1,29 +1,19 @@
 """Constants for the repository memory subsystem.
 
-All paths are derived from REPO_ROOT / DATA_DIR exposed by the engine config,
-so the memory tools pick up overrides made elsewhere automatically.
+Path constants (``HISTORY_FILE``, ``HISTORY_ARCHIVE_DIR``, ``CLAUDE_MD_FILE``,
+``DESCRIBE_HASH_FILE``, ``MEMORY_DATA_DIR``) are **client-repo-scoped** — each
+MCP session resolves them against ``src.engine.config.get_client_repo_root()``,
+not against the Agents install directory. One global Agents-Core install can
+then serve many client repos with isolated per-repo memory (issue #36).
+
+The path names are exposed via PEP 562 ``__getattr__`` so tests that swap the
+client root via ``_reset_client_repo_root_cache()`` see the updated value on
+the next attribute access.
 """
 
 import os
 
-from src.engine.config import DATA_DIR, REPO_ROOT
-
-# --- Filesystem layout -------------------------------------------------------
-
-# Vector store + hash file live under data/memory so they share the same
-# git-ignored data root as the routing/skills/implants stores.
-MEMORY_DATA_DIR = os.path.join(DATA_DIR, "memory")
-
-# Repo-root markdown artifacts (git-ignored by default — see .gitignore).
-HISTORY_FILE = os.path.join(REPO_ROOT, "history.md")
-HISTORY_ARCHIVE_DIR = os.path.join(REPO_ROOT, "history")
-CLAUDE_MD_FILE = os.path.join(REPO_ROOT, "CLAUDE.md")
-
-# Hash file used by RepoDescriber to skip work when the repo hasn't changed.
-DESCRIBE_HASH_FILE = os.path.join(MEMORY_DATA_DIR, ".describe_hash")
-
-# Vector store for lazy semantic recall over history entries.
-HISTORY_VECTOR_STORE_NAME = "history_store"
+from src.engine.config import get_client_data_dir, get_client_repo_root
 
 # --- Managed section markers (CLAUDE.md) -------------------------------------
 
@@ -71,3 +61,23 @@ DESCRIBE_EXCLUDED_DIRS = frozenset({
     ".vscode",
     "history",  # archived history files — describe doesn't care
 })
+
+# --- Vector store name (not a path) ------------------------------------------
+
+HISTORY_VECTOR_STORE_NAME = "history_store"
+
+
+# --- Lazy, client-scoped paths (PEP 562) -------------------------------------
+
+def __getattr__(name: str):
+    if name == "MEMORY_DATA_DIR":
+        return os.path.join(get_client_data_dir(), "memory")
+    if name == "HISTORY_FILE":
+        return os.path.join(get_client_repo_root(), "history.md")
+    if name == "HISTORY_ARCHIVE_DIR":
+        return os.path.join(get_client_repo_root(), "history")
+    if name == "CLAUDE_MD_FILE":
+        return os.path.join(get_client_repo_root(), "CLAUDE.md")
+    if name == "DESCRIBE_HASH_FILE":
+        return os.path.join(get_client_data_dir(), "memory", ".describe_hash")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/memory/describer.py
+++ b/src/memory/describer.py
@@ -18,12 +18,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
 
-from src.engine.config import REPO_ROOT
+from src.engine.config import get_client_repo_root
+from src.memory import config as _memory_config
 from src.memory import managed_section
 from src.memory.config import (
-    CLAUDE_MD_FILE,
     DESCRIBE_EXCLUDED_DIRS,
-    DESCRIBE_HASH_FILE,
     DESCRIBE_MARKER_BEGIN,
     DESCRIBE_MARKER_END,
     DESCRIBE_README_HEAD_LINES,
@@ -143,7 +142,7 @@ class RepoDescriber:
         claude_md_path: Optional[str] = None,
         hash_file: Optional[str] = None,
     ):
-        self.repo_path = os.path.abspath(repo_path) if repo_path else REPO_ROOT
+        self.repo_path = os.path.abspath(repo_path) if repo_path else get_client_repo_root()
         # When the caller overrides repo_path, default the CLAUDE.md and hash
         # file to live inside that repo unless explicit paths are given —
         # otherwise tests would clobber the real CLAUDE.md.
@@ -152,7 +151,7 @@ class RepoDescriber:
         elif repo_path:
             self.claude_md_path = os.path.join(self.repo_path, "CLAUDE.md")
         else:
-            self.claude_md_path = CLAUDE_MD_FILE
+            self.claude_md_path = _memory_config.CLAUDE_MD_FILE
 
         if hash_file is not None:
             self.hash_file = hash_file
@@ -161,7 +160,7 @@ class RepoDescriber:
                 self.repo_path, "data", "memory", ".describe_hash"
             )
         else:
-            self.hash_file = DESCRIBE_HASH_FILE
+            self.hash_file = _memory_config.DESCRIBE_HASH_FILE
 
     # ------------------------------------------------------------------ hash
     def compute_repo_hash(self) -> str:

--- a/src/memory/history.py
+++ b/src/memory/history.py
@@ -29,14 +29,12 @@ import threading
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
+from src.memory import config as _memory_config
 from src.memory.config import (
-    HISTORY_ARCHIVE_DIR,
     HISTORY_DEDUP_TAIL_SIZE,
-    HISTORY_FILE,
     HISTORY_FORMAT_VERSION,
     HISTORY_ROTATION_THRESHOLD_KB,
     HISTORY_VECTOR_STORE_NAME,
-    MEMORY_DATA_DIR,
 )
 
 logger = logging.getLogger(__name__)
@@ -100,8 +98,10 @@ class HistoryWriter:
         rotation_kb: int = HISTORY_ROTATION_THRESHOLD_KB,
         dedup_tail: int = HISTORY_DEDUP_TAIL_SIZE,
     ):
-        self.history_path = history_path or HISTORY_FILE
-        self.archive_dir = archive_dir or HISTORY_ARCHIVE_DIR
+        # Resolve defaults lazily via module attribute access so PEP 562 picks
+        # up the current client repo root each time (see src/memory/config.py).
+        self.history_path = history_path or _memory_config.HISTORY_FILE
+        self.archive_dir = archive_dir or _memory_config.HISTORY_ARCHIVE_DIR
         self.rotation_kb = rotation_kb
         self.dedup_tail = dedup_tail
 
@@ -304,7 +304,7 @@ class HistoryReader:
     """Parses ``history.md`` and serves recency/since/tag queries."""
 
     def __init__(self, history_path: Optional[str] = None):
-        self.history_path = history_path or HISTORY_FILE
+        self.history_path = history_path or _memory_config.HISTORY_FILE
 
     def read_all(self) -> List[HistoryEntry]:
         if not os.path.exists(self.history_path):
@@ -398,8 +398,8 @@ class HistoryStore:
         data_dir: Optional[str] = None,
         store_name: str = HISTORY_VECTOR_STORE_NAME,
     ):
-        self.history_path = history_path or HISTORY_FILE
-        self.data_dir = data_dir or MEMORY_DATA_DIR
+        self.history_path = history_path or _memory_config.HISTORY_FILE
+        self.data_dir = data_dir or _memory_config.MEMORY_DATA_DIR
         self.store_name = store_name
         self._store = None  # lazy
         self._index_lock = threading.Lock()

--- a/src/server.py
+++ b/src/server.py
@@ -71,6 +71,30 @@ from src.utils.langfuse_compat import observe, get_langfuse, is_langfuse_configu
 langfuse = get_langfuse()
 atexit.register(langfuse.flush)
 
+
+def _is_within(candidate: str, boundary: str) -> bool:
+    """Return True iff *candidate* resolves inside *boundary* (inclusive).
+
+    Uses ``os.path.commonpath`` so the check survives:
+
+    * boundary == filesystem root (``"/"`` on POSIX) — naive
+      ``startswith(boundary + os.sep)`` math would produce ``"//"`` and
+      reject everything after ``rstrip(os.sep)``.
+    * trailing-slash differences and path-normalization quirks.
+    * Windows cross-drive paths (``ValueError`` from ``commonpath``).
+
+    Mirrors the pattern in ``src/utils/prompt_loader.py:67``.
+    """
+    boundary_real = os.path.realpath(boundary)
+    candidate_real = os.path.realpath(candidate)
+    try:
+        return os.path.commonpath([boundary_real, candidate_real]) == boundary_real
+    except ValueError:
+        # Different drives on Windows, or mixed absolute/relative — treat
+        # as out-of-bounds.
+        return False
+
+
 # --- Tools ---
 
 @mcp.tool()
@@ -715,8 +739,7 @@ async def describe_repo(
             if not os.path.isabs(repo_path):
                 repo_path = os.path.join(client_root, repo_path)
             resolved = os.path.realpath(repo_path)
-            client_root_resolved = os.path.realpath(client_root) + os.sep
-            if resolved != client_root_resolved.rstrip(os.sep) and not resolved.startswith(client_root_resolved):
+            if not _is_within(resolved, client_root):
                 payload = {
                     "status": "error",
                     "error": f"repo_path must be within {client_root}",
@@ -803,8 +826,7 @@ async def write_repo_summary(
             if not os.path.isabs(repo_path):
                 repo_path = os.path.join(client_root, repo_path)
             resolved = os.path.realpath(repo_path)
-            client_root_resolved = os.path.realpath(client_root) + os.sep
-            if resolved != client_root_resolved.rstrip(os.sep) and not resolved.startswith(client_root_resolved):
+            if not _is_within(resolved, client_root):
                 payload = {
                     "status": "error",
                     "error": f"repo_path must be within {client_root}",

--- a/src/server.py
+++ b/src/server.py
@@ -32,7 +32,7 @@ from src.engine.enrichment import (
     infer_tier,
     implant_retriever,
 )
-from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD, ROUTER_SIMILARITY_THRESHOLD, REPO_ROOT
+from src.engine.config import SESSION_CACHE_MAX_SIZE, SESSION_CACHE_TTL_SECONDS, STICKY_SWITCH_THRESHOLD, ROUTER_SIMILARITY_THRESHOLD, get_client_repo_root
 from src.utils.prompt_loader import load_agent_prompt, get_agent_metadata
 from src.utils.debug_logger import debug_log
 from src.memory.describer import RepoDescriber
@@ -707,17 +707,19 @@ async def describe_repo(
     status ∈ {"refreshed", "up-to-date", "rejected", "error"}.
     """
     try:
-        # Restrict repo_path to REPO_ROOT to prevent arbitrary filesystem access.
-        # Resolve relative paths against REPO_ROOT (not CWD) for stable behavior.
+        # Restrict repo_path to the client repo root so the sandbox tracks
+        # the per-session memory boundary (issue #36). Relative paths resolve
+        # against the client root for stable behavior across sessions.
+        client_root = get_client_repo_root()
         if repo_path is not None:
             if not os.path.isabs(repo_path):
-                repo_path = os.path.join(REPO_ROOT, repo_path)
+                repo_path = os.path.join(client_root, repo_path)
             resolved = os.path.realpath(repo_path)
-            repo_root_resolved = os.path.realpath(REPO_ROOT) + os.sep
-            if resolved != repo_root_resolved.rstrip(os.sep) and not resolved.startswith(repo_root_resolved):
+            client_root_resolved = os.path.realpath(client_root) + os.sep
+            if resolved != client_root_resolved.rstrip(os.sep) and not resolved.startswith(client_root_resolved):
                 payload = {
                     "status": "error",
-                    "error": f"repo_path must be within {REPO_ROOT}",
+                    "error": f"repo_path must be within {client_root}",
                 }
                 return json.dumps(payload, ensure_ascii=False)
             if not os.path.isdir(resolved):
@@ -796,15 +798,16 @@ async def write_repo_summary(
     status ∈ {"refreshed", "rejected", "error"}.
     """
     try:
+        client_root = get_client_repo_root()
         if repo_path is not None:
             if not os.path.isabs(repo_path):
-                repo_path = os.path.join(REPO_ROOT, repo_path)
+                repo_path = os.path.join(client_root, repo_path)
             resolved = os.path.realpath(repo_path)
-            repo_root_resolved = os.path.realpath(REPO_ROOT) + os.sep
-            if resolved != repo_root_resolved.rstrip(os.sep) and not resolved.startswith(repo_root_resolved):
+            client_root_resolved = os.path.realpath(client_root) + os.sep
+            if resolved != client_root_resolved.rstrip(os.sep) and not resolved.startswith(client_root_resolved):
                 payload = {
                     "status": "error",
-                    "error": f"repo_path must be within {REPO_ROOT}",
+                    "error": f"repo_path must be within {client_root}",
                 }
                 return json.dumps(payload, ensure_ascii=False)
             if not os.path.isdir(resolved):

--- a/src/utils/debug_logger.py
+++ b/src/utils/debug_logger.py
@@ -12,7 +12,7 @@ import os
 import re
 from datetime import datetime, timezone
 
-from src.engine.config import AGENTS_DEBUG, DEBUG_LOG_DIR
+from src.engine.config import AGENTS_DEBUG, get_debug_log_dir
 
 
 def debug_log(tool: str, direction: str, data: dict) -> None:
@@ -34,7 +34,7 @@ def debug_log(tool: str, direction: str, data: dict) -> None:
         safe_dir = re.sub(r'[^\w\-.]', '_', direction)
         filename = f"{ts_prefix}_{safe_tool}_{safe_dir}.json"
 
-        target_dir = os.path.join(DEBUG_LOG_DIR, date_dir)
+        target_dir = os.path.join(get_debug_log_dir(), date_dir)
         os.makedirs(target_dir, exist_ok=True)
 
         payload = {

--- a/tests/test_config_client_root.py
+++ b/tests/test_config_client_root.py
@@ -87,12 +87,14 @@ class TestInstallRootUnchanged:
         # Client-scoped values shift...
         engine_config._reset_client_repo_root_cache()
         assert engine_config.get_client_repo_root() == os.path.realpath(str(tmp_path))
-        # ...but install-scoped values do not.
-        assert engine_config.INSTALL_ROOT.endswith("Agents")
-        assert engine_config.AGENTS_DIR.endswith("agents")
-        assert engine_config.SKILLS_DIR.endswith("skills")
-        assert engine_config.IMPLANTS_DIR.endswith("implants")
-        assert engine_config.INSTALL_DATA_DIR.endswith("data")
+        # ...but install-scoped values do not. Assert structural relationships
+        # (direct children of INSTALL_ROOT) rather than the repo folder name,
+        # which can differ across CI checkouts.
+        install_root = os.path.realpath(engine_config.INSTALL_ROOT)
+        assert os.path.realpath(engine_config.AGENTS_DIR) == os.path.join(install_root, "agents")
+        assert os.path.realpath(engine_config.SKILLS_DIR) == os.path.join(install_root, "skills")
+        assert os.path.realpath(engine_config.IMPLANTS_DIR) == os.path.join(install_root, "implants")
+        assert os.path.realpath(engine_config.INSTALL_DATA_DIR) == os.path.join(install_root, "data")
 
 
 class TestDeprecatedAliases:

--- a/tests/test_config_client_root.py
+++ b/tests/test_config_client_root.py
@@ -1,0 +1,129 @@
+"""Resolution of ``get_client_repo_root()`` — env → walk-up → cwd.
+
+Issue #36: per-repo memory requires the client repo root to be resolved
+dynamically so one global install can serve many client repos.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.engine import config as engine_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Clear the memoized client root between tests."""
+    engine_config._reset_client_repo_root_cache()
+    yield
+    engine_config._reset_client_repo_root_cache()
+
+
+class TestResolutionOrder:
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(tmp_path))
+        # Move cwd somewhere unrelated to prove env takes priority.
+        monkeypatch.chdir("/")
+        assert engine_config.get_client_repo_root() == os.path.realpath(str(tmp_path))
+
+    def test_env_override_expands_tilde(self, monkeypatch):
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", "~")
+        resolved = engine_config.get_client_repo_root()
+        assert resolved == os.path.realpath(os.path.expanduser("~"))
+
+    def test_env_override_realpaths_symlink(self, tmp_path, monkeypatch):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(link))
+        assert engine_config.get_client_repo_root() == str(real.resolve())
+
+    def test_walk_up_finds_git_dir(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENTS_CLIENT_REPO_ROOT", raising=False)
+        (tmp_path / ".git").mkdir()
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        assert engine_config.get_client_repo_root() == str(tmp_path.resolve())
+
+    def test_walk_up_accepts_git_file_worktree(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENTS_CLIENT_REPO_ROOT", raising=False)
+        # Git worktrees use a .git *file*, not a directory.
+        (tmp_path / ".git").write_text("gitdir: /elsewhere")
+        nested = tmp_path / "x" / "y"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        assert engine_config.get_client_repo_root() == str(tmp_path.resolve())
+
+    def test_walk_up_accepts_claude_md_marker(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENTS_CLIENT_REPO_ROOT", raising=False)
+        (tmp_path / "CLAUDE.md").write_text("# managed section")
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+        assert engine_config.get_client_repo_root() == str(tmp_path.resolve())
+
+    def test_cwd_fallback_when_no_marker(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENTS_CLIENT_REPO_ROOT", raising=False)
+        isolated = tmp_path / "no_markers_here"
+        isolated.mkdir()
+        monkeypatch.chdir(isolated)
+        # Walk-up will still find `/` likely lacking markers — but tmp_path
+        # itself is under / so it may hit a distant marker. Only assert we
+        # returned *some* absolute path, not that it equals cwd — real
+        # filesystems often have .git at / or elsewhere in the ancestry.
+        resolved = engine_config.get_client_repo_root()
+        assert os.path.isabs(resolved)
+
+
+class TestInstallRootUnchanged:
+    """Install-scoped constants must not drift with the client root."""
+
+    def test_install_paths_are_stable(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(tmp_path))
+        # Client-scoped values shift...
+        engine_config._reset_client_repo_root_cache()
+        assert engine_config.get_client_repo_root() == os.path.realpath(str(tmp_path))
+        # ...but install-scoped values do not.
+        assert engine_config.INSTALL_ROOT.endswith("Agents")
+        assert engine_config.AGENTS_DIR.endswith("agents")
+        assert engine_config.SKILLS_DIR.endswith("skills")
+        assert engine_config.IMPLANTS_DIR.endswith("implants")
+        assert engine_config.INSTALL_DATA_DIR.endswith("data")
+
+
+class TestDeprecatedAliases:
+    """PEP 562 aliases preserve `from src.engine.config import REPO_ROOT` callsites."""
+
+    def test_repo_root_alias_maps_to_install_root(self):
+        assert engine_config.REPO_ROOT == engine_config.INSTALL_ROOT
+
+    def test_data_dir_alias_maps_to_install_data_dir(self):
+        assert engine_config.DATA_DIR == engine_config.INSTALL_DATA_DIR
+
+    def test_debug_log_dir_resolves_client_scoped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(tmp_path))
+        engine_config._reset_client_repo_root_cache()
+        assert engine_config.DEBUG_LOG_DIR == os.path.join(
+            os.path.realpath(str(tmp_path)), "logs"
+        )
+
+
+class TestCacheReset:
+    def test_reset_lets_tests_swap_roots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(tmp_path / "a"))
+        (tmp_path / "a").mkdir()
+        engine_config._reset_client_repo_root_cache()
+        first = engine_config.get_client_repo_root()
+
+        monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(tmp_path / "b"))
+        (tmp_path / "b").mkdir()
+        # Without reset, the lru_cache returns the old value.
+        assert engine_config.get_client_repo_root() == first
+        engine_config._reset_client_repo_root_cache()
+        assert engine_config.get_client_repo_root() == os.path.realpath(
+            str(tmp_path / "b")
+        )

--- a/tests/test_config_client_root.py
+++ b/tests/test_config_client_root.py
@@ -66,6 +66,23 @@ class TestResolutionOrder:
         monkeypatch.chdir(nested)
         assert engine_config.get_client_repo_root() == str(tmp_path.resolve())
 
+    def test_cwd_unavailable_falls_back_to_install_root(self, monkeypatch, caplog):
+        """os.getcwd() raises FileNotFoundError when the cwd was deleted.
+
+        Long-running daemons started from ephemeral dirs hit this; without
+        the guard the first memory-tool call would crash the session.
+        """
+        monkeypatch.delenv("AGENTS_CLIENT_REPO_ROOT", raising=False)
+
+        def _raise_cwd():
+            raise FileNotFoundError(2, "No such file or directory")
+
+        monkeypatch.setattr(engine_config.os, "getcwd", _raise_cwd)
+        with caplog.at_level("WARNING", logger=engine_config.__name__):
+            resolved = engine_config.get_client_repo_root()
+        assert resolved == engine_config.INSTALL_ROOT
+        assert any("cwd unavailable" in rec.message for rec in caplog.records)
+
     def test_cwd_fallback_when_no_marker(self, tmp_path, monkeypatch):
         monkeypatch.delenv("AGENTS_CLIENT_REPO_ROOT", raising=False)
         isolated = tmp_path / "no_markers_here"

--- a/tests/test_config_client_root.py
+++ b/tests/test_config_client_root.py
@@ -24,8 +24,11 @@ def _reset_cache():
 class TestResolutionOrder:
     def test_env_override_wins(self, tmp_path, monkeypatch):
         monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(tmp_path))
-        # Move cwd somewhere unrelated to prove env takes priority.
-        monkeypatch.chdir("/")
+        # Move cwd somewhere unrelated to prove env takes priority. Use a
+        # tmp subdir rather than "/" so the test is portable to Windows.
+        unrelated = tmp_path / "unrelated_cwd"
+        unrelated.mkdir()
+        monkeypatch.chdir(unrelated)
         assert engine_config.get_client_repo_root() == os.path.realpath(str(tmp_path))
 
     def test_env_override_expands_tilde(self, monkeypatch):
@@ -37,7 +40,11 @@ class TestResolutionOrder:
         real = tmp_path / "real"
         real.mkdir()
         link = tmp_path / "link"
-        link.symlink_to(real)
+        try:
+            link.symlink_to(real)
+        except OSError as exc:
+            # Windows and some restricted CI sandboxes deny symlink creation.
+            pytest.skip(f"symlink creation not supported here: {exc}")
         monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(link))
         assert engine_config.get_client_repo_root() == str(real.resolve())
 

--- a/tests/test_per_repo_memory.py
+++ b/tests/test_per_repo_memory.py
@@ -39,10 +39,12 @@ class TestHistoryWriterDefault:
     def test_does_not_touch_install_root(self, client_root):
         writer = HistoryWriter()
         writer.append_entry("intent", "action", "outcome")
-        install_history = os.path.join(engine_config.INSTALL_ROOT, "history.md.test_sentinel")
-        # Creating the file is a side-effect we don't expect — assert the
-        # writer's path never points at the install root.
-        assert not writer.history_path.startswith(engine_config.INSTALL_ROOT + "/history.md")
+        # The writer must resolve outside the install root. commonpath gives
+        # us a portable (Windows-safe) containment check — if the history
+        # path were inside INSTALL_ROOT, their commonpath would equal it.
+        history_path = os.path.realpath(writer.history_path)
+        install_root = os.path.realpath(engine_config.INSTALL_ROOT)
+        assert os.path.commonpath([history_path, install_root]) != install_root
 
 
 class TestHistoryStoreDefault:

--- a/tests/test_per_repo_memory.py
+++ b/tests/test_per_repo_memory.py
@@ -1,0 +1,92 @@
+"""Issue #36: per-repo memory isolation end-to-end.
+
+Verifies that a per-session `AGENTS_CLIENT_REPO_ROOT` override routes
+`HistoryWriter`, `HistoryStore`, and `RepoDescriber` into the client repo
+instead of the Agents install directory.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.engine import config as engine_config
+from src.memory import config as memory_config
+from src.memory.describer import RepoDescriber
+from src.memory.history import HistoryStore, HistoryWriter
+
+
+@pytest.fixture
+def client_root(tmp_path, monkeypatch):
+    """Point the resolver at a fresh tmp client repo for this test."""
+    root = tmp_path / "client_repo"
+    root.mkdir()
+    monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(root))
+    engine_config._reset_client_repo_root_cache()
+    yield root
+    engine_config._reset_client_repo_root_cache()
+
+
+class TestHistoryWriterDefault:
+    def test_writes_into_client_root(self, client_root):
+        writer = HistoryWriter()
+        assert writer.history_path == str(client_root / "history.md")
+        result = writer.append_entry("intent", "action", "outcome")
+        assert result["status"] == "recorded"
+        assert (client_root / "history.md").exists()
+
+    def test_does_not_touch_install_root(self, client_root):
+        writer = HistoryWriter()
+        writer.append_entry("intent", "action", "outcome")
+        install_history = os.path.join(engine_config.INSTALL_ROOT, "history.md.test_sentinel")
+        # Creating the file is a side-effect we don't expect — assert the
+        # writer's path never points at the install root.
+        assert not writer.history_path.startswith(engine_config.INSTALL_ROOT + "/history.md")
+
+
+class TestHistoryStoreDefault:
+    def test_data_dir_is_client_scoped(self, client_root):
+        store = HistoryStore()
+        assert store.data_dir == str(client_root / "data" / "memory")
+        assert store.history_path == str(client_root / "history.md")
+
+
+class TestDescriberDefault:
+    def test_repo_path_defaults_to_client_root(self, client_root):
+        d = RepoDescriber()
+        assert d.repo_path == str(client_root)
+        assert d.claude_md_path == str(client_root / "CLAUDE.md")
+        assert d.hash_file == str(client_root / "data" / "memory" / ".describe_hash")
+
+    def test_explicit_repo_path_wins_over_client_root(self, client_root, tmp_path):
+        other = tmp_path / "other"
+        other.mkdir()
+        d = RepoDescriber(repo_path=str(other))
+        assert d.repo_path == str(other)
+        assert d.claude_md_path == str(other / "CLAUDE.md")
+
+
+class TestMemoryConfigLazyAttrs:
+    def test_history_file_resolves_against_client_root(self, client_root):
+        assert memory_config.HISTORY_FILE == str(client_root / "history.md")
+
+    def test_memory_data_dir_resolves_against_client_root(self, client_root):
+        assert memory_config.MEMORY_DATA_DIR == str(client_root / "data" / "memory")
+
+    def test_describe_hash_file_resolves_against_client_root(self, client_root):
+        assert memory_config.DESCRIBE_HASH_FILE == str(
+            client_root / "data" / "memory" / ".describe_hash"
+        )
+
+
+class TestInstallDataStaysShared:
+    """Skills/implants/router stores index install-shipped content and must
+    stay rooted at the install dir regardless of the client override."""
+
+    def test_skills_store_uses_install_data_dir(self, client_root):
+        from src.engine.config import INSTALL_DATA_DIR
+
+        # Matches the binding in src/engine/skills.py / router.py / implants.py.
+        assert INSTALL_DATA_DIR.endswith(os.sep + "data")
+        assert not INSTALL_DATA_DIR.startswith(str(client_root))

--- a/tests/test_per_repo_memory.py
+++ b/tests/test_per_repo_memory.py
@@ -19,12 +19,20 @@ from src.memory.history import HistoryStore, HistoryWriter
 
 @pytest.fixture
 def client_root(tmp_path, monkeypatch):
-    """Point the resolver at a fresh tmp client repo for this test."""
+    """Point the resolver at a fresh tmp client repo for this test.
+
+    Yields the *resolved* (realpath'd) Path — the production resolver
+    always returns ``os.path.realpath(...)``, so comparing against a
+    raw ``tmp_path`` would spuriously fail on macOS where ``/var`` is a
+    symlink to ``/private/var``.
+    """
     root = tmp_path / "client_repo"
     root.mkdir()
     monkeypatch.setenv("AGENTS_CLIENT_REPO_ROOT", str(root))
     engine_config._reset_client_repo_root_cache()
-    yield root
+    # resolve() collapses symlinked ancestors (macOS /var -> /private/var)
+    # so tests compare apples to apples.
+    yield root.resolve()
     engine_config._reset_client_repo_root_cache()
 
 

--- a/tests/test_server_sandbox.py
+++ b/tests/test_server_sandbox.py
@@ -1,0 +1,65 @@
+"""Regression tests for the `_is_within` sandbox helper used by
+`describe_repo` / `write_repo_summary` (PR #37 review feedback).
+
+The earlier implementation used ``realpath(boundary) + os.sep`` +
+``startswith``, which rejected every `repo_path` when the boundary
+resolved to the filesystem root (``"/"``): ``"/"`` + ``"/"`` → ``"//"``
+→ ``rstrip`` → ``""``. These tests lock in the ``commonpath``-based
+replacement.
+"""
+
+from __future__ import annotations
+
+import os
+
+from src.server import _is_within
+
+
+class TestIsWithin:
+    def test_same_dir_is_within_itself(self, tmp_path):
+        assert _is_within(str(tmp_path), str(tmp_path))
+
+    def test_subdir_is_within_parent(self, tmp_path):
+        sub = tmp_path / "a" / "b"
+        sub.mkdir(parents=True)
+        assert _is_within(str(sub), str(tmp_path))
+
+    def test_sibling_is_not_within(self, tmp_path):
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        assert not _is_within(str(tmp_path / "b"), str(tmp_path / "a"))
+
+    def test_parent_is_not_within_child(self, tmp_path):
+        child = tmp_path / "child"
+        child.mkdir()
+        assert not _is_within(str(tmp_path), str(child))
+
+    def test_filesystem_root_as_boundary_accepts_descendants(self):
+        """Regression: the old ``"/" + os.sep`` math rejected every path
+        when the boundary was the filesystem root. ``commonpath`` handles
+        this cleanly."""
+        if os.name != "posix":
+            # On Windows, "/" isn't the true drive root; skip — the
+            # Windows-specific ``ValueError`` path is covered below.
+            return
+        # Any real absolute path should resolve as "within" /.
+        assert _is_within("/etc", "/")
+        assert _is_within("/", "/")
+
+    def test_rejects_outside_path(self, tmp_path):
+        # Create a fake "other" dir next to tmp_path.
+        other = tmp_path.parent / (tmp_path.name + "_sibling")
+        other.mkdir(exist_ok=True)
+        try:
+            assert not _is_within(str(other), str(tmp_path))
+        finally:
+            other.rmdir()
+
+    def test_nonexistent_boundary_still_compares(self, tmp_path):
+        # realpath() on a missing path returns the literal absolute path
+        # without resolution; commonpath still produces a deterministic
+        # answer.
+        ghost = tmp_path / "does_not_exist"
+        # A path that would be inside the ghost boundary if it existed.
+        inside = ghost / "sub"
+        assert _is_within(str(inside), str(ghost))

--- a/tests/test_server_sandbox.py
+++ b/tests/test_server_sandbox.py
@@ -1,5 +1,5 @@
 """Regression tests for the `_is_within` sandbox helper used by
-`describe_repo` / `write_repo_summary` (PR #37 review feedback).
+`describe_repo` / `write_repo_summary` (issue #36).
 
 The earlier implementation used ``realpath(boundary) + os.sep`` +
 ``startswith``, which rejected every `repo_path` when the boundary
@@ -11,6 +11,8 @@ replacement.
 from __future__ import annotations
 
 import os
+
+import pytest
 
 from src.server import _is_within
 
@@ -37,11 +39,14 @@ class TestIsWithin:
     def test_filesystem_root_as_boundary_accepts_descendants(self):
         """Regression: the old ``"/" + os.sep`` math rejected every path
         when the boundary was the filesystem root. ``commonpath`` handles
-        this cleanly."""
+        this cleanly.
+
+        POSIX-only — ``"/"`` isn't a meaningful drive root on Windows.
+        Skipped (not silently passed) so CI reporting reflects that the
+        case wasn't exercised on this platform.
+        """
         if os.name != "posix":
-            # On Windows, "/" isn't the true drive root; skip — the
-            # Windows-specific ``ValueError`` path is covered below.
-            return
+            pytest.skip("filesystem-root semantics are POSIX-specific")
         # Any real absolute path should resolve as "within" /.
         assert _is_within("/etc", "/")
         assert _is_within("/", "/")


### PR DESCRIPTION
## Summary

- Split `REPO_ROOT` into **`INSTALL_ROOT`** (shipped content + indexes over shipped content: `agents/`, `skills/`, `implants/`, capabilities, router/skills/implants vector stores) and **`get_client_repo_root()`** (per-session, lazy, memoized — resolves via `AGENTS_CLIENT_REPO_ROOT` env → walk-up from cwd for `.git`/`CLAUDE.md` → cwd).
- Client-scoped paths (`history.md`, `history/` archive, managed `CLAUDE.md` section, `.describe_hash`, `history_store` vector index, `AGENTS_DEBUG` logs) now land in the repo Claude Code was launched from, not in the Agents install dir.
- `src/memory/config.py` exposes path names via PEP 562 `__getattr__` so `from src.memory.config import HISTORY_FILE` keeps working; deprecated `REPO_ROOT`/`DATA_DIR`/`DEBUG_LOG_DIR` aliases on `src/engine/config.py` preserve older imports.
- `describe_repo` / `write_repo_summary` sandboxes now clamp `repo_path` to the client root (was: install root).

Fixes #36.

## Design notes

- **Two install modes both work.** In per-repo-install mode, the cwd walk-up finds the client repo's `.git`; in shared-install mode (one Agents clone, many client repos), Claude Code's stdio subprocess inherits the workspace cwd and the walk-up still resolves correctly.
- **No env injection in `init_repo.sh`.** Injecting `AGENTS_CLIENT_REPO_ROOT` at registration time would pin every future session to whichever repo ran `init_repo.sh` — reintroducing the bug for shared-install users. The env var is supported as a manual/test override only.
- **No migration** of the existing `{install}/history.md`. Entries have no repo provenance; any migration would be heuristic. Old file stays readable via `HistoryReader(history_path=...)`.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_language.py` → **199 passed, 0 regressions** (the 6 `test_language.py` failures are pre-existing `langdetect` import errors unrelated to this PR).
- [x] `tests/test_config_client_root.py` (13 tests) — env > walk-up > cwd precedence; `~` expansion; symlink realpath; `.git` file (worktree); `CLAUDE.md` marker; install-root invariance; alias mapping; cache reset.
- [x] `tests/test_per_repo_memory.py` (8 tests) — `HistoryWriter`, `HistoryStore`, `RepoDescriber` defaults respect `AGENTS_CLIENT_REPO_ROOT`; install data stays rooted at the install dir.
- [x] Manual end-to-end smoke: `AGENTS_CLIENT_REPO_ROOT=/tmp/fakerepo python -c 'from src.memory import config; print(config.HISTORY_FILE)'` → `/tmp/fakerepo/history.md`; unset → walks up to `.git`.

## Follow-ups (deliberate non-goals)

- [ ] Per-call `repo_path` override on `log_interaction` / `read_history` — one-liner if a multi-workspace-per-server scenario surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how filesystem roots are resolved and used for memory/log paths and tool sandboxing, which could redirect writes/reads across environments if the client-root resolution is wrong.
> 
> **Overview**
> This PR introduces a **two-root path model**: install-scoped assets/indexes stay under `INSTALL_ROOT`/`INSTALL_DATA_DIR`, while per-repo memory artifacts (e.g. `history.md`, managed `CLAUDE.md` section, `.describe_hash`, `history_store`, debug logs) are now resolved under a lazily-detected `get_client_repo_root()` (env override → walk-up for `.git`/`CLAUDE.md` → cwd).
> 
> It updates memory code (`src/memory/config.py`, `RepoDescriber`, `HistoryWriter`/`Reader`/`Store`) and debug/error logging to use client-scoped paths via PEP 562 lazy attributes, and adjusts `describe_repo`/`write_repo_summary` sandbox validation to clamp `repo_path` within the client root using a new `commonpath`-based `_is_within` helper.
> 
> Adds focused tests for client-root resolution, per-repo memory isolation defaults, and sandbox containment edge cases (including filesystem-root boundary regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e95180ae25ea6eba6b7c535ac51701e7f4028f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->