### PR TITLE
feat(rules): always-on universal rules layer + caveman tokenomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ src/
     debug_logger.py    — JSON debug logging (AGENTS_DEBUG=1)
     langfuse_compat.py — Optional Langfuse observability
   schemas/
-    protocol.py        — RouterDecision, AgentRequest, EnrichmentResult (rules_loaded)
+    protocol.py        — RouterDecision, AgentRequest, AgentResponse
 agents/
   [name]/system_prompt.mdc — Agent persona with YAML frontmatter (identity, routing, skills)
   common/agent-schema.json — Frontmatter JSON schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ This applies to ALL queries: coding, research, questions, documentation, debuggi
    - `ERROR` → Answer directly (only in this case).
 
 3. **Post-flight (after EVERY response):**
-   - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-   - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
+   - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, tool/CLI output, and the mandatory footer labels `Agent`, `Skills`, `Implants`, `Rules` stay in English.
+   - Append at the end (labels in English, values are canonical IDs): **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
    - Call `log_interaction(agent_name, query, response_content)` — this **always** appends an entry to `history.md` and (if Langfuse is configured) sends a generation trace. For meaningful turns (decisions, fixes, refactors, new features), additionally pass `intent=`, `action=`, `outcome=`, `files=[...]`, `tags=[...]` to curate the entry; otherwise the raw query/response are used.
 
 4. **Repository memory (first session per repo):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This applies to ALL queries: coding, research, questions, documentation, debuggi
 
 3. **Post-flight (after EVERY response):**
    - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-   - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
+   - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
    - Call `log_interaction(agent_name, query, response_content)` — this **always** appends an entry to `history.md` and (if Langfuse is configured) sends a generation trace. For meaningful turns (decisions, fixes, refactors, new features), additionally pass `intent=`, `action=`, `outcome=`, `files=[...]`, `tags=[...]` to curate the entry; otherwise the raw query/response are used.
 
 4. **Repository memory (first session per repo):**
@@ -61,6 +61,14 @@ If `route_and_load` fails or Agents-Core MCP is not connected:
 
 ---
 
+## Enrichment layers (order in every system prompt)
+
+1. **Base agent system_prompt** — agent persona from `agents/<name>/system_prompt.mdc`.
+2. **Rules** (`rules/rule-*.mdc`) — **always-on, universal, no semantic retrieval, no opt-out**. Loaded by `src/engine/rules.py`. Architectural invariant: rules apply to every agent without exception. Per-agent guidance belongs in `skills/`. Toggle via `RULES_ENABLED=0`.
+3. **Skills** (`skills/skill-*.mdc`) — semantic retrieval + per-agent opt-in via `preferred_skills` / `capabilities`. Caveman-style output compression lives here as `skill-caveman-tokenomics`, opt-in via the `concise-output` capability.
+4. **Implants** (`implants/implant-*.mdc`) — semantic retrieval, cognitive reasoning patterns.
+5. **Capability Directives** — terse one-liners from `agents/capabilities/registry.yaml`.
+
 ## Repository Structure
 
 ```
@@ -70,8 +78,9 @@ src/
     router.py          — SemanticRouter: cache lookup, keyword matching, agent catalog
     vector_store.py    — NumpyVectorStore: numpy-based cosine similarity store
     embedder.py        — FastEmbed wrapper (model configurable via EMBEDDING_MODEL env var)
-    config.py          — Thresholds, paths, env-based configuration
-    enrichment.py      — Prompt enrichment with skills/implants by tier (lite/standard/deep)
+    config.py          — Thresholds, paths, env-based configuration (RULES_ENABLED, RULES_DIR)
+    enrichment.py      — Prompt enrichment with rules/skills/implants by tier (lite/standard/deep)
+    rules.py           — Universal always-on rules layer (no retrieval, no opt-out)
     skills.py          — Skill retrieval from vector store
     implants.py        — Implant retrieval from vector store
     capabilities.py    — Capability -> skill resolution via registry.yaml
@@ -82,17 +91,19 @@ src/
     debug_logger.py    — JSON debug logging (AGENTS_DEBUG=1)
     langfuse_compat.py — Optional Langfuse observability
   schemas/
-    protocol.py        — RouterDecision, AgentRequest, EnrichmentResult
+    protocol.py        — RouterDecision, AgentRequest, EnrichmentResult (rules_loaded)
 agents/
   [name]/system_prompt.mdc — Agent persona with YAML frontmatter (identity, routing, skills)
   common/agent-schema.json — Frontmatter JSON schema
-  capabilities/registry.yaml — Capability -> skill mapping
-skills/skill-*.mdc         — Compiled skill prompts
+  capabilities/registry.yaml — Capability -> skill mapping (incl. concise-output)
+rules/rule-*.mdc           — Universal always-on directives (accuracy, honesty, language, sycophancy)
+skills/skill-*.mdc         — Compiled skill prompts (incl. skill-caveman-tokenomics)
 implants/implant-*.mdc     — Cognitive reasoning implants
 tests/
   test_routing.py      — Routing logic, sticky routing, keyword boosting tests
   test_vector_store.py — NumpyVectorStore correctness tests
   test_language.py     — Language detection tests
+  test_rules.py        — Rules layer: parsing, priority, invariant (no opt-out fields)
 ```
 
 ## Routing Flow (Internal)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ If `route_and_load` fails or Agents-Core MCP is not connected:
 1. **Base agent system_prompt** — agent persona from `agents/<name>/system_prompt.mdc`.
 2. **Rules** (`rules/rule-*.mdc`) — **always-on, universal, no semantic retrieval, no opt-out**. Loaded by `src/engine/rules.py`. Architectural invariant: rules apply to every agent without exception. Per-agent guidance belongs in `skills/`. Toggle via `RULES_ENABLED=0`.
 3. **Skills** (`skills/skill-*.mdc`) — semantic retrieval + per-agent opt-in via `preferred_skills` / `capabilities`. Caveman-style output compression lives here as `skill-caveman-tokenomics`, opt-in via the `concise-output` capability.
-4. **Implants** (`implants/implant-*.mdc`) — semantic retrieval, cognitive reasoning patterns.
-5. **Capability Directives** — terse one-liners from `agents/capabilities/registry.yaml`.
+4. **Capability Directives** — terse one-liners from `agents/capabilities/registry.yaml`.
+5. **Implants** (`implants/implant-*.mdc`) — semantic retrieval, cognitive reasoning patterns.
 
 ## Repository Structure
 

--- a/agents/agent_builder/system_prompt.mdc
+++ b/agents/agent_builder/system_prompt.mdc
@@ -21,6 +21,7 @@ preferred_skills:
 capabilities:
 - content-structure
 - tech-documentation
+- concise-output
 ---
 # Agent Builder System Prompt
 

--- a/agents/ai_senior_engineer/system_prompt.mdc
+++ b/agents/ai_senior_engineer/system_prompt.mdc
@@ -18,6 +18,7 @@ capabilities:
   - content-structure
   - prompt-design
   - development
+  - concise-output
 ---
 
 ## Identity

--- a/agents/capabilities/registry.yaml
+++ b/agents/capabilities/registry.yaml
@@ -202,3 +202,8 @@ child-psychology:
     - skill-psy-child-dev
     - skill-psy-digital-wellbeing
   directive: "Age-stage first. Normalize before pathologize. Attachment lens. Digital context assessment. Parent coaching. Authoritative boundaries. Never diagnose."
+
+concise-output:
+  skills:
+    - skill-caveman-tokenomics
+  directive: "Terse output. BLUF (answer-first). Drop fluff, keep technical substance verbatim. Off in code blocks, commits, PRs."

--- a/agents/code_reviewer/system_prompt.mdc
+++ b/agents/code_reviewer/system_prompt.mdc
@@ -35,6 +35,7 @@ preferred_skills:
 capabilities:
 - code-review
 - development
+- concise-output
 ---
 # Code Reviewer System Prompt
 

--- a/agents/data_analyst/system_prompt.mdc
+++ b/agents/data_analyst/system_prompt.mdc
@@ -21,6 +21,7 @@ preferred_skills:
 capabilities:
 - critical-analysis
 - data-investigation
+- concise-output
 ---
 
 ## Identity

--- a/agents/database_admin/system_prompt.mdc
+++ b/agents/database_admin/system_prompt.mdc
@@ -35,6 +35,7 @@ preferred_skills:
 capabilities:
   - development
   - critical-analysis
+  - concise-output
 ---
 
 ## Identity

--- a/agents/devops_engineer/system_prompt.mdc
+++ b/agents/devops_engineer/system_prompt.mdc
@@ -36,6 +36,7 @@ preferred_skills:
 capabilities:
   - development
   - critical-analysis
+  - concise-output
 ---
 
 ## Identity

--- a/agents/mcp_builder/system_prompt.mdc
+++ b/agents/mcp_builder/system_prompt.mdc
@@ -22,6 +22,7 @@ preferred_skills:
 capabilities:
   - development
   - tech-documentation
+  - concise-output
 ---
 # MCP Builder System Prompt
 

--- a/agents/prompt_engineer/system_prompt.mdc
+++ b/agents/prompt_engineer/system_prompt.mdc
@@ -25,6 +25,7 @@ capabilities:
 - prompt-design
 - critical-analysis
 - content-structure
+- concise-output
 ---
 # Prompt Engineer System Prompt
 

--- a/agents/security_expert/system_prompt.mdc
+++ b/agents/security_expert/system_prompt.mdc
@@ -28,6 +28,7 @@ preferred_skills:
 capabilities:
 - dev-security
 - critical-analysis
+- concise-output
 ---
 # Security Expert System Prompt
 

--- a/agents/software_engineer/system_prompt.mdc
+++ b/agents/software_engineer/system_prompt.mdc
@@ -33,6 +33,7 @@ capabilities:
 - development
 - dev-security
 - performance-engineering
+- concise-output
 ---
 
 ## Identity

--- a/agents/sysadmin/system_prompt.mdc
+++ b/agents/sysadmin/system_prompt.mdc
@@ -18,6 +18,7 @@ preferred_skills:
   - "skill-error-recovery"
 capabilities:
   - critical-analysis
+  - concise-output
 ---
 
 ## Identity

--- a/agents/system_architect/system_prompt.mdc
+++ b/agents/system_architect/system_prompt.mdc
@@ -34,6 +34,7 @@ capabilities:
 - system-design
 - development
 - visualization
+- concise-output
 ---
 
 ## Identity

--- a/rules/rule-anti-sycophancy.mdc
+++ b/rules/rule-anti-sycophancy.mdc
@@ -1,0 +1,19 @@
+---
+name: anti-sycophancy
+description: Don't agree to agree. Push back on errors.
+priority: 30
+category: reasoning
+---
+# Anti-sycophancy
+
+Don't agree to agree. If the user is wrong → say so + cite the reason.
+
+Skip empty preambles: "Great question!", "You're absolutely right…", "Excellent point!" when not earned.
+
+Push back on:
+- factual errors
+- broken approaches
+- requests with hidden bad assumptions
+- premises that contradict prior turns
+
+State the disagreement first, then propose the alternative. Validating emotion is fine — agreeing with a falsehood is not.

--- a/rules/rule-honest-uncertainty.mdc
+++ b/rules/rule-honest-uncertainty.mdc
@@ -1,0 +1,15 @@
+---
+name: honest-uncertainty
+description: Mark every claim by confidence level.
+priority: 20
+category: accuracy
+---
+# Honest uncertainty
+
+Tag every claim by confidence:
+
+- **Verified** — read the code, ran the command, cited the source → state plainly.
+- **Reasoned** — logical inference without proof → "I think", "likely", "probably".
+- **Unknown** — say "I don't know". Do not fill the gap with a plausible-sounding guess.
+
+Never pretend to recall what you didn't see. Never round "I'm 60% sure" up to certainty.

--- a/rules/rule-language-match.mdc
+++ b/rules/rule-language-match.mdc
@@ -1,0 +1,15 @@
+---
+name: language-match
+description: Reply in the language of the user's last message.
+priority: 90
+category: localization
+---
+# Language match
+
+Reply in the language of the user's **last** message. Re-detect each turn — do not anchor to the first message.
+
+Always-English exceptions:
+- code, file paths, command-line flags
+- CLI/tool output verbatim
+- commit messages, PR titles, branch names
+- technical terms with no native equivalent (do not translate "callback", "deadlock", "race condition")

--- a/rules/rule-language-match.mdc
+++ b/rules/rule-language-match.mdc
@@ -13,3 +13,4 @@ Always-English exceptions:
 - CLI/tool output verbatim
 - commit messages, PR titles, branch names
 - technical terms with no native equivalent (do not translate "callback", "deadlock", "race condition")
+- mandatory response footer labels: `Agent`, `Skills`, `Implants`, `Rules` (technical metadata; their values — agent/skill/implant/rule names — are also canonical English IDs)

--- a/rules/rule-no-fabrication.mdc
+++ b/rules/rule-no-fabrication.mdc
@@ -1,0 +1,15 @@
+---
+name: no-fabrication
+description: Never invent facts, benchmarks, citations, or APIs.
+priority: 10
+category: accuracy
+---
+# No fabrication
+
+Never invent: numbers, benchmarks, citations, library APIs, function names, version numbers, paper titles, URLs.
+
+If unsure → say "I'm not certain" or "common pattern, not verified".
+
+If user asks for a fact → cite source (URL, file:line, paper) or refuse.
+
+Verifiable claim must be verifiable. Pattern-of-thought claims must be marked as such.

--- a/scripts/templates/routing-protocol-core.md
+++ b/scripts/templates/routing-protocol-core.md
@@ -23,8 +23,8 @@ This applies to ALL queries: coding, research, questions, documentation, debuggi
    - `ERROR` → Answer directly (only in this case).
 
 3. **Post-flight (after EVERY response):**
-   - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-   - Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
+   - Respond in the same language as the user's query (auto-detect). Exceptions: code blocks, technical terms, tool/CLI output, and the mandatory footer labels `Agent`, `Skills`, `Implants`, `Rules` stay in English.
+   - Append at the end (labels in English, values are canonical IDs): **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
    - Call `log_interaction(agent_name, query, response_content)`.
 
 ## Available MCP Tools
@@ -56,6 +56,14 @@ If `route_and_load` fails or Agents-Core MCP is not connected:
 
 ---
 
+## Enrichment layers (order in every system prompt)
+
+1. **Base agent system_prompt** — agent persona from `agents/<name>/system_prompt.mdc`.
+2. **Rules** (`rules/rule-*.mdc`) — **always-on, universal, no semantic retrieval, no opt-out**. Loaded by `src/engine/rules.py`. Architectural invariant: rules apply to every agent without exception. Per-agent guidance belongs in `skills/`. Toggle via `RULES_ENABLED=0`.
+3. **Skills** (`skills/skill-*.mdc`) — semantic retrieval + per-agent opt-in via `preferred_skills` / `capabilities`. Caveman-style output compression lives here as `skill-caveman-tokenomics`, opt-in via the `concise-output` capability.
+4. **Capability Directives** — terse one-liners from `agents/capabilities/registry.yaml`.
+5. **Implants** (`implants/implant-*.mdc`) — semantic retrieval, cognitive reasoning patterns.
+
 ## Repository Structure
 
 ```
@@ -65,8 +73,9 @@ src/
     router.py          — SemanticRouter: cache lookup, keyword matching, agent catalog
     vector_store.py    — NumpyVectorStore: numpy-based cosine similarity store
     embedder.py        — FastEmbed wrapper (model configurable via EMBEDDING_MODEL env var)
-    config.py          — Thresholds, paths, env-based configuration
-    enrichment.py      — Prompt enrichment with skills/implants by tier (lite/standard/deep)
+    config.py          — Thresholds, paths, env-based configuration (RULES_ENABLED, RULES_DIR)
+    enrichment.py      — Prompt enrichment with rules/skills/implants by tier (lite/standard/deep)
+    rules.py           — Universal always-on rules layer (no retrieval, no opt-out)
     skills.py          — Skill retrieval from vector store
     implants.py        — Implant retrieval from vector store
     capabilities.py    — Capability -> skill resolution via registry.yaml
@@ -77,17 +86,19 @@ src/
     debug_logger.py    — JSON debug logging (AGENTS_DEBUG=1)
     langfuse_compat.py — Optional Langfuse observability
   schemas/
-    protocol.py        — RouterDecision, AgentRequest, EnrichmentResult
+    protocol.py        — RouterDecision, AgentRequest, AgentResponse
 agents/
   [name]/system_prompt.mdc — Agent persona with YAML frontmatter (identity, routing, skills)
   common/agent-schema.json — Frontmatter JSON schema
-  capabilities/registry.yaml — Capability -> skill mapping
-skills/skill-*.mdc         — Compiled skill prompts
+  capabilities/registry.yaml — Capability -> skill mapping (incl. concise-output)
+rules/rule-*.mdc           — Universal always-on directives (accuracy, honesty, language, sycophancy)
+skills/skill-*.mdc         — Compiled skill prompts (incl. skill-caveman-tokenomics)
 implants/implant-*.mdc     — Cognitive reasoning implants
 tests/
   test_routing.py      — Routing logic, sticky routing, keyword boosting tests
   test_vector_store.py — NumpyVectorStore correctness tests
   test_language.py     — Language detection tests
+  test_rules.py        — Rules layer: parsing, priority, invariant (no opt-out fields)
 ```
 
 ## Routing Flow (Internal)

--- a/skills/skill-caveman-tokenomics.mdc
+++ b/skills/skill-caveman-tokenomics.mdc
@@ -1,0 +1,30 @@
+---
+description: "Terse output. BLUF (answer-first). Drop fluff, keep technical substance. Inspired by github.com/JuliusBrussee/caveman."
+compiled: "Terse. BLUF. Drop articles/filler/hedging. Keep numbers/code/paths verbatim. Pattern: [thing][action][reason].[next]. Off in code/commits."
+---
+## Role
+Token economist: every word costs money. Cut what does not buy meaning.
+
+## Rules
+- **Terse**: technical substance exact, fluff dies.
+- **BLUF**: answer first, justification after. Skip warm-ups ("Sure!", "Let me explain", "I'd be happy to").
+- **Drop**: articles, filler (just/really/basically/actually), pleasantries, hedging, restating the question.
+- **Keep verbatim**: numbers, names, code, file paths, URLs, error messages.
+
+## Pattern
+`[thing] [action] [reason]. [next step].`
+
+Fragments OK. Lists > paragraphs. Tables for comparison.
+
+## Off-switches
+Normal verbosity required in:
+- code blocks themselves
+- commit messages, PR descriptions, changelog entries
+- legal text, medical text, official documents
+
+User says "in detail" / "stop caveman" / "verbose" → revert to normal style for the rest of the turn.
+
+## Example
+Instead of: "Sure! The reason your component is re-rendering is likely because you're creating a new object reference on each render cycle. I'd recommend wrapping the object in useMemo to memoize it."
+
+Use: "New object ref each render. Wrap in `useMemo`."

--- a/skills/skill-caveman-tokenomics.mdc
+++ b/skills/skill-caveman-tokenomics.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Terse output. BLUF (answer-first). Drop fluff, keep technical substance. Inspired by github.com/JuliusBrussee/caveman."
-compiled: "Terse. BLUF. Drop articles/filler/hedging. Keep numbers/code/paths verbatim. Pattern: [thing][action][reason].[next]. Off in code/commits."
+compiled: "Terse. BLUF. Drop articles/filler/hollow-hedging. Keep numbers/code/paths verbatim AND required uncertainty markers (honest-uncertainty rule wins). Pattern: [thing][action][reason].[next]. Off in code/commits."
 ---
 ## Role
 Token economist: every word costs money. Cut what does not buy meaning.
@@ -8,8 +8,9 @@ Token economist: every word costs money. Cut what does not buy meaning.
 ## Rules
 - **Terse**: technical substance exact, fluff dies.
 - **BLUF**: answer first, justification after. Skip warm-ups ("Sure!", "Let me explain", "I'd be happy to").
-- **Drop**: articles, filler (just/really/basically/actually), pleasantries, hedging, restating the question.
+- **Drop**: articles, unnecessary filler (just/really/basically/actually), pleasantries, hollow hedging ("I'd say maybe", "perhaps just", "I would tend to think"), restating the question.
 - **Keep verbatim**: numbers, names, code, file paths, URLs, error messages.
+- **Keep required confidence markers**: the always-on `honest-uncertainty` rule wins over compression. Words like "I think", "likely", "probably", "I don't know" stay when they signal real uncertainty — drop only the cosmetic versions that mask a confident claim.
 
 ## Pattern
 `[thing] [action] [reason]. [next step].`

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -18,6 +18,7 @@ INSTALL_DATA_DIR = os.path.join(INSTALL_ROOT, "data")
 AGENTS_DIR = os.path.join(INSTALL_ROOT, "agents")
 SKILLS_DIR = os.path.join(INSTALL_ROOT, "skills")
 IMPLANTS_DIR = os.path.join(INSTALL_ROOT, "implants")
+RULES_DIR = os.path.join(INSTALL_ROOT, "rules")
 CAPABILITIES_FILE = os.path.join(INSTALL_ROOT, "agents", "capabilities", "registry.yaml")
 
 # --- Client repo root (per-session, per-repo memory artifacts) ---------------
@@ -161,6 +162,10 @@ SESSION_CACHE_TTL_SECONDS = 600
 
 # Debug logging — set AGENTS_DEBUG=1 in .env to write per-call JSON files to logs/
 AGENTS_DEBUG = os.getenv("AGENTS_DEBUG", "").lower() in ("1", "true")
+
+# Rules layer — universal directives loaded into every enriched prompt.
+# Disable with RULES_ENABLED=0 to compare behavior with/without the layer.
+RULES_ENABLED = os.getenv("RULES_ENABLED", "1").lower() in ("1", "true")
 
 
 # --- Deprecated name aliases (PEP 562) ---------------------------------------

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -50,14 +50,20 @@ async def get_dynamic_context_string(
     capabilities: Optional[List[str]] = None,
     preferred_implants: Optional[List[str]] = None,
 ) -> EnrichmentResult:
-    """Build the dynamic context block prepended to an agent's base prompt.
+    """Build the dynamic context block that ``enrich_agent_prompt`` appends to
+    an agent's base prompt.
 
-    Layer order (constant; tier only affects what's in each layer):
+    The block itself is composed of four sub-layers in this fixed internal
+    order (tier only affects which sub-layers are populated):
+
     1. **Rules** — always-on universal directives from ``rules/`` (no
        semantic retrieval, no opt-out). Skipped only when ``RULES_ENABLED=0``.
     2. **Skills** — semantic + capability-resolved (skipped at ``lite`` tier).
     3. **Capability Directives** — terse one-liners from ``agents/capabilities/registry.yaml``.
     4. **Implants** — cognitive reasoning patterns (``standard``/``deep`` tiers only).
+
+    Final concatenation in ``enrich_agent_prompt``: ``base_prompt + "\\n\\n" +
+    block``. The agent persona retains primacy; the dynamic block follows.
 
     The returned ``EnrichmentResult`` carries the joined prompt fragment plus
     the names loaded for each layer, which the server surfaces to clients.

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -176,7 +176,16 @@ async def enrich_agent_prompt(
     capabilities: Optional[List[str]] = None,
     preferred_implants: Optional[List[str]] = None,
 ) -> EnrichmentResult:
-    """Enrich the base system prompt with dynamic skills and implants."""
+    """Append the dynamic context block (rules, skills, capability directives,
+    implants) to the agent's base system prompt and return the combined prompt.
+
+    Concatenation: ``base_prompt + "\\n\\n" + dynamic_block``. Agent persona
+    keeps primacy; the dynamic block follows. Any of the four sub-layers may be
+    empty depending on tier, ``RULES_ENABLED``, and the agent's frontmatter.
+
+    Returns ``EnrichmentResult`` with the combined prompt plus the names loaded
+    for each layer (``rules_loaded``, ``skills_loaded``, ``implants_loaded``).
+    """
     if chat_history is None:
         chat_history = []
     if tier is None:

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -10,6 +10,7 @@ from src.engine.config import AGENTS_DEBUG, get_debug_log_dir
 from src.engine.skills import SkillRetriever
 from src.engine.implants import ImplantRetriever
 from src.engine.capabilities import resolve_capabilities
+from src.engine.rules import format_rules_for_prompt, get_rules
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ class EnrichmentResult:
     prompt: str
     skills_loaded: list[str] = field(default_factory=list)
     implants_loaded: list[str] = field(default_factory=list)
+    rules_loaded: list[str] = field(default_factory=list)
 
 skill_retriever = SkillRetriever()
 implant_retriever = ImplantRetriever()
@@ -55,6 +57,14 @@ async def get_dynamic_context_string(
     context_parts: list[str] = []
     loaded_skill_names: list[str] = []
     loaded_implant_names: list[str] = []
+    loaded_rule_names: list[str] = []
+
+    rules = get_rules()
+    if rules:
+        rules_block = format_rules_for_prompt(rules)
+        if rules_block:
+            context_parts.append(rules_block)
+            loaded_rule_names = [r.name for r in rules]
 
     effective_skills = list(preferred_skills or [])
     cap_directive = ""
@@ -136,6 +146,7 @@ async def get_dynamic_context_string(
         prompt="\n\n".join(context_parts),
         skills_loaded=loaded_skill_names,
         implants_loaded=loaded_implant_names,
+        rules_loaded=loaded_rule_names,
     )
 
 async def enrich_agent_prompt(
@@ -163,4 +174,5 @@ async def enrich_agent_prompt(
         prompt=base_prompt,
         skills_loaded=enrichment.skills_loaded,
         implants_loaded=enrichment.implants_loaded,
+        rules_loaded=enrichment.rules_loaded,
     )

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -50,7 +50,18 @@ async def get_dynamic_context_string(
     capabilities: Optional[List[str]] = None,
     preferred_implants: Optional[List[str]] = None,
 ) -> EnrichmentResult:
-    """Retrieve and format dynamic context (Skills + Implants) based on tier."""
+    """Build the dynamic context block prepended to an agent's base prompt.
+
+    Layer order (constant; tier only affects what's in each layer):
+    1. **Rules** — always-on universal directives from ``rules/`` (no
+       semantic retrieval, no opt-out). Skipped only when ``RULES_ENABLED=0``.
+    2. **Skills** — semantic + capability-resolved (skipped at ``lite`` tier).
+    3. **Capability Directives** — terse one-liners from ``capabilities/registry.yaml``.
+    4. **Implants** — cognitive reasoning patterns (``standard``/``deep`` tiers only).
+
+    The returned ``EnrichmentResult`` carries the joined prompt fragment plus
+    the names loaded for each layer, which the server surfaces to clients.
+    """
     if chat_history is None:
         chat_history = []
     loop = asyncio.get_running_loop()

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -76,12 +76,21 @@ async def get_dynamic_context_string(
     loaded_implant_names: list[str] = []
     loaded_rule_names: list[str] = []
 
-    rules = get_rules()
-    if rules:
-        rules_block = format_rules_for_prompt(rules)
-        if rules_block:
-            context_parts.append(rules_block)
-            loaded_rule_names = [r.name for r in rules]
+    # Rules layer must not break routing. The skills and implants blocks below
+    # are wrapped in try/except for the same reason — degrade gracefully to
+    # "fewer layers" rather than failing the whole request. `_parse_rule_file`
+    # already defends against malformed individual files (round 2 fix); this
+    # outer guard catches anything unexpected from `get_rules()` or the
+    # formatter (e.g. transient FS errors after `invalidate_cache()`).
+    try:
+        rules = get_rules()
+        if rules:
+            rules_block = format_rules_for_prompt(rules)
+            if rules_block:
+                context_parts.append(rules_block)
+                loaded_rule_names = [r.name for r in rules]
+    except Exception as e:
+        logger.error("Failed to load rules layer: %s", e, exc_info=True)
 
     effective_skills = list(preferred_skills or [])
     cap_directive = ""

--- a/src/engine/enrichment.py
+++ b/src/engine/enrichment.py
@@ -56,7 +56,7 @@ async def get_dynamic_context_string(
     1. **Rules** — always-on universal directives from ``rules/`` (no
        semantic retrieval, no opt-out). Skipped only when ``RULES_ENABLED=0``.
     2. **Skills** — semantic + capability-resolved (skipped at ``lite`` tier).
-    3. **Capability Directives** — terse one-liners from ``capabilities/registry.yaml``.
+    3. **Capability Directives** — terse one-liners from ``agents/capabilities/registry.yaml``.
     4. **Implants** — cognitive reasoning patterns (``standard``/``deep`` tiers only).
 
     The returned ``EnrichmentResult`` carries the joined prompt fragment plus

--- a/src/engine/rules.py
+++ b/src/engine/rules.py
@@ -5,10 +5,12 @@ Rules apply to every agent without exception. Anything per-agent belongs in
 is enforced in ``load_all_rules`` — any rule with ``applies_to`` or
 ``exclude_agents`` fields is rejected and logged.
 
-Rules are loaded once at import time, sorted by ``priority`` (lower first), and
-formatted as a single ``## Rules`` markdown block prepended to the dynamic
-context in ``enrichment.py``. No semantic retrieval, no caching — the set is
-fixed at process start.
+Rules are lazy-loaded via ``get_rules()``, sorted by ``priority`` (lower first),
+and formatted as a single ``## Rules`` markdown block prepended to the dynamic
+context in ``enrichment.py``. The loaded set is memoized into a process-local
+cache after the first call; there is no semantic retrieval, and rules are only
+re-read from disk when ``invalidate_cache()`` is called (e.g. by tests or after
+editing files at runtime).
 """
 
 from __future__ import annotations
@@ -16,6 +18,7 @@ from __future__ import annotations
 import glob
 import logging
 import os
+import re
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -28,6 +31,14 @@ logger = logging.getLogger(__name__)
 
 
 _FORBIDDEN_FIELDS = ("applies_to", "exclude_agents")
+
+# Strip a single leading H1 heading from rule bodies when rendering.
+# Each rule body is wrapped under a "### Rule: <name>" subheader inside the
+# enrichment prompt; an authoring H1 inside the body would create mixed
+# heading levels (### then # then text), which breaks markdown semantics.
+# The rule's name is already shown in the per-rule header, so the H1 is
+# always redundant and safe to drop.
+_LEADING_H1_RE = re.compile(r"^#\s+[^\n]*\n+")
 
 
 @dataclass(frozen=True)
@@ -134,7 +145,12 @@ def invalidate_cache() -> None:
 
 
 def format_rules_for_prompt(rules: List[Rule]) -> str:
-    """Render the rules list as a single ``## Rules`` markdown block."""
+    """Render the rules list as a single ``## Rules`` markdown block.
+
+    A leading H1 heading inside a rule body (e.g. ``# No fabrication``) is
+    stripped — each rule is already wrapped under ``### Rule: <name>``, so an
+    H1 inside would produce mixed heading levels in the rendered prompt.
+    """
     if not rules:
         return ""
 
@@ -148,6 +164,7 @@ def format_rules_for_prompt(rules: List[Rule]) -> str:
         if rule.description:
             lines.append(f"_{rule.description}_")
         lines.append("")
-        lines.append(rule.body)
+        body = _LEADING_H1_RE.sub("", rule.body, count=1).lstrip()
+        lines.append(body)
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"

--- a/src/engine/rules.py
+++ b/src/engine/rules.py
@@ -1,0 +1,153 @@
+"""Always-on universal rules layer.
+
+Rules apply to every agent without exception. Anything per-agent belongs in
+``skills/`` (see ``capabilities/registry.yaml``). The architectural invariant
+is enforced in ``load_all_rules`` — any rule with ``applies_to`` or
+``exclude_agents`` fields is rejected and logged.
+
+Rules are loaded once at import time, sorted by ``priority`` (lower first), and
+formatted as a single ``## Rules`` markdown block prepended to the dynamic
+context in ``enrichment.py``. No semantic retrieval, no caching — the set is
+fixed at process start.
+"""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import yaml
+
+from src.engine.config import RULES_DIR, RULES_ENABLED
+from src.utils.prompt_loader import split_frontmatter
+
+logger = logging.getLogger(__name__)
+
+
+_FORBIDDEN_FIELDS = ("applies_to", "exclude_agents")
+
+
+@dataclass(frozen=True)
+class Rule:
+    name: str
+    description: str
+    priority: int
+    category: str
+    body: str
+    filename: str = ""
+
+
+_cache: Optional[List[Rule]] = None
+
+
+def _parse_rule_file(path: str) -> Optional[Rule]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        logger.error("Failed to read rule file %s: %s", path, e)
+        return None
+
+    fm_str, body = split_frontmatter(content)
+    if fm_str is None:
+        logger.warning("Rule file %s has no frontmatter — skipped", path)
+        return None
+
+    try:
+        fm = yaml.safe_load(fm_str) or {}
+    except yaml.YAMLError as e:
+        logger.error("Bad frontmatter YAML in %s: %s", path, e)
+        return None
+
+    if not isinstance(fm, dict):
+        logger.error("Frontmatter in %s is not a mapping — skipped", path)
+        return None
+
+    forbidden = [k for k in _FORBIDDEN_FIELDS if k in fm]
+    if forbidden:
+        logger.error(
+            "Rule %s has forbidden fields %s — rules are universal. "
+            "Move per-agent guidance to a skill via capabilities/registry.yaml.",
+            path, forbidden,
+        )
+        return None
+
+    name = fm.get("name")
+    if not name:
+        logger.error("Rule %s missing required 'name' field — skipped", path)
+        return None
+
+    return Rule(
+        name=str(name),
+        description=str(fm.get("description", "")),
+        priority=int(fm.get("priority", 50)),
+        category=str(fm.get("category", "general")),
+        body=body.strip(),
+        filename=os.path.basename(path),
+    )
+
+
+def load_all_rules() -> List[Rule]:
+    """Read every ``rules/rule-*.mdc`` and return a list sorted by priority.
+
+    Reload-safe: call ``invalidate_cache()`` after editing files on disk.
+    Rejects rules with ``applies_to`` or ``exclude_agents`` (architectural
+    invariant — see module docstring).
+    """
+    rules: List[Rule] = []
+
+    if not os.path.isdir(RULES_DIR):
+        logger.info("Rules directory not found at %s — no rules loaded", RULES_DIR)
+        return rules
+
+    for path in sorted(glob.glob(os.path.join(RULES_DIR, "rule-*.mdc"))):
+        rule = _parse_rule_file(path)
+        if rule is not None:
+            rules.append(rule)
+
+    rules.sort(key=lambda r: (r.priority, r.name))
+    logger.info("Loaded %d rules from %s", len(rules), RULES_DIR)
+    return rules
+
+
+def get_rules() -> List[Rule]:
+    """Cached entry point used by the enrichment pipeline.
+
+    Returns an empty list when ``RULES_ENABLED=0`` so the layer can be
+    disabled for diagnostics without removing files.
+    """
+    global _cache
+    if not RULES_ENABLED:
+        return []
+    if _cache is None:
+        _cache = load_all_rules()
+    return _cache
+
+
+def invalidate_cache() -> None:
+    """Force ``get_rules()`` to re-read from disk on the next call. Tests use this."""
+    global _cache
+    _cache = None
+
+
+def format_rules_for_prompt(rules: List[Rule]) -> str:
+    """Render the rules list as a single ``## Rules`` markdown block."""
+    if not rules:
+        return ""
+
+    lines = [
+        "## Rules (always-on, MUST follow)",
+        "These directives apply to every response. They are not negotiable per turn.",
+        "",
+    ]
+    for rule in rules:
+        lines.append(f"### Rule: {rule.name}")
+        if rule.description:
+            lines.append(f"_{rule.description}_")
+        lines.append("")
+        lines.append(rule.body)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/engine/rules.py
+++ b/src/engine/rules.py
@@ -38,7 +38,11 @@ _FORBIDDEN_FIELDS = ("applies_to", "exclude_agents")
 # heading levels (### then # then text), which breaks markdown semantics.
 # The rule's name is already shown in the per-rule header, so the H1 is
 # always redundant and safe to drop.
-_LEADING_H1_RE = re.compile(r"^#\s+[^\n]*\n+")
+#
+# `[ \t]+` (horizontal whitespace only) — NOT `\s+` — so a rule body that
+# happens to start with a bare `#` followed by a newline doesn't have its
+# first content line consumed along with the (non-existent) heading text.
+_LEADING_H1_RE = re.compile(r"^#[ \t]+[^\n]*\n+")
 
 
 @dataclass(frozen=True)

--- a/src/engine/rules.py
+++ b/src/engine/rules.py
@@ -1,8 +1,8 @@
 """Always-on universal rules layer.
 
 Rules apply to every agent without exception. Anything per-agent belongs in
-``skills/`` (see ``capabilities/registry.yaml``). The architectural invariant
-is enforced in ``load_all_rules`` — any rule with ``applies_to`` or
+``skills/`` (see ``agents/capabilities/registry.yaml``). The architectural
+invariant is enforced in ``load_all_rules`` — any rule with ``applies_to`` or
 ``exclude_agents`` fields is rejected and logged.
 
 Rules are lazy-loaded via ``get_rules()``, sorted by ``priority`` (lower first),
@@ -19,7 +19,7 @@ import glob
 import logging
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
 
 import yaml
@@ -81,7 +81,7 @@ def _parse_rule_file(path: str) -> Optional[Rule]:
     if forbidden:
         logger.error(
             "Rule %s has forbidden fields %s — rules are universal. "
-            "Move per-agent guidance to a skill via capabilities/registry.yaml.",
+            "Move per-agent guidance to a skill via agents/capabilities/registry.yaml.",
             path, forbidden,
         )
         return None
@@ -91,10 +91,23 @@ def _parse_rule_file(path: str) -> Optional[Rule]:
         logger.error("Rule %s missing required 'name' field — skipped", path)
         return None
 
+    raw_priority = fm.get("priority", 50)
+    try:
+        priority = int(raw_priority)
+    except (TypeError, ValueError):
+        # A non-numeric priority (e.g. "high", a list) used to crash the entire
+        # enrichment pipeline because this exception bubbled up to every request.
+        # Skip the rule instead — one malformed file must not break routing.
+        logger.error(
+            "Rule %s has non-integer 'priority' value %r — skipped",
+            path, raw_priority,
+        )
+        return None
+
     return Rule(
         name=str(name),
         description=str(fm.get("description", "")),
-        priority=int(fm.get("priority", 50)),
+        priority=priority,
         category=str(fm.get("category", "general")),
         body=body.strip(),
         filename=os.path.basename(path),

--- a/src/server.py
+++ b/src/server.py
@@ -1053,6 +1053,24 @@ def _warmup_embedding_model():
         logger.warning("Embedding model warmup failed: %s", e, exc_info=True)
 
 
+def _warmup_rules():
+    """Pre-load and cache the always-on rules layer at startup.
+
+    ``get_rules()`` does sync filesystem I/O on its first call (parsing
+    ``rules/rule-*.mdc``). It's invoked from ``get_dynamic_context_string``
+    on the async path, so without this warmup the very first request would
+    block the event loop while reading the rule files. Rules are static
+    for the process lifetime, so a single eager load amortizes the cost.
+    """
+    try:
+        from src.engine.rules import get_rules
+        rules = get_rules()
+        logger.info("Rules layer warmed up: %d rule(s) loaded", len(rules))
+    except Exception as e:
+        logger.warning("Rules layer warmup failed: %s", e, exc_info=True)
+
+
 if __name__ == "__main__":
     _warmup_embedding_model()
+    _warmup_rules()
     mcp.run()

--- a/src/server.py
+++ b/src/server.py
@@ -185,19 +185,28 @@ async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[
     cache_key = f"{agent_name}:{query_hash}:{tier}"
     if cache_key in SESSION_CACHE:
         cached = SESSION_CACHE[cache_key]
+        cache_used = False
         if isinstance(cached, tuple):
             if len(cached) == 4:
                 prompt, skills_loaded, implants_loaded, rules_loaded = cached
+                cache_used = True
             elif len(cached) == 3:
+                # Pre-rules cache shape — accept but treat rules as empty.
                 prompt, skills_loaded, implants_loaded = cached
                 rules_loaded = []
-            else:
-                prompt, skills_loaded, implants_loaded, rules_loaded = cached[0], [], [], []
-        else:
-            prompt, skills_loaded, implants_loaded, rules_loaded = cached, [], [], []
-        logger.info(f"Session cache hit for {agent_name} (tier={tier})")
-        debug_log("_load_and_enrich", "res", {"agent": agent_name, "tier": tier, "cache": "hit", "prompt_len": len(prompt)})
-        return prompt, _compute_context_hash(prompt), skills_loaded, implants_loaded, rules_loaded, tier
+                cache_used = True
+        if cache_used:
+            logger.info(f"Session cache hit for {agent_name} (tier={tier})")
+            debug_log("_load_and_enrich", "res", {"agent": agent_name, "tier": tier, "cache": "hit", "prompt_len": len(prompt)})
+            return prompt, _compute_context_hash(prompt), skills_loaded, implants_loaded, rules_loaded, tier
+        # Unknown shape — log loudly and evict so the bug surfaces deterministically
+        # instead of silently returning partial metadata.
+        logger.warning(
+            "SESSION_CACHE entry for %s has unexpected shape %r; evicting and refetching.",
+            cache_key, type(cached).__name__ + (f"[{len(cached)}]" if isinstance(cached, tuple) else ""),
+        )
+        debug_log("_load_and_enrich", "cache_corrupt", {"agent": agent_name, "tier": tier, "shape": str(type(cached))})
+        del SESSION_CACHE[cache_key]
 
     base_prompt = await loop.run_in_executor(None, load_agent_prompt, agent_name)
 

--- a/src/server.py
+++ b/src/server.py
@@ -55,8 +55,10 @@ mcp = FastMCP(
         "- NO_CHANGE → context unchanged, continue.\n"
         "- ERROR → answer directly (only fallback).\n\n"
         "Respond in the same language as the user's query (auto-detect). "
-        "Exceptions: code blocks, technical terms, and tool/CLI output stay in English.\n"
-        "Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]"
+        "Exceptions: code blocks, technical terms, tool/CLI output, and the mandatory footer "
+        "labels `Agent`, `Skills`, `Implants`, `Rules` stay in English.\n"
+        "Append at the end (labels in English, values are canonical IDs): "
+        "**Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]"
     ),
 )
 
@@ -280,8 +282,10 @@ async def route_and_load(
     - ERROR → Answer directly (only fallback).
 
     Respond in the same language as the user's query (auto-detect).
-    Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-    Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
+    Exceptions: code blocks, technical terms, tool/CLI output, and the mandatory
+    footer labels `Agent`, `Skills`, `Implants`, `Rules` stay in English.
+    Append at the end (labels in English, values are canonical IDs):
+    **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
     Pass `context_hash` from a previous response to enable delta mode.
     When context_hash maps to a previously loaded agent, sticky routing is activated:
     the router prefers keeping the current agent unless a very strong semantic signal
@@ -481,8 +485,10 @@ async def get_agent_context(agent_name: str, query: str, reasoning: str = "Selec
     If the client supports sampling, returns a ready-made response (SUCCESS_SAMPLED).
     Otherwise returns the system_prompt for you to use as context.
     Respond in the same language as the user's query (auto-detect).
-    Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-    Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
+    Exceptions: code blocks, technical terms, tool/CLI output, and the mandatory
+    footer labels `Agent`, `Skills`, `Implants`, `Rules` stay in English.
+    Append at the end (labels in English, values are canonical IDs):
+    **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
     """
     try:
         chat_history_list = _normalize_chat_history(chat_history)

--- a/src/server.py
+++ b/src/server.py
@@ -56,7 +56,7 @@ mcp = FastMCP(
         "- ERROR → answer directly (only fallback).\n\n"
         "Respond in the same language as the user's query (auto-detect). "
         "Exceptions: code blocks, technical terms, and tool/CLI output stay in English.\n"
-        "Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]"
+        "Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]"
     ),
 )
 
@@ -161,9 +161,9 @@ def _build_route_required(request_id: str, tier: str, candidates: list) -> str:
     debug_log("route_and_load", "res", result)
     return json.dumps(result, ensure_ascii=False)
 
-async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[str], tier: str | None = None) -> tuple[str, str, list[str], list[str], str]:
-    """Shared helper: load prompt, enrich with skills/implants/capabilities.
-    Returns (final_prompt, context_hash, skills_loaded, implants_loaded, effective_tier).
+async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[str], tier: str | None = None) -> tuple[str, str, list[str], list[str], list[str], str]:
+    """Shared helper: load prompt, enrich with rules/skills/implants/capabilities.
+    Returns (final_prompt, context_hash, skills_loaded, implants_loaded, rules_loaded, effective_tier).
     """
     tier_explicit = tier is not None
     if tier is None:
@@ -186,12 +186,18 @@ async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[
     if cache_key in SESSION_CACHE:
         cached = SESSION_CACHE[cache_key]
         if isinstance(cached, tuple):
-            prompt, skills_loaded, implants_loaded = cached
+            if len(cached) == 4:
+                prompt, skills_loaded, implants_loaded, rules_loaded = cached
+            elif len(cached) == 3:
+                prompt, skills_loaded, implants_loaded = cached
+                rules_loaded = []
+            else:
+                prompt, skills_loaded, implants_loaded, rules_loaded = cached[0], [], [], []
         else:
-            prompt, skills_loaded, implants_loaded = cached, [], []
+            prompt, skills_loaded, implants_loaded, rules_loaded = cached, [], [], []
         logger.info(f"Session cache hit for {agent_name} (tier={tier})")
         debug_log("_load_and_enrich", "res", {"agent": agent_name, "tier": tier, "cache": "hit", "prompt_len": len(prompt)})
-        return prompt, _compute_context_hash(prompt), skills_loaded, implants_loaded, tier
+        return prompt, _compute_context_hash(prompt), skills_loaded, implants_loaded, rules_loaded, tier
 
     base_prompt = await loop.run_in_executor(None, load_agent_prompt, agent_name)
 
@@ -202,7 +208,7 @@ async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[
         preferred_implants=preferred_implants,
     )
     final_prompt = enrichment.prompt
-    SESSION_CACHE[cache_key] = (final_prompt, enrichment.skills_loaded, enrichment.implants_loaded)
+    SESSION_CACHE[cache_key] = (final_prompt, enrichment.skills_loaded, enrichment.implants_loaded, enrichment.rules_loaded)
     ctx_hash = _compute_context_hash(final_prompt)
     CONTEXT_HASH_CACHE[ctx_hash] = agent_name
     debug_log("_load_and_enrich", "res", {
@@ -211,8 +217,9 @@ async def _load_and_enrich(agent_name: str, query: str, chat_history_list: List[
         "preferred_implants": preferred_implants, "capabilities": capabilities,
         "skills_loaded": enrichment.skills_loaded,
         "implants_loaded": enrichment.implants_loaded,
+        "rules_loaded": enrichment.rules_loaded,
     })
-    return final_prompt, ctx_hash, enrichment.skills_loaded, enrichment.implants_loaded, tier
+    return final_prompt, ctx_hash, enrichment.skills_loaded, enrichment.implants_loaded, enrichment.rules_loaded, tier
 
 
 async def _sample_with_agent(ctx: Context, system_prompt: str, query: str) -> str:
@@ -265,7 +272,7 @@ async def route_and_load(
 
     Respond in the same language as the user's query (auto-detect).
     Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-    Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
+    Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
     Pass `context_hash` from a previous response to enable delta mode.
     When context_hash maps to a previously loaded agent, sticky routing is activated:
     the router prefers keeping the current agent unless a very strong semantic signal
@@ -393,7 +400,7 @@ async def route_and_load(
 
         # 3. Cache hit or meta-query — load enriched prompt
         # Pass explicit_tier only for meta-queries (preserves "lite"); None lets _load_and_enrich infer + promote
-        final_prompt, new_hash, skills_loaded, implants_loaded, tier = await _load_and_enrich(agent_name, query, chat_history_list, explicit_tier)
+        final_prompt, new_hash, skills_loaded, implants_loaded, rules_loaded, tier = await _load_and_enrich(agent_name, query, chat_history_list, explicit_tier)
 
         if context_hash and context_hash == new_hash:
             result = {
@@ -404,6 +411,7 @@ async def route_and_load(
                 "tier": tier,
                 "skills_loaded": skills_loaded,
                 "implants_loaded": implants_loaded,
+                "rules_loaded": rules_loaded,
             }
             debug_log("route_and_load", "res", result)
             return json.dumps(result, ensure_ascii=False)
@@ -425,6 +433,7 @@ async def route_and_load(
                     "response": response,
                     "skills_loaded": skills_loaded,
                     "implants_loaded": implants_loaded,
+                    "rules_loaded": rules_loaded,
                 }
                 debug_log("route_and_load", "res", result)
                 return json.dumps(result, ensure_ascii=False)
@@ -443,6 +452,7 @@ async def route_and_load(
             "system_prompt": final_prompt,
             "skills_loaded": skills_loaded,
             "implants_loaded": implants_loaded,
+            "rules_loaded": rules_loaded,
         }
         debug_log("route_and_load", "res", result)
         return json.dumps(result, ensure_ascii=False)
@@ -463,14 +473,14 @@ async def get_agent_context(agent_name: str, query: str, reasoning: str = "Selec
     Otherwise returns the system_prompt for you to use as context.
     Respond in the same language as the user's query (auto-detect).
     Exceptions: code blocks, technical terms, and tool/CLI output stay in English.
-    Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants]
+    Append at the end: **Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]
     """
     try:
         chat_history_list = _normalize_chat_history(chat_history)
         request_id = str(uuid.uuid4())
         debug_log("get_agent_context", "req", {"agent_name": agent_name, "query": query, "reasoning": reasoning})
 
-        final_prompt, ctx_hash, skills_loaded, implants_loaded, _ = await _load_and_enrich(agent_name, query, chat_history_list)
+        final_prompt, ctx_hash, skills_loaded, implants_loaded, rules_loaded, _ = await _load_and_enrich(agent_name, query, chat_history_list)
         await router.update_cache(query, agent_name, reasoning, request_id)
 
         # Try sampling: generate response with agent's system prompt via client LLM
@@ -485,6 +495,7 @@ async def get_agent_context(agent_name: str, query: str, reasoning: str = "Selec
                     "response": response,
                     "skills_loaded": skills_loaded,
                     "implants_loaded": implants_loaded,
+                    "rules_loaded": rules_loaded,
                 }
                 debug_log("get_agent_context", "res", result)
                 return json.dumps(result, ensure_ascii=False)
@@ -501,6 +512,7 @@ async def get_agent_context(agent_name: str, query: str, reasoning: str = "Selec
             "system_prompt": final_prompt,
             "skills_loaded": skills_loaded,
             "implants_loaded": implants_loaded,
+            "rules_loaded": rules_loaded,
         }
         debug_log("get_agent_context", "res", result)
         return json.dumps(result, ensure_ascii=False)
@@ -937,7 +949,7 @@ async def ask(query: str) -> list:
                 f"Agents:\n" + "\n".join(lines) + f"\n\nQuery: {query}"
             )]
 
-        prompt, _, _, _, _ = await _load_and_enrich(agent_name, query, [])
+        prompt, _, _, _, _, _ = await _load_and_enrich(agent_name, query, [])
         return [UserMessage(
             f"SYSTEM INSTRUCTIONS (MANDATORY — follow exactly):\n\n"
             f"{prompt}\n\n"
@@ -963,7 +975,7 @@ def _register_agent_prompts():
         def make_prompt(a_name, d_name, r):
             async def agent_prompt(query: str) -> list:
                 try:
-                    prompt, _, _, _, _ = await _load_and_enrich(a_name, query, [])
+                    prompt, _, _, _, _, _ = await _load_and_enrich(a_name, query, [])
                     return [UserMessage(
                         f"SYSTEM INSTRUCTIONS (MANDATORY — follow exactly):\n\n"
                         f"{prompt}\n\n"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -190,10 +190,13 @@ class TestStickyRouting:
         srv.SESSION_CACHE = self.original_session_cache
 
     def _make_enrich_result(self, agent_name):
-        """Helper: return a fake _load_and_enrich result."""
+        """Helper: return a fake _load_and_enrich result.
+
+        Tuple shape: (prompt, ctx_hash, skills_loaded, implants_loaded, rules_loaded, tier).
+        """
         prompt = f"system prompt for {agent_name}"
         ctx_hash = f"hash_{agent_name}"
-        return (prompt, ctx_hash, ["skill-a"], ["implant-a"], "standard")
+        return (prompt, ctx_hash, ["skill-a"], ["implant-a"], ["rule-a"], "standard")
 
     @pytest.mark.asyncio
     async def test_no_sticky_cache_miss_returns_route_required(self):
@@ -376,7 +379,7 @@ class TestStickyRouting:
         with patch.object(self.srv.router, "query_nearest",
                           new_callable=AsyncMock, return_value=None), \
              patch("src.server._load_and_enrich", new_callable=AsyncMock,
-                   return_value=("prompt", "prev_hash", ["s"], ["i"], "standard")), \
+                   return_value=("prompt", "prev_hash", ["s"], ["i"], ["r"], "standard")), \
              patch.object(self.srv.router, "update_cache", new_callable=AsyncMock):
             result = json.loads(await self.srv.route_and_load(
                 "Comment optimiser ce code?",
@@ -407,7 +410,7 @@ class TestPreferredImplants:
 
     def _fake_enrichment(self, **kwargs):
         from src.engine.enrichment import EnrichmentResult
-        return EnrichmentResult(prompt="enriched", skills_loaded=["s"], implants_loaded=["i"])
+        return EnrichmentResult(prompt="enriched", skills_loaded=["s"], implants_loaded=["i"], rules_loaded=["r"])
 
     @pytest.mark.asyncio
     async def test_tier_promoted_when_preferred_implants_present(self):
@@ -423,7 +426,7 @@ class TestPreferredImplants:
              patch("src.server.enrich_agent_prompt", new_callable=AsyncMock,
                    return_value=self._fake_enrichment()) as mock_enrich:
             # Short query → would infer "lite", but preferred_implants promotes to "standard"
-            _, _, _, _, effective_tier = await self.srv._load_and_enrich(
+            _, _, _, _, _, effective_tier = await self.srv._load_and_enrich(
                 "math_scientist", "hi", [])
             assert effective_tier == "standard"
 
@@ -440,7 +443,7 @@ class TestPreferredImplants:
              patch("src.server.load_agent_prompt", return_value="base prompt"), \
              patch("src.server.enrich_agent_prompt", new_callable=AsyncMock,
                    return_value=self._fake_enrichment()):
-            _, _, _, _, effective_tier = await self.srv._load_and_enrich(
+            _, _, _, _, _, effective_tier = await self.srv._load_and_enrich(
                 "math_scientist", "hi", [], tier="lite")
             assert effective_tier == "lite"
 
@@ -478,7 +481,7 @@ class TestPreferredImplants:
              patch("src.server.load_agent_prompt", return_value="base prompt"), \
              patch("src.server.enrich_agent_prompt", new_callable=AsyncMock,
                    return_value=self._fake_enrichment()):
-            _, _, _, _, effective_tier = await self.srv._load_and_enrich(
+            _, _, _, _, _, effective_tier = await self.srv._load_and_enrich(
                 "universal_agent", "hi", [])
             assert effective_tier == "lite"
 
@@ -693,7 +696,7 @@ class TestKeywordBoosting:
              patch.object(srv.router, "keyword_veto", return_value="russian_lawyer"), \
              patch.object(srv.router, "update_cache", new_callable=AsyncMock) as mock_cache, \
              patch("src.server._load_and_enrich", new_callable=AsyncMock, return_value=(
-                 "prompt", "hash123", ["skill1"], ["implant1"], "standard"
+                 "prompt", "hash123", ["skill1"], ["implant1"], ["rule1"], "standard"
              )), \
              patch("src.server._sample_with_agent", new_callable=AsyncMock, return_value=None):
             result = await srv.route_and_load("Проверить доверенность на соответствие российскому законодательству")

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -184,6 +184,41 @@ def test_loader_handles_missing_directory(tmp_path, monkeypatch):
     assert rules_module.load_all_rules() == []
 
 
+def test_enrichment_degrades_gracefully_when_rules_layer_raises(monkeypatch, caplog):
+    """A failure inside the rules layer must not break routing.
+
+    Regression guard for the cursor finding: ``get_dynamic_context_string``
+    used to call ``get_rules()`` outside any try/except, so an unexpected
+    error (FS hiccup after ``invalidate_cache()``, formatter bug, etc.)
+    would propagate and fail the whole request — even though the rules
+    layer is the ironically-named "always-on" guardrail. Skills/implants
+    already degrade to "fewer layers" on error; rules now do too.
+    """
+    import asyncio
+
+    from src.engine import enrichment as enrichment_module
+
+    def _boom():
+        raise RuntimeError("simulated rules-layer failure")
+
+    monkeypatch.setattr(enrichment_module, "get_rules", _boom)
+
+    async def _run():
+        return await enrichment_module.get_dynamic_context_string(
+            agent_name="universal_agent",
+            query="hello",
+            tier="lite",
+        )
+
+    with caplog.at_level("ERROR"):
+        result = asyncio.run(_run())
+
+    assert result.rules_loaded == [], "Rules failure must not populate rules_loaded"
+    assert any("Failed to load rules layer" in rec.message for rec in caplog.records)
+    # Routing continues — caller still gets a (possibly empty) prompt back.
+    assert isinstance(result.prompt, str)
+
+
 def test_loader_skips_rule_with_non_integer_priority(tmp_path, monkeypatch, caplog):
     """A malformed rule (e.g. ``priority: high``) must not crash the pipeline.
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -135,6 +135,37 @@ def test_format_rules_for_prompt_empty_list():
     assert rules_module.format_rules_for_prompt([]) == ""
 
 
+def test_format_rules_strips_leading_h1_only_with_horizontal_space():
+    """Regression guard for the H1-stripping regex.
+
+    `_LEADING_H1_RE` used to match `^#\\s+...` where `\\s+` greedily included
+    newlines. A rule body starting with a bare `#` line followed by real
+    content would have had that next content line silently swallowed when
+    rendered. The regex now requires `[ \\t]+` (horizontal whitespace only),
+    so a bare `#\\n` is left alone — the only thing dropped is a real
+    Markdown H1 like `# Title`.
+    """
+    rule_real_h1 = rules_module.Rule(
+        name="r1", description="d", priority=10, category="x",
+        body="# Real H1 heading\n\nbody after",
+        filename="rule-r1.mdc",
+    )
+    rule_bare_hash = rules_module.Rule(
+        name="r2", description="d", priority=20, category="x",
+        body="#\nFirst content line must survive\nrest",
+        filename="rule-r2.mdc",
+    )
+
+    rendered = rules_module.format_rules_for_prompt([rule_real_h1, rule_bare_hash])
+
+    # Real H1 is stripped — body underneath remains.
+    assert "Real H1 heading" not in rendered
+    assert "body after" in rendered
+
+    # Bare `#` + newline is NOT a valid H1; the first content line must survive.
+    assert "First content line must survive" in rendered
+
+
 def test_loader_rejects_synthetic_rule_with_forbidden_field(tmp_path, monkeypatch, caplog):
     """A rule file shipping ``exclude_agents`` must be rejected at load time."""
     rules_dir = tmp_path / "rules"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,172 @@
+"""Tests for the universal rules layer.
+
+The rules layer must remain agent-agnostic — every rule applies to every agent.
+That invariant is the layer's only architectural reason to exist (otherwise it
+collapses into the skills layer). These tests guard the invariant and the
+loader contract used by ``src/engine/enrichment.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.engine import rules as rules_module
+from src.engine.config import RULES_DIR
+from src.utils.prompt_loader import split_frontmatter
+
+
+_FORBIDDEN_FIELDS = ("applies_to", "exclude_agents")
+_EXPECTED_RULE_NAMES = {
+    "no-fabrication",
+    "honest-uncertainty",
+    "anti-sycophancy",
+    "language-match",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_rules_cache():
+    """Each test gets a clean cache so fixtures from other tests don't leak."""
+    rules_module.invalidate_cache()
+    yield
+    rules_module.invalidate_cache()
+
+
+def _list_rule_files() -> list[Path]:
+    return sorted(Path(RULES_DIR).glob("rule-*.mdc"))
+
+
+def test_rules_directory_exists():
+    assert os.path.isdir(RULES_DIR), f"rules/ should exist at {RULES_DIR}"
+
+
+def test_v1_rule_files_present():
+    """The v1 set is the contract — adding/removing rules is a deliberate change."""
+    files = _list_rule_files()
+    names = {f.stem.removeprefix("rule-") for f in files}
+    assert _EXPECTED_RULE_NAMES <= names, (
+        f"Missing v1 rules: {_EXPECTED_RULE_NAMES - names}"
+    )
+
+
+def test_all_rule_files_parse():
+    rules = rules_module.load_all_rules()
+    expected_count = len(_list_rule_files())
+    assert len(rules) == expected_count, (
+        "load_all_rules dropped some files — check logs for parsing errors"
+    )
+
+
+def test_invariant_no_per_agent_fields_in_any_rule_file():
+    """Architectural invariant: rules are universal, no opt-in/opt-out fields.
+
+    A rule that needs ``applies_to`` or ``exclude_agents`` is not a rule —
+    promote it to a skill via ``agents/capabilities/registry.yaml``.
+    """
+    for path in _list_rule_files():
+        content = path.read_text(encoding="utf-8")
+        fm_str, _ = split_frontmatter(content)
+        assert fm_str is not None, f"{path} has no frontmatter"
+        fm = yaml.safe_load(fm_str) or {}
+        present = [k for k in _FORBIDDEN_FIELDS if k in fm]
+        assert not present, (
+            f"{path.name} contains forbidden fields {present}. "
+            "Per-agent guidance belongs in skills, not rules."
+        )
+
+
+def test_get_rules_sorted_by_priority():
+    rules = rules_module.get_rules()
+    priorities = [r.priority for r in rules]
+    assert priorities == sorted(priorities), "Rules must be sorted by priority asc"
+
+
+def test_get_rules_contains_v1_set():
+    names = {r.name for r in rules_module.get_rules()}
+    assert _EXPECTED_RULE_NAMES <= names
+
+
+def test_get_rules_disabled_returns_empty(monkeypatch):
+    monkeypatch.setattr(rules_module, "RULES_ENABLED", False)
+    rules_module.invalidate_cache()
+    assert rules_module.get_rules() == []
+
+
+def test_get_rules_caches_between_calls():
+    first = rules_module.get_rules()
+    second = rules_module.get_rules()
+    assert first is second, "get_rules should memoize until invalidate_cache()"
+
+
+def test_invalidate_cache_forces_reload():
+    first = rules_module.get_rules()
+    rules_module.invalidate_cache()
+    second = rules_module.get_rules()
+    assert first is not second
+    assert [r.name for r in first] == [r.name for r in second]
+
+
+def test_format_rules_for_prompt_includes_each_name():
+    rules = rules_module.get_rules()
+    rendered = rules_module.format_rules_for_prompt(rules)
+    assert rendered.startswith("## Rules"), "Block should be marked as ## Rules"
+    for r in rules:
+        assert r.name in rendered, f"Rule {r.name} missing from rendered block"
+
+
+def test_format_rules_for_prompt_empty_list():
+    assert rules_module.format_rules_for_prompt([]) == ""
+
+
+def test_loader_rejects_synthetic_rule_with_forbidden_field(tmp_path, monkeypatch, caplog):
+    """A rule file shipping ``exclude_agents`` must be rejected at load time."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "rule-bad.mdc").write_text(
+        textwrap.dedent(
+            """\
+            ---
+            name: bad-rule
+            description: Should be rejected.
+            priority: 5
+            category: accuracy
+            exclude_agents: [literary_writer]
+            ---
+            # Bad rule
+            Per-agent guidance — does not belong in rules/.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(rules_module, "RULES_DIR", str(rules_dir))
+    rules_module.invalidate_cache()
+
+    with caplog.at_level("ERROR"):
+        loaded = rules_module.load_all_rules()
+
+    assert loaded == [], "Forbidden-field rule must not be loaded"
+    assert any("forbidden fields" in rec.message for rec in caplog.records)
+
+
+def test_loader_skips_files_without_frontmatter(tmp_path, monkeypatch):
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "rule-empty.mdc").write_text("just a body, no frontmatter\n", encoding="utf-8")
+
+    monkeypatch.setattr(rules_module, "RULES_DIR", str(rules_dir))
+    rules_module.invalidate_cache()
+
+    assert rules_module.load_all_rules() == []
+
+
+def test_loader_handles_missing_directory(tmp_path, monkeypatch):
+    nonexistent = tmp_path / "no-rules-here"
+    monkeypatch.setattr(rules_module, "RULES_DIR", str(nonexistent))
+    rules_module.invalidate_cache()
+    assert rules_module.load_all_rules() == []

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -170,3 +170,53 @@ def test_loader_handles_missing_directory(tmp_path, monkeypatch):
     monkeypatch.setattr(rules_module, "RULES_DIR", str(nonexistent))
     rules_module.invalidate_cache()
     assert rules_module.load_all_rules() == []
+
+
+def test_loader_skips_rule_with_non_integer_priority(tmp_path, monkeypatch, caplog):
+    """A malformed rule (e.g. ``priority: high``) must not crash the pipeline.
+
+    Regression guard: previously ``int(fm.get("priority"))`` raised ``ValueError``
+    that propagated through ``get_rules`` → ``get_dynamic_context_string`` and
+    failed every request. Now the bad file is skipped with an error log; well-
+    formed rules in the same directory continue to load.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "rule-bad-priority.mdc").write_text(
+        textwrap.dedent(
+            """\
+            ---
+            name: bad-priority
+            description: Should be skipped, not crash.
+            priority: high
+            category: accuracy
+            ---
+            # Bad priority
+            Non-numeric priority used to take down the whole pipeline.
+            """
+        ),
+        encoding="utf-8",
+    )
+    (rules_dir / "rule-good.mdc").write_text(
+        textwrap.dedent(
+            """\
+            ---
+            name: good
+            description: Survives the malformed sibling.
+            priority: 5
+            category: accuracy
+            ---
+            Body.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(rules_module, "RULES_DIR", str(rules_dir))
+    rules_module.invalidate_cache()
+
+    with caplog.at_level("ERROR"):
+        loaded = rules_module.load_all_rules()
+
+    assert [r.name for r in loaded] == ["good"], "Malformed rule must be skipped, not crash"
+    assert any("non-integer 'priority'" in rec.message for rec in caplog.records)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -46,11 +46,23 @@ def test_rules_directory_exists():
 
 
 def test_v1_rule_files_present():
-    """The v1 set is the contract — adding/removing rules is a deliberate change."""
+    """The v1 set is the contract — adding/removing rules is a deliberate change.
+
+    Rules are always-on for every agent, so any addition or removal alters the
+    behavior of the whole system. The strict-equality check forces a paired
+    update of ``_EXPECTED_RULE_NAMES`` whenever ``rules/`` changes — that
+    paper trail is the point.
+    """
     files = _list_rule_files()
     names = {f.stem.removeprefix("rule-") for f in files}
-    assert _EXPECTED_RULE_NAMES <= names, (
-        f"Missing v1 rules: {_EXPECTED_RULE_NAMES - names}"
+    missing = _EXPECTED_RULE_NAMES - names
+    unexpected = names - _EXPECTED_RULE_NAMES
+    assert names == _EXPECTED_RULE_NAMES, (
+        f"Rule set changed. "
+        f"Missing v1 rules: {sorted(missing)}. "
+        f"Unexpected rule files: {sorted(unexpected)}. "
+        f"If this addition/removal is intentional, update _EXPECTED_RULE_NAMES "
+        f"in this test file as part of the same commit."
     )
 
 


### PR DESCRIPTION
## Summary
- New universal `rules/` layer (always-on, no semantic retrieval, no opt-out) with 4 directives: `no-fabrication`, `honest-uncertainty`, `anti-sycophancy`, `language-match`. Loader rejects any rule shipping `applies_to` / `exclude_agents` — per-agent guidance must live in `skills/`.
- Caveman-style output compression (inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman), ~75% output token reduction) added as `skill-caveman-tokenomics`. Opt-in for 12 technical agents via the new `concise-output` capability; verbose-output agents (legal, medical, literary, psychology) intentionally not opted in.
- `rules_loaded` now flows through `enrichment.py`, `server.py`, the session cache, and the response footer (`· **Rules**: [rules]`). Toggle with `RULES_ENABLED=0`.

## Test plan
- [x] `pytest tests/test_rules.py` — 14 new tests pass (loader, priority order, invariant against forbidden fields, cache, disabled mode)
- [x] `pytest tests/test_routing.py tests/test_vector_store.py` — 142 regression tests pass after 6-tuple `_load_and_enrich` shape update
- [x] End-to-end smoke: `enrich_agent_prompt(software_engineer, ...)` returns `rules_loaded=[no-fabrication, honest-uncertainty, anti-sycophancy, language-match]` in priority order `[10, 20, 30, 90]` and renders the `## Rules` block in the system prompt
- [x] Caveman opt-in path: `skill-caveman-tokenomics` resolves through the `concise-output` capability for opted-in agents
- [x] Manual MCP smoke via Claude Desktop / Claude Code — verify response footer shows `· **Rules**: [...]` on a real query
- [ ] (v2) Quantify token savings on real history once token-counting lands

## Out of scope
- Real token counting (tiktoken / Anthropic `usage` plumbing)
- Per-tier token budgets, auto-truncation under budget pressure
- Tier-modulated caveman levels (Lite/Full/Ultra/文言文)
- Additional candidate rules (cite-sources, verify-destructive, plan-then-act, surface-assumptions, etc.) — deferred until v1 metrics are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the prompt-enrichment pipeline and response metadata for every routed request by introducing an always-on `rules/` layer and expanding cache/result tuple shapes, which could subtly affect agent behavior and any clients depending on prior response schemas.
> 
> **Overview**
> Introduces a new **always-on universal `rules/` layer** (loaded from `rules/rule-*.mdc`) and integrates it into prompt enrichment ahead of skills/implants, including caching, warmup, and surfacing `rules_loaded` through `route_and_load`/`get_agent_context` responses.
> 
> Adds four initial rule files (accuracy, uncertainty marking, anti-sycophancy, language matching) with a loader that enforces the *no per-agent opt-in/opt-out* invariant and degrades gracefully on malformed rule files.
> 
> Adds `skill-caveman-tokenomics` and a new `concise-output` capability, then opts multiple technical agents into it; documentation/templates are updated to include the new `Rules` footer field, and tests are updated/added (`test_rules.py`) to lock rule-set and loader behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c11a35815332335652ae3d07fb6bbdc3e152d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->