### PR TITLE
Bug fixes: langdetect dependency + router cache dim mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pdf2image>=1.16.0",
     "Pillow>=10.0.0",
     "anthropic>=0.18.0",
+    "langdetect>=1.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -4,6 +4,8 @@ import os
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
 
+import numpy as np
+
 from src.engine.config import (
     ROUTER_SIMILARITY_THRESHOLD, AGENTS_DIR, DATA_DIR, EMBEDDING_MODEL,
     KEYWORD_OVERRIDE_MIN_HITS, KEYWORD_UNIQUENESS_RATIO,
@@ -31,7 +33,14 @@ class SemanticRouter:
         self._agent_descriptions = self._load_agent_descriptions()
 
     def _invalidate_on_model_change(self):
-        """Clear router cache when the embedding model changes."""
+        """Clear router cache when embedding model name OR vector dim changes.
+
+        The marker file tracks the model name, but a name match doesn't
+        guarantee the on-disk vectors have the expected dim — the cache may
+        have been written by a different model whose marker was later
+        overwritten. Probe the embedder to confirm dim alignment when there
+        is cached data at risk.
+        """
         stored_model = ""
         try:
             if os.path.exists(_ROUTER_MODEL_HASH_FILE):
@@ -40,11 +49,29 @@ class SemanticRouter:
         except Exception:
             pass
 
-        if stored_model != EMBEDDING_MODEL:
+        name_changed = stored_model != EMBEDDING_MODEL
+        dim_mismatch = False
+
+        cache_dim = self.store.dim()
+        if cache_dim is not None and not name_changed:
+            try:
+                probe = embed_query("__router_dim_probe__")
+                embedder_dim = int(np.asarray(probe).squeeze().shape[0])
+                if cache_dim != embedder_dim:
+                    dim_mismatch = True
+                    logger.warning(
+                        "Router cache dim mismatch (cache=%d, embedder=%d), "
+                        "wiping stale cache",
+                        cache_dim, embedder_dim,
+                    )
+            except Exception as e:
+                logger.warning("Embedder dim probe failed during cache validation: %s", e)
+
+        if name_changed or dim_mismatch:
             if self.store.count() > 0:
                 logger.info(
-                    "Embedding model changed (%s → %s), clearing router cache",
-                    stored_model or "<none>", EMBEDDING_MODEL,
+                    "Clearing router cache (model: %r → %r, dim_mismatch=%s)",
+                    stored_model or "<none>", EMBEDDING_MODEL, dim_mismatch,
                 )
                 self.store.clear()
                 self.store.save()

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import tempfile
+import threading
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, Tuple
 
@@ -28,6 +29,12 @@ _DIM_MISMATCH_ERROR_FRAGMENT = "Dimension mismatch"
 
 class SemanticRouter:
     def __init__(self):
+        # Serializes (store mutation + marker write) sequences across
+        # update_cache and the query-time self-heal so the on-disk marker
+        # cannot drift from the on-disk vector store under concurrent
+        # writers. NumpyVectorStore has its own lock for in-memory state,
+        # but doesn't span the marker write — this lock bridges that gap.
+        self._marker_lock = threading.RLock()
         self.store = NumpyVectorStore(name="router_cache", data_dir=DATA_DIR)
         self._invalidate_on_model_change()
 
@@ -97,17 +104,23 @@ class SemanticRouter:
     def _write_marker(model_name: str, dim: Optional[int]) -> None:
         """Persist (model_name, dim) to the marker atomically.
 
-        Writes to a tempfile in the same directory and ``os.replace``-s into
-        place — same crash-safety pattern as ``NumpyVectorStore.save``. A
-        crash mid-write leaves the original marker untouched rather than a
-        truncated payload that could trigger spurious wipes or decode
-        errors. Empty caches write only the model name so the legacy
-        format is the natural rest state.
+        Writes to a tempfile in the same directory as the marker and
+        ``os.replace``-s into place — same crash-safety pattern as
+        ``NumpyVectorStore.save``. A crash mid-write leaves the original
+        marker untouched rather than a truncated payload that could trigger
+        spurious wipes or decode errors. Empty caches write only the model
+        name so the legacy format is the natural rest state.
+
+        The temp file is created in ``os.path.dirname(_ROUTER_MODEL_HASH_FILE)``
+        rather than ``DATA_DIR`` so the rename stays on the same filesystem
+        even if a future refactor or test override decouples the two paths
+        (cross-filesystem ``os.replace`` is not atomic on POSIX).
         """
-        os.makedirs(DATA_DIR, exist_ok=True)
+        target_dir = os.path.dirname(_ROUTER_MODEL_HASH_FILE) or "."
+        os.makedirs(target_dir, exist_ok=True)
         payload = f"{model_name}|{dim}" if dim is not None else model_name
         fd, tmp_path = tempfile.mkstemp(
-            dir=DATA_DIR,
+            dir=target_dir,
             prefix=".router_cache_model.",
             suffix=".tmp",
         )
@@ -131,10 +144,16 @@ class SemanticRouter:
     def _wipe_and_remark(self) -> None:
         """Drop all cached entries and reset the marker. Used by the lazy
         self-heal path in ``query_nearest`` when a query exposes a dim
-        mismatch the init-time check could not detect."""
-        self.store.clear()
-        self.store.save()
-        self._write_marker(EMBEDDING_MODEL, None)
+        mismatch the init-time check could not detect.
+
+        Holds ``_marker_lock`` so a concurrent ``update_cache`` cannot
+        slip a marker write between the store clear and our marker reset,
+        which would leave the on-disk pair out of sync.
+        """
+        with self._marker_lock:
+            self.store.clear()
+            self.store.save()
+            self._write_marker(EMBEDDING_MODEL, None)
 
     def _scan_agents(self) -> List[str]:
         """
@@ -372,21 +391,27 @@ class SemanticRouter:
             query_emb = await loop.run_in_executor(None, embed_query, query)
 
             def _mutate_and_save():
-                self.store.add(
-                    ids=[request_id],
-                    embeddings=query_emb.reshape(1, -1),
-                    documents=[query],
-                    metadatas=[{
-                        "target_agent": agent_name,
-                        "reasoning": reasoning,
-                        "timestamp": datetime.now(timezone.utc).isoformat()
-                    }],
-                )
-                self.store.trim(ROUTER_CACHE_MAX_SIZE)
-                self.store.save()
-                # Keep the marker in sync with cache contents so the next
-                # startup can detect drift without loading the embedder.
-                self._write_marker(EMBEDDING_MODEL, self.store.dim())
+                # Hold the router-level lock for the whole (store + marker)
+                # sequence so concurrent update_cache / _wipe_and_remark
+                # callers can't interleave their disk writes and leave the
+                # marker disagreeing with the on-disk store.
+                with self._marker_lock:
+                    self.store.add(
+                        ids=[request_id],
+                        embeddings=query_emb.reshape(1, -1),
+                        documents=[query],
+                        metadatas=[{
+                            "target_agent": agent_name,
+                            "reasoning": reasoning,
+                            "timestamp": datetime.now(timezone.utc).isoformat()
+                        }],
+                    )
+                    self.store.trim(ROUTER_CACHE_MAX_SIZE)
+                    self.store.save()
+                    # Keep the marker in sync with cache contents so the
+                    # next startup can detect drift without loading the
+                    # embedder.
+                    self._write_marker(EMBEDDING_MODEL, self.store.dim())
 
             await loop.run_in_executor(None, _mutate_and_save)
         except Exception as e:

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -2,9 +2,7 @@ import asyncio
 import logging
 import os
 from datetime import datetime, timezone
-from typing import List, Optional, Dict, Any
-
-import numpy as np
+from typing import List, Optional, Dict, Any, Tuple
 
 from src.engine.config import (
     ROUTER_SIMILARITY_THRESHOLD, AGENTS_DIR, DATA_DIR, EMBEDDING_MODEL,
@@ -21,6 +19,10 @@ logger = logging.getLogger(__name__)
 ROUTER_CACHE_MAX_SIZE = 500
 KEYWORD_VETO_ROUTE_REQUIRED = "__ROUTE_REQUIRED__"
 _ROUTER_MODEL_HASH_FILE = os.path.join(DATA_DIR, ".router_cache_model")
+# Substring in the ValueError raised by NumpyVectorStore.query() when the
+# query vector and stored vectors disagree on dimensionality. Matched in
+# query_nearest() to trigger lazy self-heal.
+_DIM_MISMATCH_ERROR_FRAGMENT = "Dimension mismatch"
 
 
 class SemanticRouter:
@@ -33,51 +35,73 @@ class SemanticRouter:
         self._agent_descriptions = self._load_agent_descriptions()
 
     def _invalidate_on_model_change(self):
-        """Clear router cache when embedding model name OR vector dim changes.
+        """Clear router cache when the model name changes or the marker's
+        recorded dim drifts from the on-disk vector dim.
 
-        The marker file tracks the model name, but a name match doesn't
-        guarantee the on-disk vectors have the expected dim — the cache may
-        have been written by a different model whose marker was later
-        overwritten. Probe the embedder to confirm dim alignment when there
-        is cached data at risk.
+        Marker format: ``<model>|<dim>`` (current) or ``<model>`` (legacy,
+        accepted on read and upgraded on next save). A name match alone does
+        not guarantee correctness — the cache may have been written by a
+        different model whose marker was later overwritten — so we also
+        compare the marker's dim against the actual stored dim. Reading the
+        npz dim is cheap (already loaded by NumpyVectorStore), so this check
+        runs without loading the embedder. Queries against a stale cache
+        that still slips past this check self-heal in ``query_nearest``.
         """
-        stored_model = ""
-        try:
-            if os.path.exists(_ROUTER_MODEL_HASH_FILE):
-                with open(_ROUTER_MODEL_HASH_FILE, "r") as f:
-                    stored_model = f.read().strip()
-        except Exception:
-            pass
+        stored_model, stored_dim = self._read_marker()
+        cache_dim = self.store.dim()
 
         name_changed = stored_model != EMBEDDING_MODEL
-        dim_mismatch = False
+        dim_drifted = (
+            stored_dim is not None
+            and cache_dim is not None
+            and stored_dim != cache_dim
+        )
 
-        cache_dim = self.store.dim()
-        if cache_dim is not None and not name_changed:
-            try:
-                probe = embed_query("__router_dim_probe__")
-                embedder_dim = int(np.asarray(probe).squeeze().shape[0])
-                if cache_dim != embedder_dim:
-                    dim_mismatch = True
-                    logger.warning(
-                        "Router cache dim mismatch (cache=%d, embedder=%d), "
-                        "wiping stale cache",
-                        cache_dim, embedder_dim,
-                    )
-            except Exception as e:
-                logger.warning("Embedder dim probe failed during cache validation: %s", e)
-
-        if name_changed or dim_mismatch:
+        if name_changed or dim_drifted:
             if self.store.count() > 0:
                 logger.info(
-                    "Clearing router cache (model: %r → %r, dim_mismatch=%s)",
-                    stored_model or "<none>", EMBEDDING_MODEL, dim_mismatch,
+                    "Clearing router cache (model: %r → %r, dim_drifted=%s)",
+                    stored_model or "<none>", EMBEDDING_MODEL, dim_drifted,
                 )
                 self.store.clear()
                 self.store.save()
-            os.makedirs(DATA_DIR, exist_ok=True)
-            with open(_ROUTER_MODEL_HASH_FILE, "w") as f:
-                f.write(EMBEDDING_MODEL)
+            self._write_marker(EMBEDDING_MODEL, None)
+
+    @staticmethod
+    def _read_marker() -> Tuple[str, Optional[int]]:
+        """Parse the marker file. Returns (model_name, dim). dim is None for
+        legacy markers, missing files, or unparseable values."""
+        try:
+            if not os.path.exists(_ROUTER_MODEL_HASH_FILE):
+                return "", None
+            with open(_ROUTER_MODEL_HASH_FILE, "r") as f:
+                raw = f.read().strip()
+        except OSError:
+            return "", None
+        if "|" not in raw:
+            return raw, None
+        name, _, dim_str = raw.partition("|")
+        try:
+            return name, int(dim_str)
+        except ValueError:
+            return name, None
+
+    @staticmethod
+    def _write_marker(model_name: str, dim: Optional[int]) -> None:
+        """Persist (model_name, dim) to the marker. Empty caches write only
+        the model name so the legacy format is the natural rest state."""
+        os.makedirs(DATA_DIR, exist_ok=True)
+        payload = f"{model_name}|{dim}" if dim is not None else model_name
+        with open(_ROUTER_MODEL_HASH_FILE, "w") as f:
+            f.write(payload)
+
+    def _wipe_and_remark(self) -> None:
+        """Drop all cached entries and reset the marker. Used by the lazy
+        self-heal path in ``query_nearest`` when a query exposes a dim
+        mismatch the init-time check could not detect."""
+        self.store.clear()
+        self.store.save()
+        self._write_marker(EMBEDDING_MODEL, None)
 
     def _scan_agents(self) -> List[str]:
         """
@@ -251,9 +275,24 @@ class SemanticRouter:
 
         loop = asyncio.get_running_loop()
         query_emb = await loop.run_in_executor(None, embed_query, semantic_query)
-        results = await loop.run_in_executor(
-            None, lambda: self.store.query(query_embedding=query_emb, n_results=1)
-        )
+        try:
+            results = await loop.run_in_executor(
+                None, lambda: self.store.query(query_embedding=query_emb, n_results=1)
+            )
+        except ValueError as e:
+            # Self-heal a stale cache whose vectors disagree with the current
+            # embedder's dim. The init-time marker check catches drift the
+            # codebase wrote, but a marker and npz that agree with each other
+            # but not with the embedder (e.g. cache restored from a backup
+            # taken under a different model) only surface here. Wipe, log,
+            # and let the query miss — the next update will repopulate.
+            if _DIM_MISMATCH_ERROR_FRAGMENT in str(e):
+                logger.warning(
+                    "Router cache dim mismatch at query time, wiping: %s", e
+                )
+                await loop.run_in_executor(None, self._wipe_and_remark)
+                return None
+            raise
 
         if results.ids and results.distances and len(results.distances) > 0:
             distance = results.distances[0]
@@ -308,6 +347,9 @@ class SemanticRouter:
                 )
                 self.store.trim(ROUTER_CACHE_MAX_SIZE)
                 self.store.save()
+                # Keep the marker in sync with cache contents so the next
+                # startup can detect drift without loading the embedder.
+                self._write_marker(EMBEDDING_MODEL, self.store.dim())
 
             await loop.run_in_executor(None, _mutate_and_save)
         except Exception as e:

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -141,16 +141,33 @@ class SemanticRouter:
                     pass
             raise
 
-    def _wipe_and_remark(self) -> None:
-        """Drop all cached entries and reset the marker. Used by the lazy
-        self-heal path in ``query_nearest`` when a query exposes a dim
-        mismatch the init-time check could not detect.
+    def _wipe_and_remark(self, expected_dim: Optional[int] = None) -> None:
+        """Drop all cached entries and reset the marker.
 
-        Holds ``_marker_lock`` so a concurrent ``update_cache`` cannot
-        slip a marker write between the store clear and our marker reset,
-        which would leave the on-disk pair out of sync.
+        Used by the lazy self-heal path in ``query_nearest`` when a query
+        exposes a dim mismatch the init-time check could not detect. Holds
+        ``_marker_lock`` so a concurrent ``update_cache`` cannot slip a
+        marker write between the store clear and our marker reset.
+
+        When ``expected_dim`` is provided, the wipe is **conditional**: we
+        re-check the store's dim under the lock and skip the wipe if the
+        store is already empty or already at ``expected_dim``. This guards
+        against the race where a concurrent ``update_cache`` self-heals
+        the store between ``query_nearest``'s failing ``store.query`` (no
+        lock) and the wipe call (lock acquired here) — without the
+        re-check, the unconditional wipe would discard a freshly-healed
+        correct-dim entry.
         """
         with self._marker_lock:
+            if expected_dim is not None:
+                current_dim = self.store.dim()
+                if current_dim is None or current_dim == expected_dim:
+                    logger.info(
+                        "Router cache dim mismatch resolved by another writer "
+                        "(current=%s, expected=%s); skipping redundant wipe",
+                        current_dim, expected_dim,
+                    )
+                    return
             self.store.clear()
             self.store.save()
             self._write_marker(EMBEDDING_MODEL, None)
@@ -346,7 +363,14 @@ class SemanticRouter:
                 logger.warning(
                     "Router cache dim mismatch at query time, wiping: %s", e
                 )
-                await loop.run_in_executor(None, self._wipe_and_remark)
+                # Pass the embedder's dim so the locked wipe can detect
+                # and skip a redundant clear if a concurrent update_cache
+                # already self-healed the store between our failing
+                # store.query (no lock) and the wipe (lock acquired below).
+                embedder_dim = int(query_emb.shape[0])
+                await loop.run_in_executor(
+                    None, lambda: self._wipe_and_remark(expected_dim=embedder_dim)
+                )
                 return None
             raise
 

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -70,13 +70,17 @@ class SemanticRouter:
     @staticmethod
     def _read_marker() -> Tuple[str, Optional[int]]:
         """Parse the marker file. Returns (model_name, dim). dim is None for
-        legacy markers, missing files, or unparseable values."""
+        legacy markers, missing files, unreadable files, or unparseable
+        values. A corrupted marker (non-text bytes, IO failure) is treated
+        as "no marker" rather than crashing init — the caller falls back
+        to wiping and rewriting on the next save."""
         try:
             if not os.path.exists(_ROUTER_MODEL_HASH_FILE):
                 return "", None
-            with open(_ROUTER_MODEL_HASH_FILE, "r") as f:
+            with open(_ROUTER_MODEL_HASH_FILE, "r", encoding="utf-8") as f:
                 raw = f.read().strip()
-        except OSError:
+        except (OSError, UnicodeDecodeError) as e:
+            logger.warning("Failed to read router marker file: %s", e)
             return "", None
         if "|" not in raw:
             return raw, None
@@ -264,8 +268,12 @@ class SemanticRouter:
         the cache has no entries. No threshold is applied — the caller decides
         what to do with the distance.
 
-        Raises on errors so callers can distinguish empty cache from
-        lookup failure and handle each appropriately.
+        Returns None instead of raising when a query-vs-store dim mismatch
+        is detected: the stale store is wiped via ``_wipe_and_remark`` and
+        the lookup is treated as a cache miss so the next ``update_cache``
+        repopulates with vectors from the current embedder. All other
+        ``ValueError``s and any other exceptions still propagate so callers
+        can distinguish empty-cache from lookup-failure scenarios.
         """
         if self.store.count() == 0:
             return None

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -385,10 +385,29 @@ class SemanticRouter:
     async def update_cache(self, query: str, agent_name: str, reasoning: str, request_id: str):
         """
         Manually adds an entry to the cache.
+
+        Self-heals a stale cache whose stored vector dim disagrees with the
+        current embedder: if ``NumpyVectorStore.add`` raises a dim-mismatch
+        ``ValueError``, the store is wiped and the add is retried once
+        against the now-empty store. This complements the query-time
+        self-heal in ``query_nearest`` for callers that hit ``update_cache``
+        before any lookup has run (e.g. an LLM routing decision recorded
+        before any cached query touched the store).
         """
         loop = asyncio.get_running_loop()
         try:
             query_emb = await loop.run_in_executor(None, embed_query, query)
+
+            add_kwargs = dict(
+                ids=[request_id],
+                embeddings=query_emb.reshape(1, -1),
+                documents=[query],
+                metadatas=[{
+                    "target_agent": agent_name,
+                    "reasoning": reasoning,
+                    "timestamp": datetime.now(timezone.utc).isoformat()
+                }],
+            )
 
             def _mutate_and_save():
                 # Hold the router-level lock for the whole (store + marker)
@@ -396,16 +415,20 @@ class SemanticRouter:
                 # callers can't interleave their disk writes and leave the
                 # marker disagreeing with the on-disk store.
                 with self._marker_lock:
-                    self.store.add(
-                        ids=[request_id],
-                        embeddings=query_emb.reshape(1, -1),
-                        documents=[query],
-                        metadatas=[{
-                            "target_agent": agent_name,
-                            "reasoning": reasoning,
-                            "timestamp": datetime.now(timezone.utc).isoformat()
-                        }],
-                    )
+                    try:
+                        self.store.add(**add_kwargs)
+                    except ValueError as e:
+                        if _DIM_MISMATCH_ERROR_FRAGMENT not in str(e):
+                            raise
+                        logger.warning(
+                            "Router cache dim mismatch on update, wiping and "
+                            "retrying with current-dim vectors: %s", e,
+                        )
+                        # Wipe the stale store; the empty store accepts any
+                        # dim on the next add, so the retry succeeds.
+                        self.store.clear()
+                        self.store.save()
+                        self.store.add(**add_kwargs)
                     self.store.trim(ROUTER_CACHE_MAX_SIZE)
                     self.store.save()
                     # Keep the marker in sync with cache contents so the

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -71,10 +71,12 @@ class SemanticRouter:
     @staticmethod
     def _read_marker() -> Tuple[str, Optional[int]]:
         """Parse the marker file. Returns (model_name, dim). dim is None for
-        legacy markers, missing files, unreadable files, or unparseable
-        values. A corrupted marker (non-text bytes, IO failure) is treated
-        as "no marker" rather than crashing init — the caller falls back
-        to wiping and rewriting on the next save."""
+        legacy markers, unparseable dim values, or any I/O failure (missing
+        file, decode error, OS error). I/O failures collapse to ``("", None)``
+        rather than crashing init; the caller in ``_invalidate_on_model_change``
+        then sees ``name_changed=True`` and either wipes the cache (non-empty
+        store) or just rewrites the marker (empty store) — both happen
+        immediately at init, not on a deferred save."""
         try:
             if not os.path.exists(_ROUTER_MODEL_HASH_FILE):
                 return "", None
@@ -109,8 +111,13 @@ class SemanticRouter:
             prefix=".router_cache_model.",
             suffix=".tmp",
         )
+        # Close the raw fd immediately and reopen by path to write — mirrors
+        # NumpyVectorStore.save(). os.fdopen() can raise (e.g. bad fd state)
+        # before installing a context-manager owner of the descriptor; closing
+        # here guarantees no descriptor leak on any subsequent failure.
+        os.close(fd)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
+            with open(tmp_path, "w", encoding="utf-8") as f:
                 f.write(payload)
             os.replace(tmp_path, _ROUTER_MODEL_HASH_FILE)
         except Exception:

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import tempfile
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, Tuple
 
@@ -92,12 +93,33 @@ class SemanticRouter:
 
     @staticmethod
     def _write_marker(model_name: str, dim: Optional[int]) -> None:
-        """Persist (model_name, dim) to the marker. Empty caches write only
-        the model name so the legacy format is the natural rest state."""
+        """Persist (model_name, dim) to the marker atomically.
+
+        Writes to a tempfile in the same directory and ``os.replace``-s into
+        place — same crash-safety pattern as ``NumpyVectorStore.save``. A
+        crash mid-write leaves the original marker untouched rather than a
+        truncated payload that could trigger spurious wipes or decode
+        errors. Empty caches write only the model name so the legacy
+        format is the natural rest state.
+        """
         os.makedirs(DATA_DIR, exist_ok=True)
         payload = f"{model_name}|{dim}" if dim is not None else model_name
-        with open(_ROUTER_MODEL_HASH_FILE, "w") as f:
-            f.write(payload)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=DATA_DIR,
+            prefix=".router_cache_model.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp_path, _ROUTER_MODEL_HASH_FILE)
+        except Exception:
+            if os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            raise
 
     def _wipe_and_remark(self) -> None:
         """Drop all cached entries and reset the marker. Used by the lazy

--- a/src/engine/vector_store.py
+++ b/src/engine/vector_store.py
@@ -217,6 +217,13 @@ class NumpyVectorStore:
         with self._lock:
             return len(self._ids)
 
+    def dim(self) -> Optional[int]:
+        """Return the embedding dimensionality, or None if the store is empty."""
+        with self._lock:
+            if self._embeddings is None or self._embeddings.size == 0:
+                return None
+            return int(self._embeddings.shape[1])
+
     @staticmethod
     def _validate_inputs(
         ids: List[str],

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -867,6 +867,29 @@ class TestCacheInvalidation:
 
         assert (isolated_router_dir / ".router_cache_model").read_text() == EMBEDDING_MODEL
 
+    def test_corrupt_marker_does_not_crash_init(self, isolated_router_dir, monkeypatch):
+        """A marker file with non-text bytes (e.g. partial write or
+        filesystem corruption) must not crash router initialization. Treat
+        as missing/legacy and let the next save rewrite it cleanly."""
+        from unittest.mock import MagicMock
+
+        self._seed_cache(isolated_router_dir, dim=384)
+        # Non-UTF-8 bytes — `open(..., encoding="utf-8")` would raise
+        # UnicodeDecodeError if the read path didn't catch it.
+        (isolated_router_dir / ".router_cache_model").write_bytes(b"\xff\xfe\xfd corrupt")
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
+
+        from src.engine.router import SemanticRouter
+        # Must not raise UnicodeDecodeError or any other exception.
+        router = SemanticRouter()
+
+        # Corrupt marker is read as ("", None) → name_changed=True → wipe.
+        # The exact post-state isn't the point of this test; the point is
+        # that init survives the corruption.
+        assert router.store is not None
+        embed_mock.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_lazy_self_heal_on_query_dim_mismatch(self, isolated_router_dir, monkeypatch):
         """A cache that passed init-time checks but produces a query-time

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -919,6 +919,19 @@ class TestCacheInvalidation:
         assert result is None, "lazy self-heal must return None on dim mismatch"
         assert router.store.count() == 0, "store must be wiped after dim-mismatch query"
 
+    def test_write_marker_leaves_no_tempfile_on_success(self, isolated_router_dir):
+        """Atomic write via tempfile + os.replace must not leave any
+        ``.router_cache_model.*.tmp`` debris on a successful write."""
+        from src.engine.router import SemanticRouter
+
+        SemanticRouter._write_marker("test-model", 384)
+
+        marker = isolated_router_dir / ".router_cache_model"
+        assert marker.read_text(encoding="utf-8") == "test-model|384"
+
+        leftovers = list(isolated_router_dir.glob(".router_cache_model.*.tmp"))
+        assert leftovers == [], f"Atomic write left tmp debris: {leftovers}"
+
     @pytest.mark.asyncio
     async def test_update_cache_writes_marker_with_dim(self, isolated_router_dir, monkeypatch):
         """After ``update_cache`` saves a new entry, the marker records both

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -869,8 +869,12 @@ class TestCacheInvalidation:
 
     def test_corrupt_marker_does_not_crash_init(self, isolated_router_dir, monkeypatch):
         """A marker file with non-text bytes (e.g. partial write or
-        filesystem corruption) must not crash router initialization. Treat
-        as missing/legacy and let the next save rewrite it cleanly."""
+        filesystem corruption) must not crash router initialization.
+        ``_read_marker`` collapses the corrupted marker to ``("", None)``,
+        which makes ``name_changed=True`` in ``_invalidate_on_model_change``,
+        triggering an immediate wipe (non-empty store) or marker rewrite
+        (empty store) — repair is performed at init, not deferred to a
+        later save."""
         from unittest.mock import MagicMock
 
         self._seed_cache(isolated_router_dir, dim=384)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -734,6 +734,108 @@ class TestKeywordBoosting:
             assert result["status"] == "ROUTE_REQUIRED"
 
 
+class TestCacheInvalidation:
+    """Tests for _invalidate_on_model_change auto-rebuild on dim mismatch.
+
+    Regression: a stale `data/router_cache.npz` with vectors from a different
+    embedder (e.g. 1024-dim BGE-large) used to slip past the model-name check
+    when the marker was overwritten. Every cache lookup then raised
+    `ValueError: Dimension mismatch`, the error was swallowed, and the cache
+    was effectively dead. The router must now detect the dim mismatch on init
+    and wipe the stale store automatically.
+    """
+
+    @pytest.fixture
+    def isolated_router_dir(self, tmp_path, monkeypatch):
+        """Patch DATA_DIR + marker path so SemanticRouter uses a tmp directory."""
+        monkeypatch.setattr("src.engine.router.DATA_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "src.engine.router._ROUTER_MODEL_HASH_FILE",
+            str(tmp_path / ".router_cache_model"),
+        )
+        return tmp_path
+
+    def _seed_cache(self, data_dir, dim):
+        """Write a router_cache.npz with `dim`-dimensional vectors."""
+        import numpy as np
+        from src.engine.vector_store import NumpyVectorStore
+
+        store = NumpyVectorStore(name="router_cache", data_dir=str(data_dir))
+        store.add(
+            ids=["seed"],
+            embeddings=np.random.rand(1, dim).astype(np.float32),
+            documents=["seed query"],
+            metadatas=[{
+                "target_agent": "universal_agent",
+                "reasoning": "seed",
+                "timestamp": "2026-01-01T00:00:00Z",
+            }],
+        )
+        store.save()
+
+    def test_dim_mismatch_triggers_auto_rebuild(self, isolated_router_dir, monkeypatch):
+        """Stale cache with vectors of a different dim should be wiped on init."""
+        import numpy as np
+        from src.engine.config import EMBEDDING_MODEL
+
+        self._seed_cache(isolated_router_dir, dim=1024)
+        # Marker matches current model — name check would let the stale cache through.
+        (isolated_router_dir / ".router_cache_model").write_text(EMBEDDING_MODEL)
+
+        # Embedder returns 384 dims — disagrees with the seeded 1024-dim cache.
+        monkeypatch.setattr(
+            "src.engine.router.embed_query",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+
+        assert router.store.count() == 0, (
+            "Router cache should auto-rebuild when stored vectors have a "
+            "different dim than the current embedder produces"
+        )
+
+    def test_matching_dim_preserves_cache(self, isolated_router_dir, monkeypatch):
+        """When dim matches the embedder, the cache must not be wiped."""
+        import numpy as np
+        from src.engine.config import EMBEDDING_MODEL
+
+        self._seed_cache(isolated_router_dir, dim=384)
+        (isolated_router_dir / ".router_cache_model").write_text(EMBEDDING_MODEL)
+
+        monkeypatch.setattr(
+            "src.engine.router.embed_query",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+
+        assert router.store.count() == 1, (
+            "Router cache must be preserved when stored dim matches embedder"
+        )
+
+    def test_model_name_change_still_wipes(self, isolated_router_dir, monkeypatch):
+        """Existing behavior: a model-name change clears the cache without
+        needing to probe the embedder."""
+        import numpy as np
+
+        self._seed_cache(isolated_router_dir, dim=384)
+        (isolated_router_dir / ".router_cache_model").write_text("old-model-name")
+
+        # Probe should NOT be invoked when the name already differs — verify
+        # by raising if it is touched.
+        def _no_probe(text):
+            raise AssertionError("embed_query must not be called when name differs")
+        monkeypatch.setattr("src.engine.router.embed_query", _no_probe)
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+
+        assert router.store.count() == 0
+
+
 class TestClearSessionCache:
     @pytest.mark.asyncio
     async def test_clears_both_caches(self):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -937,6 +937,48 @@ class TestCacheInvalidation:
         assert leftovers == [], f"Atomic write left tmp debris: {leftovers}"
 
     @pytest.mark.asyncio
+    async def test_update_cache_self_heals_on_dim_mismatch(self, isolated_router_dir, monkeypatch):
+        """``update_cache`` must self-heal a dim-mismatched cache that
+        slipped past the init-time check (marker and npz internally
+        consistent at 1024-dim, but the current embedder produces 384).
+        ``NumpyVectorStore.add`` raises a dim-mismatch ``ValueError``;
+        ``update_cache`` catches it, wipes the stale store, retries the
+        add against the now-empty store, and rewrites the marker so the
+        new dim is recorded."""
+        import numpy as np
+        from src.engine.config import EMBEDDING_MODEL
+
+        # Marker and on-disk vectors agree at 1024-dim → init keeps cache.
+        self._seed_cache(isolated_router_dir, dim=1024)
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|1024"
+        )
+
+        # Current embedder produces 384-dim; the upcoming add will mismatch.
+        monkeypatch.setattr(
+            "src.engine.router.embed_query",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+        assert router.store.count() == 1, "init should keep the cache when marker matches"
+        assert router.store.dim() == 1024
+
+        await router.update_cache(
+            query="hello",
+            agent_name="universal_agent",
+            reasoning="test",
+            request_id="req-1",
+        )
+
+        # The 1024-dim seed should be gone, replaced by the new 384-dim entry.
+        assert router.store.count() == 1
+        assert router.store.dim() == 384
+        marker = (isolated_router_dir / ".router_cache_model").read_text()
+        assert marker == f"{EMBEDDING_MODEL}|384"
+
+    @pytest.mark.asyncio
     async def test_update_cache_writes_marker_with_dim(self, isolated_router_dir, monkeypatch):
         """After ``update_cache`` saves a new entry, the marker records both
         the model name and the current cache dim."""

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -735,14 +735,17 @@ class TestKeywordBoosting:
 
 
 class TestCacheInvalidation:
-    """Tests for _invalidate_on_model_change auto-rebuild on dim mismatch.
+    """Tests for router cache invalidation across init and query paths.
 
     Regression: a stale `data/router_cache.npz` with vectors from a different
     embedder (e.g. 1024-dim BGE-large) used to slip past the model-name check
     when the marker was overwritten. Every cache lookup then raised
     `ValueError: Dimension mismatch`, the error was swallowed, and the cache
-    was effectively dead. The router must now detect the dim mismatch on init
-    and wipe the stale store automatically.
+    was effectively dead. The router now records the cached dim alongside
+    the model name in the marker (`<model>|<dim>`) and wipes when those drift.
+    A query-time self-heal in ``query_nearest`` is the safety net for cases
+    the init-time check cannot detect (e.g. cache restored from backup that
+    was internally consistent but disagrees with the current embedder).
     """
 
     @pytest.fixture
@@ -773,67 +776,151 @@ class TestCacheInvalidation:
         )
         store.save()
 
-    def test_dim_mismatch_triggers_auto_rebuild(self, isolated_router_dir, monkeypatch):
-        """Stale cache with vectors of a different dim should be wiped on init."""
-        import numpy as np
+    def test_marker_dim_drift_wipes_at_init(self, isolated_router_dir, monkeypatch):
+        """Marker dim disagreeing with on-disk vector dim triggers init-time wipe."""
+        from unittest.mock import MagicMock
         from src.engine.config import EMBEDDING_MODEL
 
         self._seed_cache(isolated_router_dir, dim=1024)
-        # Marker matches current model — name check would let the stale cache through.
-        (isolated_router_dir / ".router_cache_model").write_text(EMBEDDING_MODEL)
-
-        # Embedder returns 384 dims — disagrees with the seeded 1024-dim cache.
-        monkeypatch.setattr(
-            "src.engine.router.embed_query",
-            lambda text: np.zeros(384, dtype=np.float32),
+        # Marker claims dim=384 but the npz has 1024-dim vectors → drift.
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|384"
         )
-
-        from src.engine.router import SemanticRouter
-        router = SemanticRouter()
-
-        assert router.store.count() == 0, (
-            "Router cache should auto-rebuild when stored vectors have a "
-            "different dim than the current embedder produces"
-        )
-
-    def test_matching_dim_preserves_cache(self, isolated_router_dir, monkeypatch):
-        """When dim matches the embedder, the cache must not be wiped."""
-        import numpy as np
-        from src.engine.config import EMBEDDING_MODEL
-
-        self._seed_cache(isolated_router_dir, dim=384)
-        (isolated_router_dir / ".router_cache_model").write_text(EMBEDDING_MODEL)
-
-        monkeypatch.setattr(
-            "src.engine.router.embed_query",
-            lambda text: np.zeros(384, dtype=np.float32),
-        )
-
-        from src.engine.router import SemanticRouter
-        router = SemanticRouter()
-
-        assert router.store.count() == 1, (
-            "Router cache must be preserved when stored dim matches embedder"
-        )
-
-    def test_model_name_change_still_wipes(self, isolated_router_dir, monkeypatch):
-        """Existing behavior: a model-name change clears the cache without
-        needing to probe the embedder."""
-        import numpy as np
-
-        self._seed_cache(isolated_router_dir, dim=384)
-        (isolated_router_dir / ".router_cache_model").write_text("old-model-name")
-
-        # Probe should NOT be invoked when the name already differs — verify
-        # by raising if it is touched.
-        def _no_probe(text):
-            raise AssertionError("embed_query must not be called when name differs")
-        monkeypatch.setattr("src.engine.router.embed_query", _no_probe)
+        # Init must not load the embedder — guard with a MagicMock that fails
+        # the assertion if invoked, regardless of how the caller handles
+        # exceptions (assert_not_called is a metadata check, not a raise).
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
 
         from src.engine.router import SemanticRouter
         router = SemanticRouter()
 
         assert router.store.count() == 0
+        embed_mock.assert_not_called()
+
+    def test_matching_marker_and_cache_preserved(self, isolated_router_dir, monkeypatch):
+        """Marker recording the actual cache dim must preserve the store."""
+        from unittest.mock import MagicMock
+        from src.engine.config import EMBEDDING_MODEL
+
+        self._seed_cache(isolated_router_dir, dim=384)
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|384"
+        )
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+
+        assert router.store.count() == 1
+        embed_mock.assert_not_called()
+
+    def test_legacy_marker_preserves_cache_at_init(self, isolated_router_dir, monkeypatch):
+        """A legacy marker (just the model name, no dim) cannot detect drift —
+        defer to the query-time self-heal rather than wiping speculatively."""
+        from unittest.mock import MagicMock
+        from src.engine.config import EMBEDDING_MODEL
+
+        self._seed_cache(isolated_router_dir, dim=1024)
+        (isolated_router_dir / ".router_cache_model").write_text(EMBEDDING_MODEL)
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+
+        assert router.store.count() == 1
+        embed_mock.assert_not_called()
+
+    def test_model_name_change_wipes_at_init(self, isolated_router_dir, monkeypatch):
+        """A model-name change clears the cache without loading the embedder."""
+        from unittest.mock import MagicMock
+
+        self._seed_cache(isolated_router_dir, dim=384)
+        (isolated_router_dir / ".router_cache_model").write_text("old-model|384")
+
+        # MagicMock-based guard: assert_not_called() is a metadata check, so
+        # the assertion holds even if a regression catches AssertionError
+        # silently inside _invalidate_on_model_change.
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+
+        assert router.store.count() == 0
+        embed_mock.assert_not_called()
+
+    def test_init_writes_legacy_marker_after_wipe(self, isolated_router_dir):
+        """After clearing a stale cache, the marker is rewritten with just
+        the current model name (no dim) — empty caches don't need a dim."""
+        from src.engine.config import EMBEDDING_MODEL
+
+        self._seed_cache(isolated_router_dir, dim=1024)
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|384"
+        )
+
+        from src.engine.router import SemanticRouter
+        SemanticRouter()
+
+        assert (isolated_router_dir / ".router_cache_model").read_text() == EMBEDDING_MODEL
+
+    @pytest.mark.asyncio
+    async def test_lazy_self_heal_on_query_dim_mismatch(self, isolated_router_dir, monkeypatch):
+        """A cache that passed init-time checks but produces a query-time
+        ``ValueError: Dimension mismatch`` must be wiped on first lookup
+        rather than propagating the error or sticking around as dead weight."""
+        import numpy as np
+        from src.engine.config import EMBEDDING_MODEL
+
+        # Marker and cache agree on dim=1024 — init has no reason to wipe.
+        self._seed_cache(isolated_router_dir, dim=1024)
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|1024"
+        )
+
+        # Current embedder produces 384 dims — disagrees with the cache.
+        monkeypatch.setattr(
+            "src.engine.router.embed_query",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+        assert router.store.count() == 1, "init should keep the cache when marker matches"
+
+        result = await router.query_nearest("any query")
+
+        assert result is None, "lazy self-heal must return None on dim mismatch"
+        assert router.store.count() == 0, "store must be wiped after dim-mismatch query"
+
+    @pytest.mark.asyncio
+    async def test_update_cache_writes_marker_with_dim(self, isolated_router_dir, monkeypatch):
+        """After ``update_cache`` saves a new entry, the marker records both
+        the model name and the current cache dim."""
+        import numpy as np
+        from src.engine.config import EMBEDDING_MODEL
+
+        # Pre-seed marker as legacy so we can verify it's upgraded.
+        (isolated_router_dir / ".router_cache_model").write_text(EMBEDDING_MODEL)
+        monkeypatch.setattr(
+            "src.engine.router.embed_query",
+            lambda text: np.zeros(384, dtype=np.float32),
+        )
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+        await router.update_cache(
+            query="hello",
+            agent_name="universal_agent",
+            reasoning="test",
+            request_id="req-1",
+        )
+
+        marker = (isolated_router_dir / ".router_cache_model").read_text()
+        assert marker == f"{EMBEDDING_MODEL}|384"
 
 
 class TestClearSessionCache:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -936,6 +936,65 @@ class TestCacheInvalidation:
         leftovers = list(isolated_router_dir.glob(".router_cache_model.*.tmp"))
         assert leftovers == [], f"Atomic write left tmp debris: {leftovers}"
 
+    def test_wipe_and_remark_skips_when_dim_already_healed(self, isolated_router_dir, monkeypatch):
+        """Race-safety: ``_wipe_and_remark(expected_dim=...)`` must skip the
+        wipe when the store has already been healed (e.g. by a concurrent
+        ``update_cache``) between the failing ``store.query`` and the lock
+        acquisition. Without this check, a query-time self-heal would
+        discard a freshly-added correct-dim entry."""
+        from unittest.mock import MagicMock
+        from src.engine.config import EMBEDDING_MODEL
+
+        # Simulate: a concurrent writer already healed the cache to 384-dim.
+        self._seed_cache(isolated_router_dir, dim=384)
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|384"
+        )
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+        assert router.store.count() == 1
+        assert router.store.dim() == 384
+
+        # query_nearest would have failed against an old 1024-dim store; by
+        # the time _wipe_and_remark gets the lock, the store has been
+        # healed. The conditional re-check must skip the wipe.
+        router._wipe_and_remark(expected_dim=384)
+
+        assert router.store.count() == 1, (
+            "Conditional wipe must not discard a freshly-healed correct-dim cache"
+        )
+        marker = (isolated_router_dir / ".router_cache_model").read_text()
+        assert marker == f"{EMBEDDING_MODEL}|384"
+
+    def test_wipe_and_remark_wipes_when_dim_still_mismatched(self, isolated_router_dir, monkeypatch):
+        """Race-safety counterpart: when the store is still at the stale
+        dim under the lock, ``_wipe_and_remark(expected_dim=...)`` must
+        proceed with the wipe (the race didn't happen)."""
+        from unittest.mock import MagicMock
+        from src.engine.config import EMBEDDING_MODEL
+
+        self._seed_cache(isolated_router_dir, dim=1024)
+        (isolated_router_dir / ".router_cache_model").write_text(
+            f"{EMBEDDING_MODEL}|1024"
+        )
+        embed_mock = MagicMock(side_effect=AssertionError("embedder must not load at init"))
+        monkeypatch.setattr("src.engine.router.embed_query", embed_mock)
+
+        from src.engine.router import SemanticRouter
+        router = SemanticRouter()
+        assert router.store.count() == 1
+        assert router.store.dim() == 1024
+
+        # Embedder produces 384-dim; store is still 1024-dim under the lock.
+        router._wipe_and_remark(expected_dim=384)
+
+        assert router.store.count() == 0
+        marker = (isolated_router_dir / ".router_cache_model").read_text()
+        assert marker == EMBEDDING_MODEL
+
     @pytest.mark.asyncio
     async def test_update_cache_self_heals_on_dim_mismatch(self, isolated_router_dir, monkeypatch):
         """``update_cache`` must self-heal a dim-mismatched cache that


### PR DESCRIPTION
## Summary
Two independent bug fixes accumulated on the `bug/fixes` branch.

### `fix(deps)`: add `langdetect` to runtime dependencies (`7917327`)
`src/engine/language.py` imports `langdetect`, but the package was missing from `[project].dependencies` in `pyproject.toml`. On a fresh install, the import raised `ModuleNotFoundError` and 6 tests in `tests/test_language.py` fell through to the default-language fallback. Adding `langdetect>=1.0` makes the dependency declared and installable, restoring the language detection path.

### `fix(router)`: wipe router cache on embedder dim mismatch (`57f7a11`)
A stale `data/router_cache.npz` written by a different model (e.g. 1024-dim BGE-large) slipped past the marker-only check in `_invalidate_on_model_change()` whenever the marker file was overwritten with the current model's name. Every cache lookup raised `ValueError: Dimension mismatch`, was swallowed by the generic `except` in `lookup_cache_with_distance`, and the semantic cache became effectively dead — every query fell through to keyword matching.

The router now probes the embedder once when there is cached data at risk and wipes the store if the on-disk dim differs from what the embedder produces. The probe is gated on `cache_dim is not None and not name_changed`, so empty stores and the existing name-changed path do not load the embedder.

Also adds:
- public `NumpyVectorStore.dim()` accessor
- `tests/test_routing.py::TestCacheInvalidation` with 3 regression cases (dim mismatch wipes / dim match preserves / name change still wipes without probing)

## Test plan
- [x] `pytest tests/test_language.py` → 29 passed (was 6 failed)
- [x] `pytest tests/ -q` → 256 passed in 6.35s
- [x] End-to-end against the actual stale 1024-dim cache: router auto-wipes on init, subsequent `lookup_cache` returns `None` cleanly (no `ValueError` propagated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches routing cache persistence and concurrency (marker + vector store coordination) and changes error handling around cache lookups; a mistake could cause unexpected cache wipes or masking real vector-store failures.
> 
> **Overview**
> Fixes two runtime issues: declares `langdetect>=1.0` in `pyproject.toml` so language detection doesn’t fail on fresh installs.
> 
> Hardens the semantic router cache against embedding dimensionality drift by extending the on-disk marker to record `<model>|<dim>`, atomically writing it, and serializing marker/store updates with a router-level lock. On init it now wipes the cache when the marker’s recorded dim disagrees with the loaded store, and at runtime `query_nearest`/`update_cache` detect `Dimension mismatch` errors and wipe+recover (treating lookups as cache misses and retrying adds once).
> 
> Adds `NumpyVectorStore.dim()` and a new `TestCacheInvalidation` suite covering init-time invalidation, query-time lazy self-heal, marker corruption/atomic write behavior, and update-time self-heal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3313e0d8edf0c87ff621aab140607c25f78c9e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->