### PR TITLE
feat: Add debugging and assumption verification implants

### DIFF
--- a/agents/devops_engineer/system_prompt.mdc
+++ b/agents/devops_engineer/system_prompt.mdc
@@ -33,6 +33,8 @@ static_skills:
 preferred_skills:
   - "skill-dev-clean-code"
   - "skill-dev-debugging"
+preferred_implants:
+  - "implant-regression-first"
 capabilities:
   - development
   - critical-analysis

--- a/agents/software_engineer/system_prompt.mdc
+++ b/agents/software_engineer/system_prompt.mdc
@@ -49,6 +49,9 @@ preferred_skills:
 - skill-dev-security
 - skill-dev-api-design
 - skill-error-recovery
+preferred_implants:
+- implant-regression-first
+- implant-iteration-budget
 capabilities:
 - development
 - dev-security

--- a/agents/sysadmin/system_prompt.mdc
+++ b/agents/sysadmin/system_prompt.mdc
@@ -44,6 +44,8 @@ static_skills:
 preferred_skills:
   - "skill-dev-debugging"
   - "skill-error-recovery"
+preferred_implants:
+  - "implant-regression-first"
 capabilities:
   - critical-analysis
   - concise-output

--- a/implants/implant-iteration-budget.mdc
+++ b/implants/implant-iteration-budget.mdc
@@ -1,0 +1,31 @@
+---
+description: Iteration Budget for Failed Fixes. If the third consecutive fix did not close the task — DO NOT propose a fourth. Stop and state out loud (for the user) what you are assuming, which assumption could be false, and what command verifies it. 3 failed iterations means your mental model of the problem is wrong; piling hacks on a wrong model makes it worse, not better. Circuit-breaker against stacking workarounds.
+globs: []
+alwaysApply: false
+short_name: IterBudget
+one_liner: stop after 3 failed fixes and re-examine the mental model
+---
+## Pattern
+1. **Count failed attempts** in the current debugging thread. A failed attempt = a fix you proposed/applied that did not close the task.
+2. **Threshold at 3**: If you are about to propose attempt #4 — STOP. Do not propose another fix.
+3. **Switch modes — speak out loud (visible to the user)**:
+   - **What am I assuming?** Enumerate the 2-3 load-bearing assumptions of your current mental model (e.g. "I'm assuming this is a kitty window", "I'm assuming the config reloads on save").
+   - **Which assumption could be false?** Mark the weakest link — the assumption you have the least evidence for.
+   - **What ONE command verifies it?** Concrete probe. If you can't write one, the assumption is even shakier than it looks.
+4. **Run the probe** (or ask the user to). Update the mental model based on the result.
+5. **Only then propose attempt #4** — and if the probe falsified the model, attempt #4 is a *different kind* of fix, not a variant of attempts 1–3.
+
+## When to Use
+- Any debugging / troubleshooting / configuration thread in which you have already proposed 3 fixes.
+- When user reports "no, that didn't work either" for the third time.
+- When you catch yourself proposing variants of the same fix (font_size → +1, then +2, then +3).
+- Long sessions where small adjustments stack without progress.
+
+## Limitations
+- Not everything is a "fix" — clarifying questions don't burn the budget.
+- Some bugs genuinely require ≥3 incremental adjustments (tuning a regex, calibrating a threshold) — judge by whether attempts are *variants* of one model (budget applies) or *independent* hypotheses (budget less applicable).
+- The threshold of 3 is heuristic; for high-stakes domains (security, finance) drop to 2.
+- Requires honest attempt-counting; collapsing "well that was just a typo fix" to hide failures defeats the purpose.
+
+## Anti-Pattern
+Proposing attempt #4, #5, #6 as variants of the same model. Each piled-on hack accretes complexity, hides the real cause, and burns user time. 3 failed iterations is not a sign to try harder — it is a sign your model is wrong.

--- a/implants/implant-regression-first.mdc
+++ b/implants/implant-regression-first.mdc
@@ -9,7 +9,7 @@ one_liner: localize the regression before proposing any fix
 1. **Detect the signal**: User says "worked before", "broke yesterday", "stopped after I changed X", "used to work", "регрессия", "после моих правок перестало" — any reference to a working baseline that no longer works.
 2. **Halt hypothesis generation**: Do not propose fixes, root causes, or architectural theories yet.
 3. **Enumerate recent changes** in order of recency-likelihood:
-   - Edits made in the current chat session (highest prior — these are causally closest).
+   - Edits made in the current chat session (highest prior probability — these are causally closest).
    - `git log -5 --oneline` and `git diff HEAD~1` on the relevant repo.
    - Recently modified files: `find <path> -mtime -2 -type f`.
    - Recent config / dependency / lockfile / OS upgrade changes.

--- a/implants/implant-regression-first.mdc
+++ b/implants/implant-regression-first.mdc
@@ -1,0 +1,32 @@
+---
+description: Regression-First Debugging. When user reports "was working before, broke now", "worked yesterday", "stopped working after", "used to work" — locate the last change in the system (recent session edits, git log, file mtimes, dependency bumps) BEFORE proposing fixes. Hypothesize that the last change is the cause; test that hypothesis first. Prevents symptom-chasing when a working baseline exists.
+globs: []
+alwaysApply: false
+short_name: RegressionFirst
+one_liner: localize the regression before proposing any fix
+---
+## Pattern
+1. **Detect the signal**: User says "worked before", "broke yesterday", "stopped after I changed X", "used to work", "регрессия", "после моих правок перестало" — any reference to a working baseline that no longer works.
+2. **Halt hypothesis generation**: Do not propose fixes, root causes, or architectural theories yet.
+3. **Enumerate recent changes** in order of recency-likelihood:
+   - Edits made in the current chat session (highest prior — these are causally closest).
+   - `git log -5 --oneline` and `git diff HEAD~1` on the relevant repo.
+   - Recently modified files: `find <path> -mtime -2 -type f`.
+   - Recent config / dependency / lockfile / OS upgrade changes.
+4. **State the regression hypothesis explicitly**: "Change X (specific commit / edit / config) is the cause."
+5. **Test that hypothesis first**: revert the suspected change in isolation (or `git bisect` if multiple). Only after it is falsified do you move to general root-cause analysis.
+
+## When to Use
+- User reports a regression (was-working-now-broken), not a greenfield bug.
+- After a deploy, config change, dependency bump, OS / tooling upgrade.
+- "It worked on my machine yesterday" / "this used to work in version N".
+- A test that passed on the previous commit now fails.
+
+## Limitations
+- Useless for greenfield bugs (no working baseline exists).
+- Unreliable if the user's "before" memory is wrong — confirm the working version actually worked.
+- Bisection cost grows with batched changes; narrow the time window first.
+- Does not apply when the cause is external (upstream API change) with no local recent change.
+
+## Anti-Pattern
+Proposing fixes for the symptom (rewriting a function, adding a workaround) without identifying what changed. If a baseline worked and now doesn't, **something changed** — find the change first. Every fix proposed without localizing the regression = wasted user time.

--- a/implants/implant-verify-assumptions.mdc
+++ b/implants/implant-verify-assumptions.mdc
@@ -1,0 +1,34 @@
+---
+description: Verify Assumptions Before Architecture. Before proposing architectural decisions, refactors, integrations, or "we should use X" recommendations — list 1-3 facts you're taking as true (e.g. "X is a TUI app", "the config was applied", "the process is killed", "the font is installed") and give each ONE-COMMAND verification. Run all verifications BEFORE designing. Prevents building architecture on a hypothesis instead of fact.
+globs: []
+alwaysApply: false
+short_name: VerifyAssumptions
+one_liner: list and verify 1-3 load-bearing facts before architectural decisions
+---
+## Pattern
+1. **Detect the signal**: You're about to propose a design, refactor, integration, library choice, or "we should X" recommendation.
+2. **Enumerate load-bearing assumptions**: List 1-3 facts your proposal depends on. Be specific — vague assumptions ("the system is fast enough") don't qualify; concrete claims do ("X is a TUI app, not GUI"; "the config is applied at startup"; "the lockfile pins version Y").
+3. **Pair each with a ONE-COMMAND verification**:
+   - "X is a TUI app" → `ls $(nix eval --raw nixpkgs#X)/Applications/` (presence of `.app` ⇒ GUI).
+   - "Config Y was applied" → `<app> +show-config | grep <key>`.
+   - "Font Z is found" → `fc-list | grep <font>`.
+   - "Process is killed" → `pgrep -f <name>`.
+   - "Migration ran" → `<db> -c "SELECT * FROM schema_migrations ORDER BY version DESC LIMIT 5"`.
+4. **Run all checks**. State the actual output.
+5. **Only then propose the design**. If any verification falsifies an assumption, revise the proposal before presenting it.
+
+## When to Use
+- Architectural recommendations ("we should use X").
+- Library / framework / tool choices.
+- Refactoring proposals that hinge on properties of existing code.
+- "It will work because Y" claims where Y is unverified.
+- Any decision presented before reading the code or running a check.
+
+## Limitations
+- Adds latency: 1-3 commands and their interpretation before the recommendation.
+- Verifications themselves can be wrong (running the wrong probe). The one-command form is a feature — it forces specificity, but doesn't guarantee correctness.
+- Not every assumption is verifiable in one command; for those, be explicit they are unverified ("assuming X, please confirm").
+- Overkill for trivial choices (which date library to use).
+
+## Anti-Pattern
+Building architecture on top of an unverified assumption ("we'll use kitty for wrapping because X is a TUI app") when a 5-second check (`ls .../Applications/`) would have falsified the premise. Without verify-step you build architecture on hypothesis, not fact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ evals = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*", "evals*"]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: integration tests that load embedding model / vector store (deselect with '-m \"not slow\"')",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ where = ["."]
 include = ["src*", "evals*"]
 
 [tool.pytest.ini_options]
+addopts = ["-m", "not slow"]
 markers = [
-    "slow: integration tests that load embedding model / vector store (deselect with '-m \"not slow\"')",
+    "slow: integration tests that load embedding model / vector store (opt-in: run with `pytest -m slow`)",
 ]

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -485,6 +485,75 @@ class TestPreferredImplants:
                 "universal_agent", "hi", [])
             assert effective_tier == "lite"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("agent_name, expected_implants", [
+        ("software_engineer", ["implant-regression-first", "implant-iteration-budget"]),
+        ("sysadmin", ["implant-regression-first"]),
+        ("devops_engineer", ["implant-regression-first"]),
+    ])
+    async def test_debugging_implants_forwarded_for_real_agents(self, agent_name, expected_implants):
+        """Real agent frontmatter must forward debugging implants to enrich_agent_prompt."""
+        from src.utils.prompt_loader import get_agent_metadata
+
+        real_metadata = get_agent_metadata(agent_name)
+        assert real_metadata.get("preferred_implants") == expected_implants, (
+            f"Agent {agent_name} frontmatter missing/mismatched preferred_implants: "
+            f"got {real_metadata.get('preferred_implants')!r}"
+        )
+
+        with patch("src.server.load_agent_prompt", return_value="base prompt"), \
+             patch("src.server.enrich_agent_prompt", new_callable=AsyncMock,
+                   return_value=self._fake_enrichment()) as mock_enrich:
+            await self.srv._load_and_enrich(agent_name, "explain a regression I just hit", [])
+            mock_enrich.assert_called_once()
+            assert mock_enrich.call_args.kwargs["preferred_implants"] == expected_implants
+
+
+# ---------------------------------------------------------------------------
+# Semantic retrieval thresholds for debugging implants (slow / integration)
+# ---------------------------------------------------------------------------
+
+class TestDebuggingImplantsRetrieval:
+    """Probe-query retrieval test for the three debugging implants.
+
+    Marked slow because it spins up ImplantRetriever (model load + index)
+    on first invocation. Run via: pytest -m slow.
+    """
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("query, expected_implant", [
+        ("функция логировала всё нормально, после моих правок перестала", "implant-regression-first.mdc"),
+        ("it was working yesterday and now it's broken after the deploy", "implant-regression-first.mdc"),
+        ("I'm going to design a TUI client around far2l, assuming it's a CLI app", "implant-verify-assumptions.mdc"),
+        ("this is my fourth attempt to fix the rendering, none worked", "implant-iteration-budget.mdc"),
+        ("no, that fix didn't work either, that's three tries now", "implant-iteration-budget.mdc"),
+    ])
+    def test_debugging_implants_retrieved_on_triggers(self, query, expected_implant):
+        from src.engine.implants import ImplantRetriever
+        retriever = ImplantRetriever()
+        results = retriever.retrieve(query=query, n_results=5)
+        ids = [r["filename"] for r in results]
+        assert expected_implant in ids, (
+            f"Expected {expected_implant} for query: {query!r}, got: {ids}"
+        )
+
+    @pytest.mark.slow
+    def test_debugging_implants_negative_control(self):
+        """Greenfield coding requests must NOT pull debugging implants."""
+        from src.engine.implants import ImplantRetriever
+        retriever = ImplantRetriever()
+        results = retriever.retrieve(query="write me a fibonacci function", n_results=5)
+        ids = [r["filename"] for r in results]
+        debugging_implants = {
+            "implant-regression-first.mdc",
+            "implant-verify-assumptions.mdc",
+            "implant-iteration-budget.mdc",
+        }
+        intersect = debugging_implants.intersection(ids)
+        assert not intersect, (
+            f"Negative control failed — debugging implants leaked for greenfield query: {intersect}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # clear_session_cache clears both caches

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -529,6 +529,13 @@ class TestDebuggingImplantsRetrieval:
     on first invocation. Run via: pytest -m slow.
     """
 
+    @pytest.fixture(scope="class")
+    def retriever(self):
+        """One ImplantRetriever instance reused across the class — avoids repeated
+        vector-store load/reindex on every parametrized case."""
+        from src.engine.implants import ImplantRetriever
+        return ImplantRetriever()
+
     @pytest.mark.slow
     @pytest.mark.parametrize("query, expected_implant", [
         ("функция логировала всё нормально, после моих правок перестала", "implant-regression-first.mdc"),
@@ -537,21 +544,24 @@ class TestDebuggingImplantsRetrieval:
         ("this is my fourth attempt to fix the rendering, none worked", "implant-iteration-budget.mdc"),
         ("no, that fix didn't work either, that's three tries now", "implant-iteration-budget.mdc"),
     ])
-    def test_debugging_implants_retrieved_on_triggers(self, query, expected_implant):
-        """Trigger phrases (RU + EN) must surface the matching debugging implant within top-5."""
-        from src.engine.implants import ImplantRetriever
-        retriever = ImplantRetriever()
+    def test_debugging_implants_retrieved_on_triggers(self, retriever, query, expected_implant):
+        """Trigger phrases (RU + EN) must surface the matching debugging implant
+        within top-5 AND under the relevance threshold (so threshold drift is caught)."""
+        from src.engine.config import IMPLANTS_RELEVANCE_THRESHOLD
         results = retriever.retrieve(query=query, n_results=5)
         ids = [r["filename"] for r in results]
         assert expected_implant in ids, (
             f"Expected {expected_implant} for query: {query!r}, got: {ids}"
         )
+        matched = next(r for r in results if r["filename"] == expected_implant)
+        assert matched["distance"] < IMPLANTS_RELEVANCE_THRESHOLD, (
+            f"Expected {expected_implant} distance < {IMPLANTS_RELEVANCE_THRESHOLD}, "
+            f"got {matched['distance']:.4f} for query {query!r}"
+        )
 
     @pytest.mark.slow
-    def test_debugging_implants_negative_control(self):
+    def test_debugging_implants_negative_control(self, retriever):
         """Greenfield coding requests must NOT pull debugging implants."""
-        from src.engine.implants import ImplantRetriever
-        retriever = ImplantRetriever()
         results = retriever.retrieve(query="write me a fibonacci function", n_results=5)
         ids = [r["filename"] for r in results]
         debugging_implants = {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -492,13 +492,18 @@ class TestPreferredImplants:
         ("devops_engineer", ["implant-regression-first"]),
     ])
     async def test_debugging_implants_forwarded_for_real_agents(self, agent_name, expected_implants):
-        """Real agent frontmatter must forward debugging implants to enrich_agent_prompt."""
+        """Real agent frontmatter must forward debugging implants to enrich_agent_prompt.
+
+        Uses subset semantics: adding new implants alongside the debugging ones
+        is fine, but removing/renaming any of the expected implants must fail.
+        """
         from src.utils.prompt_loader import get_agent_metadata
 
         real_metadata = get_agent_metadata(agent_name)
-        assert real_metadata.get("preferred_implants") == expected_implants, (
-            f"Agent {agent_name} frontmatter missing/mismatched preferred_implants: "
-            f"got {real_metadata.get('preferred_implants')!r}"
+        actual_in_frontmatter = real_metadata.get("preferred_implants") or []
+        assert set(expected_implants).issubset(set(actual_in_frontmatter)), (
+            f"Agent {agent_name} frontmatter missing debugging implants: "
+            f"expected superset of {expected_implants!r}, got {actual_in_frontmatter!r}"
         )
 
         with patch("src.server.load_agent_prompt", return_value="base prompt"), \
@@ -506,7 +511,11 @@ class TestPreferredImplants:
                    return_value=self._fake_enrichment()) as mock_enrich:
             await self.srv._load_and_enrich(agent_name, "explain a regression I just hit", [])
             mock_enrich.assert_called_once()
-            assert mock_enrich.call_args.kwargs["preferred_implants"] == expected_implants
+            forwarded = mock_enrich.call_args.kwargs["preferred_implants"] or []
+            assert set(expected_implants).issubset(set(forwarded)), (
+                f"enrich_agent_prompt received {forwarded!r}, "
+                f"missing expected {set(expected_implants) - set(forwarded)!r}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -529,6 +538,7 @@ class TestDebuggingImplantsRetrieval:
         ("no, that fix didn't work either, that's three tries now", "implant-iteration-budget.mdc"),
     ])
     def test_debugging_implants_retrieved_on_triggers(self, query, expected_implant):
+        """Trigger phrases (RU + EN) must surface the matching debugging implant within top-5."""
         from src.engine.implants import ImplantRetriever
         retriever = ImplantRetriever()
         results = retriever.retrieve(query=query, n_results=5)


### PR DESCRIPTION
Introduces `implant-regression-first`, `implant-iteration-budget`, and `implant-verify-assumptions` to enhance agent debugging and decision-making processes. These implants provide structured guidance for identifying regression causes, managing failed fix attempts, and verifying critical assumptions before proposing solutions.

**Preferred-implant wiring (2 of 3 explicit, 1 semantic-only by design):**
- `software_engineer` → preferred: `regression-first`, `iteration-budget`
- `sysadmin`, `devops_engineer` → preferred: `regression-first`
- `verify-assumptions` is **intentionally NOT in any agent's `preferred_implants`**. Its triggers ("we should use X", "let's design Y", "I'm going to architect…") span multiple agents (`system_architect`, `mcp_builder`, etc.), so pure semantic retrieval gives broader and more appropriate coverage than tying it to a single agent. Surfacing on triggers is validated by the slow integration test (`test_debugging_implants_retrieved_on_triggers`, probe distance 0.7488 < 0.85 threshold).

**Tests:**
- `test_debugging_implants_forwarded_for_real_agents` — verifies real agent frontmatter forwards the expected debugging implants (subset check, so future additions don't break the test).
- `test_debugging_implants_retrieved_on_triggers` (slow) — 5 probe queries (RU + EN), each surfaces the expected implant within top-5 under the 0.85 cosine-distance threshold.
- `test_debugging_implants_negative_control` (slow) — greenfield "fibonacci" query must NOT pull any of the three debugging implants.

**pytest config:** `slow` marker registered; `addopts = ["-m", "not slow"]` makes slow tests opt-in (`pytest -m slow` to run).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new prompt content and test coverage; runtime impact is limited to agent configuration metadata and pytest defaults, with low risk to production code paths.
> 
> **Overview**
> Adds three new debugging-focused implants: `implant-regression-first`, `implant-iteration-budget`, and `implant-verify-assumptions`.
> 
> Wires `preferred_implants` into the `software_engineer`, `sysadmin`, and `devops_engineer` agent frontmatter (ensuring these implants are forwarded into prompt enrichment), and adds tests to validate both *frontmatter forwarding* and *semantic retrieval behavior* (including a negative control).
> 
> Registers a `slow` pytest marker and makes slow integration tests opt-in by default via `-m not slow` in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f855d054fac8a7ef6fba7f3df9110e0f2595b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regression-first debugging guidance to identify recent changes before proposing fixes.
  * Iteration-budget rule that halts after three failed fix attempts and enforces targeted assumption probes.
  * Assumption-verification pattern for architecture/refactor recommendations.

* **Improvements**
  * Agents now prefer the new debugging aids, improving troubleshooting prioritization.

* **Tests**
  * Added integration tests to verify preferred debugging aids are surfaced and retrieved for relevant queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WonderMr/Agents/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->