### PR TITLE
feat(evals): MCP-vs-vanilla bench harness with pairwise LLM judge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ whisper_models/
 # Exceptions (keep these visible)
 !.gitignore
 !.git/
-#Competition reports
+# Generated benchmark reports
 evals/reports/*
 
 # Evals: keep baseline.md and SOURCES.md, ignore per-PR/per-run reports

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ whisper_models/
 # Exceptions (keep these visible)
 !.gitignore
 !.git/
-!evals/reports/.gitkeep
+#Competition reports
+evals/reports/*
 
 # Evals: keep baseline.md and SOURCES.md, ignore per-PR/per-run reports
 evals/.cache/
@@ -56,4 +57,4 @@ agents_private.egg-info/
 uv.lock
 
 # Local-only Russian architecture overview (not for upstream)
-docs/architecture-ru.md
+docs/*-ru.md

--- a/evals/judges/pairwise_judge.py
+++ b/evals/judges/pairwise_judge.py
@@ -34,7 +34,7 @@ Evaluation criteria (apply all five, weight equally):
 
 Score each criterion 1–5 for each response, then choose the overall winner.
 
-Output ONLY via the `submit_verdict` tool. Choose:
+Return your verdict as a structured object matching the verdict schema (the host wires this as a tool call for Anthropic and as a JSON-schema response for OpenAI — both paths land in the same shape). Choose:
 - "left" — LEFT is clearly better
 - "right" — RIGHT is clearly better
 - "tie" — both are roughly equivalent OR both are bad

--- a/evals/judges/pairwise_judge.py
+++ b/evals/judges/pairwise_judge.py
@@ -112,12 +112,20 @@ _REQUIRED_CRITERION_KEYS = frozenset({
 })
 
 
+_SCORE_MIN = 1
+_SCORE_MAX = 5
+
+
 def _validate_verdict_payload(payload: dict[str, Any]) -> tuple[str, str, dict[str, int]]:
     """Validate that the judge payload conforms to VERDICT_SCHEMA before use.
 
     Fail-fast on malformed responses instead of letting unknown winners silently
     degrade to TIE in `aggregate_with_swap` — that would skew benchmark numbers
     without raising an error.
+
+    Score values are checked against the schema's `integer 1..5` constraint:
+    `bool` is rejected explicitly because `isinstance(True, int) is True` in
+    Python and a `True`/`False` score should not silently sail through as 1/0.
     """
     winner = payload.get("winner")
     reasoning = payload.get("reasoning")
@@ -129,7 +137,17 @@ def _validate_verdict_payload(payload: dict[str, Any]) -> tuple[str, str, dict[s
     if not isinstance(scores, dict) or _REQUIRED_CRITERION_KEYS - scores.keys():
         missing = sorted(_REQUIRED_CRITERION_KEYS - (scores.keys() if isinstance(scores, dict) else set()))
         raise RuntimeError(f"Judge returned incomplete criterion_scores; missing keys: {missing}")
-    return winner, reasoning, dict(scores)
+    for key in _REQUIRED_CRITERION_KEYS:
+        v = scores[key]
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise RuntimeError(
+                f"Judge returned non-integer criterion score for {key!r}: {v!r} (type {type(v).__name__})"
+            )
+        if not (_SCORE_MIN <= v <= _SCORE_MAX):
+            raise RuntimeError(
+                f"Judge returned out-of-range criterion score for {key!r}: {v} (expected {_SCORE_MIN}..{_SCORE_MAX})"
+            )
+    return winner, reasoning, {k: scores[k] for k in _REQUIRED_CRITERION_KEYS}
 
 
 def run_judge(

--- a/evals/judges/pairwise_judge.py
+++ b/evals/judges/pairwise_judge.py
@@ -1,0 +1,182 @@
+"""
+Pairwise LLM-as-judge with positional swap.
+
+Provider-agnostic: the actual API call lives in `evals/runners/_providers.py`.
+This module owns the pure logic — judge system prompt, tool/function schema,
+swap aggregation — that does not depend on which SDK is used.
+
+Each judge call uses tool/function calling for a structured verdict:
+  {"winner": "left" | "right" | "tie", "reasoning": str, "criterion_scores": {...}}
+
+`aggregate_with_swap` maps two judge calls (with positions swapped between them)
+back to an arm-level verdict and resolves contradictions to TIE.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+JUDGE_SYSTEM_PROMPT = """You are an impartial expert evaluator. You will be shown a USER QUERY and two AI responses labelled LEFT and RIGHT. Decide which response better serves the user.
+
+Evaluation criteria (apply all five, weight equally):
+1. **helpfulness** — does it answer the question and move the user forward?
+2. **correctness** — are the claims factually accurate, free of fabrication?
+3. **depth** — is the level of detail appropriate (not too thin, not bloated)?
+4. **structure** — is it organised, skimmable, free of redundancy?
+5. **intent-fit** — does it address what the user actually asked, not adjacent topics?
+
+Score each criterion 1–5 for each response, then choose the overall winner.
+
+Output ONLY via the `submit_verdict` tool. Choose:
+- "left" — LEFT is clearly better
+- "right" — RIGHT is clearly better
+- "tie" — both are roughly equivalent OR both are bad
+
+Be decisive: prefer "left"/"right" over "tie" unless the responses are genuinely indistinguishable. Position (LEFT vs RIGHT) is randomised — do not let order influence you.
+"""
+
+# Anthropic-compatible schema; the OpenAI provider re-wraps `input_schema`
+# as `parameters` for the function-calling format.
+VERDICT_SCHEMA: dict[str, Any] = {
+    "name": "submit_verdict",
+    "description": "Submit the pairwise verdict for this query.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "winner": {
+                "type": "string",
+                "enum": ["left", "right", "tie"],
+                "description": "Which response is better overall.",
+            },
+            "reasoning": {
+                "type": "string",
+                "maxLength": 600,
+                "description": "Concise justification (1-3 sentences).",
+            },
+            "criterion_scores": {
+                "type": "object",
+                "properties": {
+                    "left_helpfulness": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "left_correctness": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "left_depth": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "left_structure": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "left_intent_fit": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "right_helpfulness": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "right_correctness": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "right_depth": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "right_structure": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "right_intent_fit": {"type": "integer", "minimum": 1, "maximum": 5},
+                },
+                "required": [
+                    "left_helpfulness", "left_correctness", "left_depth", "left_structure", "left_intent_fit",
+                    "right_helpfulness", "right_correctness", "right_depth", "right_structure", "right_intent_fit",
+                ],
+            },
+        },
+        "required": ["winner", "reasoning", "criterion_scores"],
+    },
+}
+
+
+@dataclass(frozen=True)
+class JudgeCall:
+    winner: Literal["left", "right", "tie"]
+    reasoning: str
+    criterion_scores: dict[str, int]
+    usage: dict[str, int]
+
+
+@dataclass(frozen=True)
+class SwapVerdict:
+    final: Literal["vanilla", "mcp", "tie"]
+    pos1: JudgeCall
+    pos2: JudgeCall
+    contradicted: bool
+    total_usage: dict[str, int]
+
+
+def run_judge(
+    *,
+    provider,
+    sync_client,
+    query: str,
+    left: str,
+    right: str,
+    model: str,
+    max_tokens: int = 4096,
+) -> JudgeCall:
+    # Default bumped from 1024 → 4096 so reasoning models (gpt-5.x) have
+    # headroom for both hidden reasoning tokens and the structured tool_call
+    # output. Anthropic / non-reasoning models simply use less of the budget.
+    """Provider-agnostic judge call. `provider` is a ProviderImpl from _providers.py."""
+    payload, usage = provider.call_judge(
+        sync_client,
+        query,
+        left,
+        right,
+        model,
+        JUDGE_SYSTEM_PROMPT,
+        max_tokens,
+        VERDICT_SCHEMA,
+    )
+    return JudgeCall(
+        winner=payload["winner"],
+        reasoning=payload["reasoning"],
+        criterion_scores=dict(payload.get("criterion_scores", {})),
+        usage=usage,
+    )
+
+
+def aggregate_with_swap(
+    *,
+    pos1: JudgeCall,
+    pos2: JudgeCall,
+    pos1_left_is: Literal["vanilla", "mcp"],
+) -> SwapVerdict:
+    """Map two judge calls (positions swapped between them) to a single arm-level verdict.
+
+    `pos1_left_is`: which arm sat on the LEFT in the first call (the second call
+    is the swap, so its LEFT is the other arm).
+
+    Resolution table:
+      - both calls pick the same ARM (after un-swapping) → that arm wins
+      - calls disagree on the arm → contradiction → TIE
+      - any call returns "tie" → falls back to the other call's choice (or tie if both)
+    """
+    pos2_left_is = "mcp" if pos1_left_is == "vanilla" else "vanilla"
+
+    def call_to_arm(call: JudgeCall, left_is: str) -> str:
+        right_is = "mcp" if left_is == "vanilla" else "vanilla"
+        if call.winner == "left":
+            return left_is
+        if call.winner == "right":
+            return right_is
+        return "tie"
+
+    arm1 = call_to_arm(pos1, pos1_left_is)
+    arm2 = call_to_arm(pos2, pos2_left_is)
+
+    if arm1 == arm2:
+        final = arm1
+        contradicted = False
+    elif arm1 == "tie" or arm2 == "tie":
+        non_tie = arm1 if arm2 == "tie" else arm2
+        final = non_tie
+        contradicted = False
+    else:
+        final = "tie"
+        contradicted = True
+
+    total = {
+        k: pos1.usage.get(k, 0) + pos2.usage.get(k, 0)
+        for k in {"input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"}
+    }
+
+    return SwapVerdict(
+        final=final,  # type: ignore[arg-type]
+        pos1=pos1,
+        pos2=pos2,
+        contradicted=contradicted,
+        total_usage=total,
+    )

--- a/evals/judges/pairwise_judge.py
+++ b/evals/judges/pairwise_judge.py
@@ -2,11 +2,17 @@
 Pairwise LLM-as-judge with positional swap.
 
 Provider-agnostic: the actual API call lives in `evals/runners/_providers.py`.
-This module owns the pure logic — judge system prompt, tool/function schema,
+This module owns the pure logic — judge system prompt, verdict schema,
 swap aggregation — that does not depend on which SDK is used.
 
-Each judge call uses tool/function calling for a structured verdict:
+Each judge call returns a structured verdict shaped by `VERDICT_SCHEMA`:
   {"winner": "left" | "right" | "tie", "reasoning": str, "criterion_scores": {...}}
+
+The two provider adapters arrive at the same payload by different routes:
+  - Anthropic: tool-use with `tools` + `tool_choice` on the `submit_verdict` tool.
+  - OpenAI:    `response_format=json_schema` (structured outputs), since
+               function-calling does not pass through reliably via OpenAI-compat
+               proxy layers that relay to Gemini.
 
 `aggregate_with_swap` maps two judge calls (with positions swapped between them)
 back to an arm-level verdict and resolves contradictions to TIE.
@@ -36,8 +42,9 @@ Output ONLY via the `submit_verdict` tool. Choose:
 Be decisive: prefer "left"/"right" over "tie" unless the responses are genuinely indistinguishable. Position (LEFT vs RIGHT) is randomised — do not let order influence you.
 """
 
-# Anthropic-compatible schema; the OpenAI provider re-wraps `input_schema`
-# as `parameters` for the function-calling format.
+# Anthropic-shaped schema (`name` + `input_schema`). The OpenAI provider unwraps
+# `input_schema` and passes it as the `schema` field of a `response_format`
+# `json_schema` block; see `call_judge_openai` for the conversion.
 VERDICT_SCHEMA: dict[str, Any] = {
     "name": "submit_verdict",
     "description": "Submit the pairwise verdict for this query.",
@@ -96,6 +103,35 @@ class SwapVerdict:
     total_usage: dict[str, int]
 
 
+_ALLOWED_WINNERS = frozenset({"left", "right", "tie"})
+_REQUIRED_CRITERION_KEYS = frozenset({
+    "left_helpfulness", "left_correctness", "left_depth",
+    "left_structure", "left_intent_fit",
+    "right_helpfulness", "right_correctness", "right_depth",
+    "right_structure", "right_intent_fit",
+})
+
+
+def _validate_verdict_payload(payload: dict[str, Any]) -> tuple[str, str, dict[str, int]]:
+    """Validate that the judge payload conforms to VERDICT_SCHEMA before use.
+
+    Fail-fast on malformed responses instead of letting unknown winners silently
+    degrade to TIE in `aggregate_with_swap` — that would skew benchmark numbers
+    without raising an error.
+    """
+    winner = payload.get("winner")
+    reasoning = payload.get("reasoning")
+    scores = payload.get("criterion_scores")
+    if winner not in _ALLOWED_WINNERS:
+        raise RuntimeError(f"Judge returned invalid winner: {winner!r}")
+    if not isinstance(reasoning, str):
+        raise RuntimeError(f"Judge returned non-string reasoning: {type(reasoning).__name__}")
+    if not isinstance(scores, dict) or _REQUIRED_CRITERION_KEYS - scores.keys():
+        missing = sorted(_REQUIRED_CRITERION_KEYS - (scores.keys() if isinstance(scores, dict) else set()))
+        raise RuntimeError(f"Judge returned incomplete criterion_scores; missing keys: {missing}")
+    return winner, reasoning, dict(scores)
+
+
 def run_judge(
     *,
     provider,
@@ -120,10 +156,11 @@ def run_judge(
         max_tokens,
         VERDICT_SCHEMA,
     )
+    winner, reasoning, scores = _validate_verdict_payload(payload)
     return JudgeCall(
-        winner=payload["winner"],
-        reasoning=payload["reasoning"],
-        criterion_scores=dict(payload.get("criterion_scores", {})),
+        winner=winner,  # type: ignore[arg-type]
+        reasoning=reasoning,
+        criterion_scores=scores,
         usage=usage,
     )
 

--- a/evals/judges/pairwise_judge.py
+++ b/evals/judges/pairwise_judge.py
@@ -160,10 +160,13 @@ def run_judge(
     model: str,
     max_tokens: int = 4096,
 ) -> JudgeCall:
-    # Default bumped from 1024 → 4096 so reasoning models (gpt-5.x) have
-    # headroom for both hidden reasoning tokens and the structured tool_call
-    # output. Anthropic / non-reasoning models simply use less of the budget.
-    """Provider-agnostic judge call. `provider` is a ProviderImpl from _providers.py."""
+    """Provider-agnostic judge call. `provider` is a ProviderImpl from _providers.py.
+
+    `max_tokens` defaults to 4096 (vs the legacy 1024) so reasoning models
+    (gpt-5.x) have headroom for both hidden reasoning tokens and the
+    structured tool_call / json_schema output. Anthropic and non-reasoning
+    models simply use less of the budget.
+    """
     payload, usage = provider.call_judge(
         sync_client,
         query,

--- a/evals/runners/_providers.py
+++ b/evals/runners/_providers.py
@@ -151,11 +151,17 @@ def _supports_temperature_anthropic(model: str) -> bool:
 
 
 def judge_user_prompt(query: str, left: str, right: str) -> str:
+    # The instruction is provider-neutral: Anthropic submits via the
+    # `submit_verdict` tool (tool_choice forces it), and OpenAI returns a
+    # JSON object via `response_format=json_schema`. Either path is "matching
+    # the verdict schema", so we phrase it that way to avoid telling the
+    # OpenAI path it can call a tool that the request never declared.
     return (
         f"USER QUERY:\n{query}\n\n"
         f"---\nLEFT:\n{left}\n\n"
         f"---\nRIGHT:\n{right}\n\n"
-        f"---\nSubmit your verdict via the submit_verdict tool."
+        f"---\nSubmit your verdict as a JSON object matching the verdict schema "
+        f"(winner, reasoning, criterion_scores)."
     )
 
 
@@ -218,16 +224,20 @@ def call_judge_openai(
     #   1. Function-calling does NOT pass through reliably via OpenAI-compat proxy
     #      layers that relay to Gemini (observed: finish_reason=None, empty tool_calls).
     #   2. `tools + reasoning_effort` was banned on gpt-5.5 anyway; json_schema
-    #      avoids that conflict entirely. We still skip reasoning_effort here
-    #      (safer; the judge doesn't need extra thinking depth).
-    response = client.chat.completions.create(
-        model=model,
-        max_completion_tokens=max_tokens,
-        messages=[
+    #      avoids that conflict entirely.
+    # On gpt-5.x judges we also pin `reasoning_effort="none"` for the same reason
+    # `complete_openai` does: the default `"medium"` makes hidden reasoning
+    # tokens count against `max_completion_tokens`, and at the judge budget that
+    # has been observed to consume the entire allowance and leave
+    # `message.content` empty — which then trips the empty-content guard below.
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "max_completion_tokens": max_tokens,
+        "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": judge_user_prompt(query, left, right)},
         ],
-        response_format={
+        "response_format": {
             "type": "json_schema",
             "json_schema": {
                 "name": verdict_schema["name"],
@@ -239,7 +249,10 @@ def call_judge_openai(
                 # structured output; we json.loads + validate downstream.
             },
         },
-    )
+    }
+    if _is_reasoning_openai_model(model):
+        kwargs["reasoning_effort"] = "none"
+    response = client.chat.completions.create(**kwargs)
     choice = response.choices[0]
     content = choice.message.content
     if not content:

--- a/evals/runners/_providers.py
+++ b/evals/runners/_providers.py
@@ -105,8 +105,10 @@ def get_pricing(model: str) -> dict[str, float]:
     if model in MODEL_PRICING:
         return MODEL_PRICING[model]
     # Try prefix match — dated snapshots map to their alias.
-    for alias, pricing in MODEL_PRICING.items():
-        if model.startswith(alias + "-") or model.startswith(alias + "@"):
+    # Sort by alias length descending so the most specific alias wins
+    # (e.g. `gpt-5.5-pro-2026-01-01` matches `gpt-5.5-pro`, not `gpt-5.5`).
+    for alias, pricing in sorted(MODEL_PRICING.items(), key=lambda item: len(item[0]), reverse=True):
+        if model.startswith((alias + "-", alias + "@")):
             return pricing
     # Conservative fallback — better to over-estimate than under-report.
     return {"input": 15.00, "output": 75.00, "cache_read": 1.50, "cache_creation": 18.75}

--- a/evals/runners/_providers.py
+++ b/evals/runners/_providers.py
@@ -1,0 +1,377 @@
+"""
+Provider abstraction: OpenAI vs Anthropic.
+
+Both providers expose the same surface:
+  - async `complete(client, model, query, system_prompt | None, max_tokens) -> (text, usage_dict, latency_ms)`
+  - sync `call_judge(client, query, left, right, model, system_prompt, max_tokens, verdict_schema) -> (payload_dict, usage_dict)`
+  - `pricing` dict (USD per 1M tokens)
+  - `default_model` / `default_judge_model`
+  - client factories
+
+Usage normalisation:
+  All token counts are mapped to a unified 4-field dict so the rest of the
+  runner / report does not need to know which provider produced them:
+    {input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}
+
+  For OpenAI, `cache_creation_input_tokens` is always 0 (OpenAI does not bill
+  cache creation separately) and `cache_read_input_tokens` mirrors
+  `usage.prompt_tokens_details.cached_tokens` when present.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+# --------------------------------------------------------------------------- #
+# Usage normalisation
+# --------------------------------------------------------------------------- #
+
+
+def normalise_usage_anthropic(usage) -> dict[str, int]:
+    return {
+        "input_tokens": getattr(usage, "input_tokens", 0) or 0,
+        "output_tokens": getattr(usage, "output_tokens", 0) or 0,
+        "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+    }
+
+
+def normalise_usage_openai(usage) -> dict[str, int]:
+    prompt = getattr(usage, "prompt_tokens", 0) or 0
+    completion = getattr(usage, "completion_tokens", 0) or 0
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = (getattr(details, "cached_tokens", 0) if details else 0) or 0
+    return {
+        "input_tokens": max(0, prompt - cached),
+        "output_tokens": completion,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": cached,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Pricing (USD per 1M tokens)
+#
+# All values are estimates — verify against current published pricing before
+# using costs in this report for any decision.
+# --------------------------------------------------------------------------- #
+
+
+# Per-model pricing (USD per 1M tokens). All values are estimates — verify
+# against current published pricing before using costs for any decision.
+# Cache write/read rates for Anthropic follow the standard 1.25× / 0.1× input
+# pattern (Reasoned, not verified for each individual model).
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    # OpenAI — verified at developers.openai.com per-model pages.
+    "gpt-4o": {"input": 2.50, "output": 10.00, "cache_read": 1.25, "cache_creation": 0.0},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60, "cache_read": 0.075, "cache_creation": 0.0},
+    "gpt-5.5": {"input": 5.00, "output": 30.00, "cache_read": 0.50, "cache_creation": 0.0},
+    "gpt-5.5-pro": {"input": 30.00, "output": 180.00, "cache_read": 3.00, "cache_creation": 0.0},
+
+    # Anthropic — verified input/output at platform.claude.com.
+    "claude-haiku-4-5": {"input": 1.00, "output": 5.00, "cache_read": 0.10, "cache_creation": 1.25},
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_creation": 3.75},
+    "claude-sonnet-4-5": {"input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_creation": 3.75},
+    "claude-opus-4-7": {"input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_creation": 6.25},
+    "claude-opus-4-6": {"input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_creation": 6.25},
+
+    # Google Gemini — verified at ai.google.dev/gemini-api/docs/pricing (standard tier, prompts ≤200K).
+    # Routed through OPENAI_BASE_URL when a local proxy exposes an OpenAI-compatible /v1 endpoint;
+    # `cache_creation` is 0 — Gemini doesn't bill cache creation separately, matching OpenAI pattern.
+    #
+    # Some local proxies expose their own aliases (e.g. `gemini-3-pro-high`) that map to Google
+    # models with specific reasoning-effort tiers. Pricing below uses Google's published Pro / Flash
+    # rates as estimates — costs through a subscription-relaying proxy are phantom anyway.
+    "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00, "cache_read": 0.20, "cache_creation": 0.0},
+    "gemini-3.1-flash-lite": {"input": 0.25, "output": 1.50, "cache_read": 0.025, "cache_creation": 0.0},
+    "gemini-3-pro-high": {"input": 2.00, "output": 12.00, "cache_read": 0.20, "cache_creation": 0.0},
+    "gemini-3-pro-low": {"input": 2.00, "output": 12.00, "cache_read": 0.20, "cache_creation": 0.0},
+    "gemini-3.1-pro-low": {"input": 2.00, "output": 12.00, "cache_read": 0.20, "cache_creation": 0.0},
+    "gemini-3.1-pro-high": {"input": 2.00, "output": 12.00, "cache_read": 0.20, "cache_creation": 0.0},
+    "gemini-3.5-flash-low": {"input": 0.25, "output": 1.50, "cache_read": 0.025, "cache_creation": 0.0},
+    "gemini-3-flash": {"input": 0.25, "output": 1.50, "cache_read": 0.025, "cache_creation": 0.0},
+}
+
+
+def get_pricing(model: str) -> dict[str, float]:
+    """Look up pricing for a model. Tries exact match, then prefix match
+    (handles dated snapshots like `gpt-4o-2024-11-20` mapping to `gpt-4o`).
+    Falls back to a conservative high estimate so the report never under-reports.
+    """
+    if model in MODEL_PRICING:
+        return MODEL_PRICING[model]
+    # Try prefix match — dated snapshots map to their alias.
+    for alias, pricing in MODEL_PRICING.items():
+        if model.startswith(alias + "-") or model.startswith(alias + "@"):
+            return pricing
+    # Conservative fallback — better to over-estimate than under-report.
+    return {"input": 15.00, "output": 75.00, "cache_read": 1.50, "cache_creation": 18.75}
+
+
+# Backwards-compat alias — provider-level fallback, used when --model is the
+# provider default. New callers should prefer `get_pricing(model)`.
+PRICING: dict[str, dict[str, float]] = {
+    "openai": MODEL_PRICING["gpt-4o"],
+    "anthropic": MODEL_PRICING["claude-sonnet-4-6"],
+}
+
+
+def _is_reasoning_openai_model(model: str) -> bool:
+    """True if the OpenAI model accepts the `reasoning_effort` parameter.
+
+    gpt-5.x family + o-series are reasoning models. gpt-4o and earlier reject
+    `reasoning_effort` with HTTP 400 (Verified at developers.openai.com docs).
+    """
+    m = model.lower()
+    return m.startswith("gpt-5") or m.startswith("o1") or m.startswith("o3") or m.startswith("o4")
+
+
+def _supports_temperature_anthropic(model: str) -> bool:
+    """False if the model REJECTS the `temperature` parameter outright.
+
+    Verified: Claude Opus 4.7 returns HTTP 400 `'temperature' is deprecated for
+    this model.` Other Claude models (Sonnet 4.6, Haiku 4.5, older Opus) still
+    accept `temperature=0` — confirmed by an N=30 Sonnet 4.6 bench run.
+    """
+    m = model.lower()
+    # Deny list grows as new models deprecate temperature.
+    deny_prefixes = ("claude-opus-4-7",)
+    return not any(m.startswith(p) for p in deny_prefixes)
+
+
+# --------------------------------------------------------------------------- #
+# Shared judge user-prompt template
+# --------------------------------------------------------------------------- #
+
+
+def judge_user_prompt(query: str, left: str, right: str) -> str:
+    return (
+        f"USER QUERY:\n{query}\n\n"
+        f"---\nLEFT:\n{left}\n\n"
+        f"---\nRIGHT:\n{right}\n\n"
+        f"---\nSubmit your verdict via the submit_verdict tool."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI implementations
+# --------------------------------------------------------------------------- #
+
+
+async def complete_openai(
+    client,
+    model: str,
+    query: str,
+    system_prompt: str | None,
+    max_tokens: int,
+) -> tuple[str, dict[str, int], int]:
+    # OpenAI's newer model family (gpt-5.x and reasoning models) requires three
+    # mitigations vs the gpt-4 era:
+    #   1. `max_tokens` is rejected — use `max_completion_tokens`.
+    #   2. `temperature` is locked to the default (1); explicit `temperature=0`
+    #      returns HTTP 400. We omit it; some non-determinism is accepted.
+    #   3. `reasoning_effort` defaults to `"medium"`; reasoning tokens count
+    #      against `max_completion_tokens` but are NOT included in
+    #      `choices[0].message.content`. Without intervention the entire budget
+    #      can be consumed by hidden reasoning, leaving an empty visible reply.
+    #      We set `"none"` so the comparison is a clean prompt-engineering test
+    #      (no reasoning confound between vanilla and MCP arms).
+    # All three adjustments are forward-compatible: `max_completion_tokens` and
+    # the default temperature are accepted by older models; `reasoning_effort`
+    # is ignored by non-reasoning models per OpenAI's parameter contract.
+    t0 = time.perf_counter()
+    messages: list[dict[str, Any]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": query})
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_completion_tokens": max_tokens,
+    }
+    if _is_reasoning_openai_model(model):
+        kwargs["reasoning_effort"] = "none"
+    response = await client.chat.completions.create(**kwargs)
+    latency_ms = int((time.perf_counter() - t0) * 1000)
+    text = response.choices[0].message.content or ""
+    return text, normalise_usage_openai(response.usage), latency_ms
+
+
+def call_judge_openai(
+    client,
+    query: str,
+    left: str,
+    right: str,
+    model: str,
+    system_prompt: str,
+    max_tokens: int,
+    verdict_schema: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, int]]:
+    # Uses `response_format=json_schema` (the modern OpenAI structured-outputs
+    # pattern) instead of `tools` + `tool_choice`. Two reasons:
+    #   1. Function-calling does NOT pass through reliably via OpenAI-compat proxy
+    #      layers that relay to Gemini (observed: finish_reason=None, empty tool_calls).
+    #   2. `tools + reasoning_effort` was banned on gpt-5.5 anyway; json_schema
+    #      avoids that conflict entirely. We still skip reasoning_effort here
+    #      (safer; the judge doesn't need extra thinking depth).
+    response = client.chat.completions.create(
+        model=model,
+        max_completion_tokens=max_tokens,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": judge_user_prompt(query, left, right)},
+        ],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": verdict_schema["name"],
+                "schema": verdict_schema["input_schema"],
+                # `strict: true` enforces schema validity on OpenAI side. Drop
+                # it: Gemini through an OpenAI-compat proxy layer chokes on
+                # strict nested-object schemas (finish_reason=malformed_function_call).
+                # We still get JSON via prompting + provider's best-effort
+                # structured output; we json.loads + validate downstream.
+            },
+        },
+    )
+    choice = response.choices[0]
+    content = choice.message.content
+    if not content:
+        raise RuntimeError(
+            f"OpenAI judge returned empty content; finish_reason={choice.finish_reason}"
+        )
+    try:
+        args = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"OpenAI judge content is not valid JSON: {exc}; first 200 chars: {content[:200]!r}") from exc
+    return args, normalise_usage_openai(response.usage)
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic implementations
+# --------------------------------------------------------------------------- #
+
+
+async def complete_anthropic(
+    client,
+    model: str,
+    query: str,
+    system_prompt: str | None,
+    max_tokens: int,
+) -> tuple[str, dict[str, int], int]:
+    # Opus 4.7 deprecates `temperature` — see _supports_temperature_anthropic.
+    # For models that still accept it, we keep `temperature=0` for determinism.
+    t0 = time.perf_counter()
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": query}],
+    }
+    if _supports_temperature_anthropic(model):
+        kwargs["temperature"] = 0
+    if system_prompt:
+        kwargs["system"] = [{"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}]
+    response = await client.messages.create(**kwargs)
+    latency_ms = int((time.perf_counter() - t0) * 1000)
+    text = "".join(getattr(b, "text", "") for b in response.content if getattr(b, "type", "") == "text")
+    return text, normalise_usage_anthropic(response.usage), latency_ms
+
+
+def call_judge_anthropic(
+    client,
+    query: str,
+    left: str,
+    right: str,
+    model: str,
+    system_prompt: str,
+    max_tokens: int,
+    verdict_schema: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, int]]:
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "system": [{"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}],
+        "tools": [verdict_schema],
+        "tool_choice": {"type": "tool", "name": verdict_schema["name"]},
+        "messages": [{"role": "user", "content": judge_user_prompt(query, left, right)}],
+    }
+    if _supports_temperature_anthropic(model):
+        kwargs["temperature"] = 0
+    response = client.messages.create(**kwargs)
+    payload: dict[str, Any] | None = None
+    for block in response.content:
+        if getattr(block, "type", None) == "tool_use" and block.name == verdict_schema["name"]:
+            payload = dict(block.input)
+            break
+    if payload is None:
+        raise RuntimeError(f"Anthropic judge returned no tool_use; stop_reason={response.stop_reason}")
+    return payload, normalise_usage_anthropic(response.usage)
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ProviderImpl:
+    name: str
+    default_model: str
+    default_judge_model: str
+    make_async_client: Callable[[], Any]
+    make_sync_client: Callable[[], Any]
+    complete: Callable  # async
+    call_judge: Callable  # sync
+    pricing: dict[str, float]
+    env_key: str  # name of the API-key env var
+    notes: str  # disclaimer text shown in the HTML report
+
+
+def _make_openai_provider() -> ProviderImpl:
+    from openai import AsyncOpenAI, OpenAI
+
+    return ProviderImpl(
+        name="openai",
+        default_model="gpt-4o",
+        default_judge_model="gpt-4o",
+        make_async_client=AsyncOpenAI,
+        make_sync_client=OpenAI,
+        complete=complete_openai,
+        call_judge=call_judge_openai,
+        pricing=PRICING["openai"],
+        env_key="OPENAI_API_KEY",
+        notes="MCP system prompts in this repo are Claude-authored. Running them against OpenAI is valid as a generalisation test, but absolute quality numbers may differ from Claude-on-Claude.",
+    )
+
+
+def _make_anthropic_provider() -> ProviderImpl:
+    from anthropic import Anthropic, AsyncAnthropic
+
+    return ProviderImpl(
+        name="anthropic",
+        default_model="claude-sonnet-4-6",
+        default_judge_model="claude-sonnet-4-6",
+        make_async_client=AsyncAnthropic,
+        make_sync_client=Anthropic,
+        complete=complete_anthropic,
+        call_judge=call_judge_anthropic,
+        pricing=PRICING["anthropic"],
+        env_key="ANTHROPIC_API_KEY",
+        notes="MCP system prompts in this repo are Claude-authored — comparison runs against the same Claude model the prompts were tuned for.",
+    )
+
+
+_PROVIDERS = {
+    "openai": _make_openai_provider,
+    "anthropic": _make_anthropic_provider,
+}
+
+
+def get_provider(name: str) -> ProviderImpl:
+    if name not in _PROVIDERS:
+        raise ValueError(f"unknown provider {name!r}; choices: {sorted(_PROVIDERS)}")
+    return _PROVIDERS[name]()

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -1,0 +1,814 @@
+"""
+Benchmark: Agents-Core MCP vs Vanilla LLM (provider-agnostic).
+
+Pipeline (N user queries from a public HF dataset):
+  1. Sample queries (deterministic via seed; streaming, no full download).
+  2. For each query, run two arms in parallel:
+       A) vanilla — provider.complete() with no system prompt
+       B) mcp     — provider.complete() with system = enriched prompt built
+                    in-process via SemanticRouter + _load_and_enrich, with
+                    platform-only footer instructions stripped.
+  3. Pairwise LLM-as-judge with positional swap (controls position bias).
+     If either arm returned empty text, judge is skipped → synthetic TIE.
+  4. Render single-file HTML report (Jinja2 template, Chart.js via CDN).
+
+Provider selection:
+    --provider openai     → uses OPENAI_API_KEY (default model: gpt-4o)
+    --provider anthropic  → uses ANTHROPIC_API_KEY (default model: claude-sonnet-4-6)
+
+Usage:
+    python -m evals.runners.run_mcp_vs_vanilla [--n 10] [--seed 42]
+        [--provider openai|anthropic] [--model ...] [--judge-model ...]
+        [--dataset wildbench|lmsys_chat_1m|...]
+        [--concurrency 8] [--max-tokens 2048] [--judge-max-tokens 4096]
+        [--out evals/reports/<date>_mcp_vs_vanilla.html]
+        [--save-json] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import hashlib
+import json
+import logging
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Literal
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from evals.judges.pairwise_judge import (  # noqa: E402
+    JudgeCall,
+    SwapVerdict,
+    aggregate_with_swap,
+    run_judge,
+)
+from evals.runners._providers import ProviderImpl, get_pricing, get_provider  # noqa: E402
+from evals.scripts.fetch import DATASETS, _require_load_dataset  # noqa: E402
+
+logger = logging.getLogger("bench")
+
+
+@dataclass
+class TrialResult:
+    arm: Literal["vanilla", "mcp"]
+    response_text: str
+    usage: dict[str, int]
+    latency_ms: int
+    mcp_meta: dict[str, Any] | None = None
+
+
+@dataclass
+class QueryRun:
+    idx: int
+    query: str
+    source_idx: int
+    vanilla: TrialResult
+    mcp: TrialResult
+    verdict: SwapVerdict
+
+
+@dataclass
+class BenchmarkResult:
+    config: dict[str, Any]
+    runs: list[QueryRun]
+    dataset_hash: str
+    wall_time_s: float
+    pricing: dict[str, float]
+    generated_at: str = field(
+        default_factory=lambda: dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Sampling
+# --------------------------------------------------------------------------- #
+
+
+def sample_queries(dataset_key: str, n: int, seed: int) -> list[tuple[int, str]]:
+    """Stream the dataset and yield N (source_idx, query) pairs with a deterministic shuffle."""
+    if dataset_key not in DATASETS:
+        raise SystemExit(f"unknown dataset {dataset_key!r}; choices: {sorted(DATASETS)}")
+    spec = DATASETS[dataset_key]
+    load_dataset = _require_load_dataset()
+    ds = load_dataset(spec.hf_id, name=spec.config, split=spec.split, streaming=True)
+    ds = ds.shuffle(seed=seed, buffer_size=max(n * 50, 500))
+    out: list[tuple[int, str]] = []
+    for i, row in enumerate(ds):
+        try:
+            q = spec.extract_query(row)
+        except Exception:
+            continue
+        if not q or len(q.strip()) < 10:
+            continue
+        out.append((i, q.strip()))
+        if len(out) >= n:
+            break
+    if len(out) < n:
+        raise SystemExit(f"dataset {dataset_key} yielded only {len(out)}/{n} usable queries")
+    return out
+
+
+def dataset_hash(queries: list[tuple[int, str]]) -> str:
+    h = hashlib.sha256()
+    for idx, q in queries:
+        h.update(f"{idx}\x00{q}\x01".encode("utf-8"))
+    return h.hexdigest()[:16]
+
+
+# --------------------------------------------------------------------------- #
+# MCP system-prompt builder (in-process, bypasses MCP protocol)
+# --------------------------------------------------------------------------- #
+
+
+# Patterns that target platform-only instructions baked into agent prompts —
+# these tell the LLM to behave as a Claude Code participant (call MCP tools,
+# append a routing footer, etc.) and are MEANINGLESS at the bench level.
+# Leaving them in pollutes the MCP arm with output that has nothing to do
+# with the user's question, biasing the judge.
+_PLATFORM_INSTRUCTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # "Append at the end (labels in English, ...): **Agent**: [name] · ..."
+    re.compile(r"Append at the end[^\n]*?\n[^\n]*?\*\*Agent\*\*:[^\n]*?\n?", re.IGNORECASE),
+    # Bare footer template line, with or without preceding "Append".
+    re.compile(r"\*\*Agent\*\*:\s*\[[^\]]+\][^\n]*?\*\*Rules\*\*:\s*\[[^\]]+\][^\n]*\n?", re.IGNORECASE),
+    # Routing-protocol imperatives that ask the model to call MCP tools.
+    re.compile(r"^CRITICAL: You MUST call.*?route_and_load.*?$", re.MULTILINE | re.IGNORECASE),
+    re.compile(r"You MUST call .*?route_and_load.*?[\.\n]", re.IGNORECASE),
+    re.compile(r"Before answering ANY user query.*?[\.\n]", re.IGNORECASE),
+    re.compile(r"This is a BLOCKING REQUIREMENT[^\n]*\n", re.IGNORECASE),
+    # "Respond in the same language as the user's query (auto-detect)." line
+    # — duplicates language-match rule but is keyed to the routing protocol.
+    re.compile(r"Respond in the same language as the user's query \(auto-detect\)\.[^\n]*\n?", re.IGNORECASE),
+)
+
+# Appended at the end to override any residual footer-instructions the regexes
+# missed. Last-instruction-wins is a stronger nudge than regex stripping.
+_BENCH_MODE_OVERRIDE = """
+
+---
+BENCH MODE: This is an evaluation context, not an interactive Claude Code session. Do NOT append any platform metadata footer (no "Agent:", "Skills:", "Implants:", "Rules:" lines). Do NOT mention MCP tools, the routing protocol, or any orchestration directives — none of those exist in this context. Respond ONLY with content that addresses the user's query above.
+"""
+
+
+def _strip_platform_instructions(prompt: str) -> str:
+    """Remove platform-only directives from an enriched MCP prompt.
+
+    Targets footer-append instructions and routing-protocol imperatives that
+    would otherwise be dutifully echoed by the LLM in the MCP arm, polluting
+    the comparison with platform metadata noise.
+    """
+    out = prompt
+    for pattern in _PLATFORM_INSTRUCTION_PATTERNS:
+        out = pattern.sub("", out)
+    return out + _BENCH_MODE_OVERRIDE
+
+
+# Lazy singleton — SemanticRouter loads .npz vector stores from disk on init;
+# re-instantiating per query is wasteful and not thread-safe with concurrent
+# .npz reads.
+_ROUTER_SINGLETON: Any = None
+
+
+def _get_router() -> Any:
+    global _ROUTER_SINGLETON
+    if _ROUTER_SINGLETON is None:
+        from src.engine.router import SemanticRouter
+        _ROUTER_SINGLETON = SemanticRouter()
+    return _ROUTER_SINGLETON
+
+
+async def build_mcp_system_prompt(query: str) -> tuple[str, dict[str, Any]]:
+    """Replicate route_and_load's prompt-building path without going through MCP."""
+    from src.server import _load_and_enrich
+
+    router = _get_router()
+    hits = router.match_keywords(query)
+    if hits and hits[0][1] > 0:
+        agent_name = hits[0][0]
+    else:
+        agent_name = "universal_agent"
+
+    prompt, _ctx_hash, skills, implants, rules, tier = await _load_and_enrich(agent_name, query, [])
+    cleaned = _strip_platform_instructions(prompt)
+    return cleaned, {
+        "agent": agent_name,
+        "tier": tier,
+        "skills_loaded": list(skills),
+        "implants_loaded": list(implants),
+        "rules_loaded": list(rules),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Transient-error retry wrapper
+# --------------------------------------------------------------------------- #
+
+
+def _retryable_api_errors() -> tuple[type[BaseException], ...]:
+    """Collect SDK-specific retryable error classes lazily — avoids importing
+    openai/anthropic at module load time when neither is needed."""
+    errs: list[type[BaseException]] = []
+    try:
+        from openai import APIConnectionError as _O1, APITimeoutError as _O2, RateLimitError as _O3
+        errs += [_O1, _O2, _O3]
+    except ImportError:
+        pass
+    try:
+        from anthropic import APIConnectionError as _A1, APITimeoutError as _A2, RateLimitError as _A3
+        errs += [_A1, _A2, _A3]
+    except ImportError:
+        pass
+    return tuple(errs)
+
+
+_RETRYABLE_CACHE: tuple[type[BaseException], ...] | None = None
+
+
+def _get_retryable() -> tuple[type[BaseException], ...]:
+    global _RETRYABLE_CACHE
+    if _RETRYABLE_CACHE is None:
+        _RETRYABLE_CACHE = _retryable_api_errors()
+    return _RETRYABLE_CACHE
+
+
+async def _with_retries(coro_factory, *, attempts: int = 3, base_delay: float = 2.0) -> Any:
+    """Run an async coroutine factory with exponential backoff on transient API errors."""
+    retryable = _get_retryable()
+    last_exc: BaseException | None = None
+    for attempt in range(attempts):
+        try:
+            return await coro_factory()
+        except retryable as exc:
+            last_exc = exc
+            if attempt == attempts - 1:
+                break
+            delay = base_delay * (2 ** attempt)
+            logger.warning("transient API error (%s); retrying in %.1fs (attempt %d/%d)", type(exc).__name__, delay, attempt + 2, attempts)
+            await asyncio.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
+
+
+# --------------------------------------------------------------------------- #
+# Arm runners
+# --------------------------------------------------------------------------- #
+
+
+async def run_arm_vanilla(provider: ProviderImpl, client, query: str, model: str, max_tokens: int) -> TrialResult:
+    text, usage, latency_ms = await _with_retries(
+        lambda: provider.complete(client, model, query, None, max_tokens)
+    )
+    if not text.strip():
+        logger.warning("vanilla arm returned empty content for query=%r", query[:80])
+    return TrialResult(arm="vanilla", response_text=text, usage=usage, latency_ms=latency_ms)
+
+
+async def run_arm_mcp(provider: ProviderImpl, client, query: str, model: str, max_tokens: int) -> TrialResult:
+    system_prompt, mcp_meta = await build_mcp_system_prompt(query)
+    text, usage, latency_ms = await _with_retries(
+        lambda: provider.complete(client, model, query, system_prompt, max_tokens)
+    )
+    if not text.strip():
+        logger.warning("mcp arm returned empty content for query=%r (agent=%s)", query[:80], mcp_meta.get("agent"))
+    return TrialResult(arm="mcp", response_text=text, usage=usage, latency_ms=latency_ms, mcp_meta=mcp_meta)
+
+
+# --------------------------------------------------------------------------- #
+# Judge orchestration
+# --------------------------------------------------------------------------- #
+
+
+async def judge_with_swap(
+    *,
+    judge_provider: ProviderImpl,
+    judge_sync_client,
+    query: str,
+    vanilla_text: str,
+    mcp_text: str,
+    judge_model: str,
+    judge_max_tokens: int,
+) -> SwapVerdict:
+    """Judge can be a different provider than arms — e.g. Gemini arms judged
+    by Claude. This breaks position bias AND avoids per-provider quirks
+    (Gemini is unreliable as a json_schema judge via OpenAI-compat layers)."""
+    pos1 = await asyncio.to_thread(
+        run_judge,
+        provider=judge_provider,
+        sync_client=judge_sync_client,
+        query=query,
+        left=vanilla_text,
+        right=mcp_text,
+        model=judge_model,
+        max_tokens=judge_max_tokens,
+    )
+    pos2 = await asyncio.to_thread(
+        run_judge,
+        provider=judge_provider,
+        sync_client=judge_sync_client,
+        query=query,
+        left=mcp_text,
+        right=vanilla_text,
+        model=judge_model,
+        max_tokens=judge_max_tokens,
+    )
+    return aggregate_with_swap(pos1=pos1, pos2=pos2, pos1_left_is="vanilla")
+
+
+def _synthetic_empty_tie(reason: str) -> SwapVerdict:
+    """Synthesize a TIE verdict when at least one arm returned empty text.
+
+    Skipping the judge avoids spending tokens on a comparison the judge can't
+    do honestly ("" vs "real text" is decided by length, not quality).
+    Both pos1/pos2 are stubbed with `winner='tie'` and zero usage so downstream
+    aggregation/cost code treats them uniformly.
+    """
+    zero_usage = {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+    stub = JudgeCall(winner="tie", reasoning=reason, criterion_scores={}, usage=dict(zero_usage))
+    return SwapVerdict(final="tie", pos1=stub, pos2=stub, contradicted=False, total_usage=dict(zero_usage))
+
+
+async def run_one_query(
+    *,
+    idx: int,
+    source_idx: int,
+    query: str,
+    provider: ProviderImpl,
+    async_client,
+    sync_client,
+    judge_provider: ProviderImpl,
+    judge_sync_client,
+    model: str,
+    judge_model: str,
+    max_tokens: int,
+    judge_max_tokens: int,
+    semaphore: asyncio.Semaphore,
+) -> QueryRun:
+    async with semaphore:
+        vanilla, mcp = await asyncio.gather(
+            run_arm_vanilla(provider, async_client, query, model, max_tokens),
+            run_arm_mcp(provider, async_client, query, model, max_tokens),
+        )
+        if not vanilla.response_text.strip() or not mcp.response_text.strip():
+            empty_arm = "vanilla" if not vanilla.response_text.strip() else "mcp"
+            verdict = _synthetic_empty_tie(
+                f"Skipped judge: {empty_arm} arm returned empty text (likely token-budget exhaustion or content filter)."
+            )
+        else:
+            verdict = await judge_with_swap(
+                judge_provider=judge_provider,
+                judge_sync_client=judge_sync_client,
+                query=query,
+                vanilla_text=vanilla.response_text,
+                mcp_text=mcp.response_text,
+                judge_model=judge_model,
+                judge_max_tokens=judge_max_tokens,
+            )
+    return QueryRun(idx=idx, query=query, source_idx=source_idx, vanilla=vanilla, mcp=mcp, verdict=verdict)
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation + rendering
+# --------------------------------------------------------------------------- #
+
+
+def _cost_usd(usage: dict[str, int], pricing: dict[str, float]) -> float:
+    return (
+        usage["input_tokens"] / 1_000_000 * pricing["input"]
+        + usage["output_tokens"] / 1_000_000 * pricing["output"]
+        + usage["cache_read_input_tokens"] / 1_000_000 * pricing["cache_read"]
+        + usage["cache_creation_input_tokens"] / 1_000_000 * pricing["cache_creation"]
+    )
+
+
+def _cost_split(usage: dict[str, int], pricing: dict[str, float]) -> dict[str, float]:
+    """Break a usage dict into per-component USD costs (input vs output vs cache)."""
+    return {
+        "input_usd": usage["input_tokens"] / 1_000_000 * pricing["input"],
+        "output_usd": usage["output_tokens"] / 1_000_000 * pricing["output"],
+        "cache_read_usd": usage["cache_read_input_tokens"] / 1_000_000 * pricing["cache_read"],
+        "cache_creation_usd": usage["cache_creation_input_tokens"] / 1_000_000 * pricing["cache_creation"],
+    }
+
+
+def _sum_usages(usages: list[dict[str, int]]) -> dict[str, int]:
+    out = {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+    for u in usages:
+        for k in out:
+            out[k] += u.get(k, 0)
+    return out
+
+
+def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
+    runs = result.runs
+    n = len(runs)
+    mcp_wins = sum(1 for r in runs if r.verdict.final == "mcp")
+    vanilla_wins = sum(1 for r in runs if r.verdict.final == "vanilla")
+    ties = sum(1 for r in runs if r.verdict.final == "tie")
+    contradictions = sum(1 for r in runs if r.verdict.contradicted)
+    pricing = result.pricing
+
+    def tot(usage_key: str, arm: str) -> int:
+        return sum(getattr(r, arm).usage[usage_key] for r in runs)
+
+    def total_arm_tokens(arm: str) -> int:
+        return sum(sum(getattr(r, arm).usage.values()) for r in runs)
+
+    avg_tokens_vanilla = round(total_arm_tokens("vanilla") / n) if n else 0
+    avg_tokens_mcp = round(total_arm_tokens("mcp") / n) if n else 0
+    token_overhead_abs = avg_tokens_mcp - avg_tokens_vanilla
+    token_overhead_pct = round(100 * token_overhead_abs / avg_tokens_vanilla, 1) if avg_tokens_vanilla else 0
+
+    cost_vanilla = sum(_cost_usd(r.vanilla.usage, pricing) for r in runs)
+    cost_mcp = sum(_cost_usd(r.mcp.usage, pricing) for r in runs)
+    cost_judge = sum(_cost_usd(r.verdict.total_usage, pricing) for r in runs)
+    total_cost = cost_vanilla + cost_mcp + cost_judge
+
+    # Per-arm aggregate usage + per-component cost split, surfaced as table rows.
+    vanilla_usage_total = _sum_usages([r.vanilla.usage for r in runs])
+    mcp_usage_total = _sum_usages([r.mcp.usage for r in runs])
+    judge_usage_total = _sum_usages([r.verdict.total_usage for r in runs])
+    total_usage = _sum_usages([vanilla_usage_total, mcp_usage_total, judge_usage_total])
+
+    def _row(label: str, usage: dict[str, int]) -> dict[str, Any]:
+        split = _cost_split(usage, pricing)
+        return {
+            "label": label,
+            "input_tokens": usage["input_tokens"],
+            "output_tokens": usage["output_tokens"],
+            "cache_read_tokens": usage["cache_read_input_tokens"],
+            "input_usd": f"{split['input_usd']:.4f}",
+            "output_usd": f"{split['output_usd']:.4f}",
+            "cache_read_usd": f"{split['cache_read_usd']:.4f}",
+            "total_usd": f"{sum(split.values()):.4f}",
+        }
+
+    cost_breakdown = [
+        _row("Vanilla (arm)", vanilla_usage_total),
+        _row("MCP (arm)", mcp_usage_total),
+        _row("Judge (×2 swap)", judge_usage_total),
+        _row("TOTAL", total_usage),
+    ]
+
+    agents = [r.mcp.mcp_meta["agent"] for r in runs if r.mcp.mcp_meta]
+    agent_counts = {a: agents.count(a) for a in set(agents)}
+    routing_summary = ", ".join(f"{a}×{c}" for a, c in sorted(agent_counts.items(), key=lambda kv: -kv[1])[:4])
+
+    def median_lat(arm: str) -> int:
+        vals = [getattr(r, arm).latency_ms for r in runs]
+        return int(statistics.median(vals)) if vals else 0
+
+    if mcp_wins > vanilla_wins:
+        overall_winner = "mcp"
+        overall_winner_label = "MCP wins"
+        overall_winner_margin = f"{mcp_wins} vs {vanilla_wins} ({ties} ties)"
+    elif vanilla_wins > mcp_wins:
+        overall_winner = "vanilla"
+        overall_winner_label = "Vanilla wins"
+        overall_winner_margin = f"{vanilla_wins} vs {mcp_wins} ({ties} ties)"
+    else:
+        overall_winner = "tie"
+        overall_winner_label = "Overall: TIE"
+        overall_winner_margin = f"{mcp_wins} MCP · {vanilla_wins} Vanilla · {ties} ties"
+
+    summary = {
+        "mcp_wins": mcp_wins,
+        "vanilla_wins": vanilla_wins,
+        "ties": ties,
+        "contradictions": contradictions,
+        "mcp_win_pct": round(100 * mcp_wins / n, 1) if n else 0,
+        "overall_winner": overall_winner,
+        "overall_winner_label": overall_winner_label,
+        "overall_winner_margin": overall_winner_margin,
+        "avg_tokens_vanilla": avg_tokens_vanilla,
+        "avg_tokens_mcp": avg_tokens_mcp,
+        "token_overhead_abs": token_overhead_abs,
+        "token_overhead_pct": token_overhead_pct,
+        "total_cost_usd": f"{total_cost:.4f}",
+        "cost_arms_usd": f"{cost_vanilla + cost_mcp:.4f}",
+        "cost_judge_usd": f"{cost_judge:.4f}",
+        "median_latency_vanilla_ms": median_lat("vanilla"),
+        "median_latency_mcp_ms": median_lat("mcp"),
+        "routing_unique_agents": len(agent_counts),
+        "routing_summary": routing_summary or "—",
+    }
+
+    def _resolved_arm(winner: str, left_arm: str) -> str:
+        """Map raw judge winner ('left'/'right'/'tie') to the actual arm name."""
+        right_arm = "mcp" if left_arm == "vanilla" else "vanilla"
+        if winner == "left":
+            return left_arm
+        if winner == "right":
+            return right_arm
+        return "tie"
+
+    # Detect truncation: an arm hitting >= 98% of the max_tokens cap almost
+    # certainly stopped at the limit rather than naturally completing.
+    arm_max = result.config.get("max_tokens", 0)
+    truncation_threshold = int(arm_max * 0.98) if arm_max else 0
+
+    def _is_truncated(usage: dict[str, int]) -> bool:
+        return arm_max > 0 and usage["output_tokens"] >= truncation_threshold
+
+    truncation_count = 0
+    per_query: list[dict[str, Any]] = []
+    for r in runs:
+        vanilla_truncated = _is_truncated(r.vanilla.usage)
+        mcp_truncated = _is_truncated(r.mcp.usage)
+        if vanilla_truncated or mcp_truncated:
+            truncation_count += 1
+        per_query.append({
+            "query": r.query,
+            "query_preview": r.query[:120] + ("…" if len(r.query) > 120 else ""),
+            "final_verdict": r.verdict.final,
+            "contradicted": r.verdict.contradicted,
+            "vanilla_response": r.vanilla.response_text,
+            "vanilla_usage": r.vanilla.usage,
+            "vanilla_latency_ms": r.vanilla.latency_ms,
+            "vanilla_truncated": vanilla_truncated,
+            "mcp_response": r.mcp.response_text,
+            "mcp_usage": r.mcp.usage,
+            "mcp_latency_ms": r.mcp.latency_ms,
+            "mcp_truncated": mcp_truncated,
+            "mcp_meta": r.mcp.mcp_meta or {"agent": "?", "tier": "?", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []},
+            "judge_pos1": {
+                "winner": r.verdict.pos1.winner,
+                "winner_arm": _resolved_arm(r.verdict.pos1.winner, "vanilla"),
+                "reasoning": r.verdict.pos1.reasoning,
+            },
+            "judge_pos2": {
+                "winner": r.verdict.pos2.winner,
+                "winner_arm": _resolved_arm(r.verdict.pos2.winner, "mcp"),
+                "reasoning": r.verdict.pos2.reasoning,
+            },
+        })
+
+    summary["truncation_count"] = truncation_count
+    summary["arm_max_tokens"] = arm_max
+
+    chart_data = {
+        "win_rate": {
+            "labels": ["MCP wins", "Vanilla wins", "Tie"],
+            "values": [mcp_wins, vanilla_wins, ties],
+        },
+        "tokens": {
+            "labels": ["Vanilla", "MCP"],
+            "input": [round(tot("input_tokens", "vanilla") / n), round(tot("input_tokens", "mcp") / n)] if n else [0, 0],
+            "output": [round(tot("output_tokens", "vanilla") / n), round(tot("output_tokens", "mcp") / n)] if n else [0, 0],
+            "cache_read": [round(tot("cache_read_input_tokens", "vanilla") / n), round(tot("cache_read_input_tokens", "mcp") / n)] if n else [0, 0],
+            "cache_creation": [round(tot("cache_creation_input_tokens", "vanilla") / n), round(tot("cache_creation_input_tokens", "mcp") / n)] if n else [0, 0],
+        },
+    }
+
+    return {
+        "date": dt.date.today().isoformat(),
+        "model": result.config["model"],
+        "judge_model": result.config["judge_model"],
+        "judge_provider": result.config.get("judge_provider", result.config["provider"]),
+        "cross_provider_judge": result.config.get("judge_provider") not in (None, result.config["provider"]),
+        "provider": result.config["provider"],
+        "provider_notes": result.config["provider_notes"],
+        "n": n,
+        "seed": result.config["seed"],
+        "dataset_key": result.config["dataset"],
+        "commit_sha": result.config.get("commit_sha", "unknown"),
+        "summary": summary,
+        "cost_breakdown": cost_breakdown,
+        "per_query": per_query,
+        "chart_data": chart_data,
+        "dataset_hash": result.dataset_hash,
+        "generated_at": result.generated_at,
+        "wall_time_s": round(result.wall_time_s, 1),
+        "pricing": pricing,
+    }
+
+
+def render_html(result: BenchmarkResult, template_path: Path) -> str:
+    from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+    env = Environment(
+        loader=FileSystemLoader(template_path.parent),
+        autoescape=select_autoescape(["html", "j2"]),
+        trim_blocks=False,
+        lstrip_blocks=False,
+    )
+    tpl = env.get_template(template_path.name)
+    return tpl.render(**build_template_context(result))
+
+
+# --------------------------------------------------------------------------- #
+# CLI / main
+# --------------------------------------------------------------------------- #
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=REPO_ROOT, stderr=subprocess.DEVNULL)
+        return out.decode().strip()
+    except Exception:
+        return "nogit"
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+    # Quiet noisy SDK loggers — keep our bench logger at INFO.
+    for noisy in ("httpx", "httpcore", "openai", "anthropic", "urllib3", "datasets", "filelock"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    provider = get_provider(args.provider)
+    model = args.model or provider.default_model
+    # Judge selection precedence: CLI flag > env var > arm provider default.
+    # `JUDGE_PROVIDER` / `JUDGE_MODEL` env vars let users swap judges without
+    # editing scripts — e.g. `./scripts/set_judge.sh opus` updates .env once
+    # and every subsequent bench run picks it up.
+    judge_provider_name = args.judge_provider or os.getenv("JUDGE_PROVIDER") or args.provider
+    judge_provider = get_provider(judge_provider_name)
+    judge_model = args.judge_model or os.getenv("JUDGE_MODEL") or judge_provider.default_judge_model
+
+    queries = sample_queries(args.dataset, args.n, args.seed)
+    ds_hash = dataset_hash(queries)
+
+    print(
+        f"[bench] provider={provider.name} model={model} "
+        f"judge_provider={judge_provider.name} judge_model={judge_model} "
+        f"dataset={args.dataset} n={len(queries)} seed={args.seed} hash={ds_hash} "
+        f"concurrency={args.concurrency}",
+        file=sys.stderr,
+    )
+    for i, (src_idx, q) in enumerate(queries, 1):
+        print(f"  [{i:>2}] (src={src_idx}) {q[:100]}{'…' if len(q) > 100 else ''}", file=sys.stderr)
+
+    if args.dry_run:
+        print(f"[bench] --dry-run: skipping API calls", file=sys.stderr)
+        return 0
+
+    if not os.getenv(provider.env_key):
+        raise SystemExit(f"{provider.env_key} not set in env (required for --provider {provider.name})")
+    if not os.getenv(judge_provider.env_key):
+        raise SystemExit(f"{judge_provider.env_key} not set in env (required for --judge-provider {judge_provider.name})")
+
+    async_client = provider.make_async_client()
+    sync_client = provider.make_sync_client()
+    # When judge_provider == provider, reuse the sync_client to save resources.
+    judge_sync_client = sync_client if judge_provider.name == provider.name else judge_provider.make_sync_client()
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    t0 = time.perf_counter()
+    runs = await asyncio.gather(*[
+        run_one_query(
+            idx=i,
+            source_idx=src_idx,
+            query=q,
+            provider=provider,
+            async_client=async_client,
+            sync_client=sync_client,
+            judge_provider=judge_provider,
+            judge_sync_client=judge_sync_client,
+            model=model,
+            judge_model=judge_model,
+            max_tokens=args.max_tokens,
+            judge_max_tokens=args.judge_max_tokens,
+            semaphore=semaphore,
+        )
+        for i, (src_idx, q) in enumerate(queries, 1)
+    ])
+    wall = time.perf_counter() - t0
+
+    # Use the per-model pricing table — falls back to provider-level if unknown.
+    pricing = get_pricing(model)
+    result = BenchmarkResult(
+        config={
+            "provider": provider.name,
+            "provider_notes": provider.notes,
+            "model": model,
+            "judge_provider": judge_provider.name,
+            "judge_model": judge_model,
+            "seed": args.seed,
+            "dataset": args.dataset,
+            "commit_sha": _git_sha(),
+            "max_tokens": args.max_tokens,
+            "judge_max_tokens": args.judge_max_tokens,
+            "concurrency": args.concurrency,
+        },
+        runs=runs,
+        dataset_hash=ds_hash,
+        wall_time_s=wall,
+        pricing=pricing,
+    )
+
+    template_path = REPO_ROOT / "evals" / "templates" / "report.html.j2"
+    html = render_html(result, template_path)
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        out_path = REPO_ROOT / "evals" / "reports" / f"{dt.date.today().isoformat()}_mcp_vs_vanilla_{provider.name}.html"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html, encoding="utf-8")
+
+    if args.save_json:
+        json_path = out_path.with_suffix(".json")
+        json_path.write_text(json.dumps({
+            "config": result.config,
+            "dataset_hash": result.dataset_hash,
+            "wall_time_s": result.wall_time_s,
+            "generated_at": result.generated_at,
+            "pricing": result.pricing,
+            "runs": [
+                {
+                    "idx": r.idx,
+                    "source_idx": r.source_idx,
+                    "query": r.query,
+                    "vanilla": asdict(r.vanilla),
+                    "mcp": asdict(r.mcp),
+                    "verdict": {
+                        "final": r.verdict.final,
+                        "contradicted": r.verdict.contradicted,
+                        "total_usage": r.verdict.total_usage,
+                        "pos1": asdict(r.verdict.pos1),
+                        "pos2": asdict(r.verdict.pos2),
+                    },
+                }
+                for r in result.runs
+            ],
+        }, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"[bench] wrote raw JSON → {json_path}", file=sys.stderr)
+
+    print(f"[bench] wrote report → {out_path}", file=sys.stderr)
+    print(
+        f"[bench] wall={wall:.1f}s · mcp_wins={sum(1 for r in runs if r.verdict.final == 'mcp')}/{len(runs)} "
+        f"· contradictions={sum(1 for r in runs if r.verdict.contradicted)}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="run_mcp_vs_vanilla", description=__doc__)
+    p.add_argument("--n", type=int, default=10, help="number of queries to sample (default: 10)")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--provider",
+        default="openai",
+        choices=["openai", "anthropic"],
+        help="LLM provider for both arms and judge (default: openai)",
+    )
+    p.add_argument("--model", default=None, help="model under test for both arms (default: provider's default)")
+    p.add_argument(
+        "--judge-provider", "--judge_provider",
+        default=None,
+        choices=["openai", "anthropic"],
+        help="separate provider for judge (default: same as --provider). Use to break self-judging bias OR to escape model-specific structured-output bugs (e.g. Gemini → claude-sonnet-4-6 judge).",
+    )
+    p.add_argument("--judge-model", "--judge_model", default=None, help="judge model (default: judge-provider's default)")
+    p.add_argument(
+        "--dataset",
+        default="wildbench",
+        choices=sorted(DATASETS),
+        help="HF source dataset (default: wildbench — open; use lmsys_chat_1m only if you have HF_TOKEN with access)",
+    )
+    p.add_argument(
+        "--max-tokens", "--max_tokens",
+        type=int,
+        default=8192,
+        help="max_tokens cap for each arm response (default: 8192). Long-form prompts (essays, code reviews) "
+        "can hit the cap; check the report for the ⚠ TRUNCATED badge. Cost is 'up to' — most responses use less.",
+    )
+    p.add_argument(
+        "--judge-max-tokens", "--judge_max_tokens",
+        type=int,
+        default=4096,
+        help="max_tokens for each judge call (default: 4096 — gives reasoning models headroom)",
+    )
+    p.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="max queries in flight simultaneously (default: 8). Each query uses 2 arm + 2 judge API calls.",
+    )
+    p.add_argument("--out", help="output HTML path (default: evals/reports/<date>_mcp_vs_vanilla_<provider>.html)")
+    p.add_argument("--save-json", "--save_json", action="store_true", help="also dump raw run data as <out>.json")
+    p.add_argument("--dry-run", "--dry_run", action="store_true", help="sample queries and print them; no API calls")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -304,27 +304,27 @@ async def judge_with_swap(
 ) -> SwapVerdict:
     """Judge can be a different provider than arms — e.g. Gemini arms judged
     by Claude. This breaks position bias AND avoids per-provider quirks
-    (Gemini is unreliable as a json_schema judge via OpenAI-compat layers)."""
-    pos1 = await asyncio.to_thread(
-        run_judge,
-        provider=judge_provider,
-        sync_client=judge_sync_client,
-        query=query,
-        left=vanilla_text,
-        right=mcp_text,
-        model=judge_model,
-        max_tokens=judge_max_tokens,
-    )
-    pos2 = await asyncio.to_thread(
-        run_judge,
-        provider=judge_provider,
-        sync_client=judge_sync_client,
-        query=query,
-        left=mcp_text,
-        right=vanilla_text,
-        model=judge_model,
-        max_tokens=judge_max_tokens,
-    )
+    (Gemini is unreliable as a json_schema judge via OpenAI-compat layers).
+
+    Each position is wrapped in `_with_retries` so a transient rate-limit or
+    timeout from the judge provider does not fail the whole query — arms
+    already retry, the judge must match that contract.
+    """
+
+    async def _judge_one(left_text: str, right_text: str) -> JudgeCall:
+        return await asyncio.to_thread(
+            run_judge,
+            provider=judge_provider,
+            sync_client=judge_sync_client,
+            query=query,
+            left=left_text,
+            right=right_text,
+            model=judge_model,
+            max_tokens=judge_max_tokens,
+        )
+
+    pos1 = await _with_retries(lambda: _judge_one(vanilla_text, mcp_text))
+    pos2 = await _with_retries(lambda: _judge_one(mcp_text, vanilla_text))
     return aggregate_with_swap(pos1=pos1, pos2=pos2, pos1_left_is="vanilla")
 
 
@@ -694,6 +694,11 @@ async def main_async(args: argparse.Namespace) -> int:
         judge_sync_client = provider.make_sync_client()
     else:
         judge_sync_client = judge_provider.make_sync_client()
+    # Pre-warm the SemanticRouter singleton before launching concurrent tasks.
+    # `_get_router` is sync (no `await`) so under asyncio cooperative
+    # scheduling it would be atomic anyway, but constructing it eagerly here
+    # removes any ambiguity and avoids the first-query latency spike.
+    _get_router()
     semaphore = asyncio.Semaphore(args.concurrency)
 
     t0 = time.perf_counter()

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -205,21 +205,64 @@ def _get_router() -> Any:
 
 
 async def build_mcp_system_prompt(query: str) -> tuple[str, dict[str, Any]]:
-    """Replicate route_and_load's prompt-building path without going through MCP."""
-    from src.server import _load_and_enrich
+    """Replicate `src.server.route_and_load` for the no-LLM-picker portion.
+
+    Production flow on a fresh query (no sticky agent, no context_hash):
+      1. `router.lookup_cache(query)` — semantic cache hit?
+         - Hit → apply `keyword_veto`:
+             - veto == agent       → cache confirms
+             - veto is another id  → keyword override
+             - veto == ROUTE_REQUIRED → ambiguous, production hands to LLM-picker
+         - Miss → fall to step 2.
+      2. `_is_meta_query(query)` → `universal_agent`.
+      3. Otherwise → ROUTE_REQUIRED → LLM-picker chooses an agent from
+         `router.get_agent_catalog()`.
+
+    The bench harness cannot reproduce step 3's LLM-picker without going
+    circular (the LLM under bench would also be making the routing call),
+    so for cache-miss-and-not-meta-query queries we fall back to the top
+    `match_keywords` hit (or `universal_agent` if no hit). Every branch is
+    recorded in `mcp_meta["routing_path"]` so the report can surface how
+    many queries used a real cache hit vs the deterministic fallback —
+    that distinction matters for interpreting the bench result.
+    """
+    from src.server import _load_and_enrich, _is_meta_query
+    from src.engine.router import KEYWORD_VETO_ROUTE_REQUIRED
 
     router = _get_router()
-    hits = router.match_keywords(query)
-    if hits and hits[0][1] > 0:
-        agent_name = hits[0][0]
-    else:
+
+    def _keyword_fallback() -> str:
+        hits = router.match_keywords(query)
+        return hits[0][0] if hits and hits[0][1] > 0 else "universal_agent"
+
+    cached = await router.lookup_cache(query, {})
+    if cached is not None:
+        veto = router.keyword_veto(query, cached.target_agent)
+        if veto is None:
+            agent_name = cached.target_agent
+            routing_path = "cache_hit"
+        elif veto == KEYWORD_VETO_ROUTE_REQUIRED:
+            # Production: ambiguous → LLM-picker. Bench: deterministic stand-in.
+            agent_name = _keyword_fallback()
+            routing_path = "keyword_fallback_after_ambiguous_veto"
+        else:
+            agent_name = veto
+            routing_path = "keyword_override_cached"
+    elif _is_meta_query(query):
         agent_name = "universal_agent"
+        routing_path = "meta_query"
+    else:
+        # Production cache miss → ROUTE_REQUIRED → LLM-picker. Bench stand-in
+        # is the top match_keywords hit, falling back to universal_agent.
+        agent_name = _keyword_fallback()
+        routing_path = "keyword_fallback"
 
     prompt, _ctx_hash, skills, implants, rules, tier = await _load_and_enrich(agent_name, query, [])
     cleaned = _strip_platform_instructions(prompt)
     return cleaned, {
         "agent": agent_name,
         "tier": tier,
+        "routing_path": routing_path,
         "skills_loaded": list(skills),
         "implants_loaded": list(implants),
         "rules_loaded": list(rules),
@@ -510,6 +553,16 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
     agent_counts = dict(Counter(agents))
     routing_summary = ", ".join(f"{a}×{c}" for a, c in sorted(agent_counts.items(), key=lambda kv: -kv[1])[:4])
 
+    # Distribution of routing paths — how many queries used a real cache hit
+    # vs. the deterministic keyword fallback vs. meta-query. Surface this so
+    # the report makes clear which slice of the bench reflects production
+    # routing fidelity vs. the no-LLM-picker stand-in.
+    routing_paths = [r.mcp.mcp_meta.get("routing_path", "unknown") for r in runs if r.mcp.mcp_meta]
+    routing_path_counts = dict(Counter(routing_paths))
+    routing_path_summary = ", ".join(
+        f"{p}×{c}" for p, c in sorted(routing_path_counts.items(), key=lambda kv: -kv[1])
+    )
+
     def median_lat(arm: str) -> int:
         vals = [getattr(r, arm).latency_ms for r in runs]
         return int(statistics.median(vals)) if vals else 0
@@ -547,6 +600,8 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
         "median_latency_mcp_ms": median_lat("mcp"),
         "routing_unique_agents": len(agent_counts),
         "routing_summary": routing_summary or "—",
+        "routing_path_summary": routing_path_summary or "—",
+        "routing_path_counts": routing_path_counts,
     }
 
     def _resolved_arm(winner: str, left_arm: str) -> str:
@@ -586,7 +641,7 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
             "mcp_usage": r.mcp.usage,
             "mcp_latency_ms": r.mcp.latency_ms,
             "mcp_truncated": mcp_truncated,
-            "mcp_meta": r.mcp.mcp_meta or {"agent": "?", "tier": "?", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []},
+            "mcp_meta": r.mcp.mcp_meta or {"agent": "?", "tier": "?", "routing_path": "?", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []},
             "judge_pos1": {
                 "winner": r.verdict.pos1.winner,
                 "winner_arm": _resolved_arm(r.verdict.pos1.winner, "vanilla"),

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -73,7 +73,13 @@ class TrialResult:
 class QueryRun:
     idx: int
     query: str
-    source_idx: int
+    # Position in the shuffled streaming iterator at sample time — NOT the
+    # HuggingFace split row index. Streaming + `.shuffle(buffer_size=…)`
+    # discards the original row index, so this field cannot be passed back to
+    # `evals.scripts.fetch --idx` to recover the source row; it only exists
+    # for in-run debugging. Provenance lives in `dataset_hash` + the query
+    # text itself.
+    stream_idx: int
     vanilla: TrialResult
     mcp: TrialResult
     verdict: SwapVerdict
@@ -100,7 +106,14 @@ class BenchmarkResult:
 
 
 def sample_queries(dataset_key: str, n: int, seed: int) -> list[tuple[int, str]]:
-    """Stream the dataset and yield N (source_idx, query) pairs with a deterministic shuffle."""
+    """Stream the dataset and yield N (stream_idx, query) pairs with a deterministic shuffle.
+
+    `stream_idx` is the enumerate position after `.shuffle(buffer_size=…)`,
+    NOT the original HuggingFace split row index. Don't pass it back to
+    `evals.scripts.fetch --idx` — that consumer expects the unshuffled
+    split index, which is unrecoverable once streaming + buffered shuffle
+    has been applied.
+    """
     if dataset_key not in DATASETS:
         raise SystemExit(f"unknown dataset {dataset_key!r}; choices: {sorted(DATASETS)}")
     spec = DATASETS[dataset_key]
@@ -344,7 +357,7 @@ def _synthetic_empty_tie(reason: str) -> SwapVerdict:
 async def run_one_query(
     *,
     idx: int,
-    source_idx: int,
+    stream_idx: int,
     query: str,
     provider: ProviderImpl,
     async_client,
@@ -376,7 +389,7 @@ async def run_one_query(
                 judge_model=judge_model,
                 judge_max_tokens=judge_max_tokens,
             )
-    return QueryRun(idx=idx, query=query, source_idx=source_idx, vanilla=vanilla, mcp=mcp, verdict=verdict)
+    return QueryRun(idx=idx, query=query, stream_idx=stream_idx, vanilla=vanilla, mcp=mcp, verdict=verdict)
 
 
 # --------------------------------------------------------------------------- #
@@ -437,12 +450,16 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
     cost_judge = sum(_cost_usd(r.verdict.total_usage, judge_pricing) for r in runs)
     total_cost = cost_vanilla + cost_mcp + cost_judge
 
-    # Per-arm aggregate usage + per-component cost split, surfaced as table rows.
+    # Per-arm aggregate usage + per-component cost split.
+    # Costs are kept as floats through aggregation and formatted exactly once
+    # at the end — formatting per-component first and re-summing the formatted
+    # strings would drift by sub-cent rounding (Copilot regression), making
+    # TOTAL.input + TOTAL.output + … ≠ TOTAL.total in the rendered HTML.
     vanilla_usage_total = _sum_usages([r.vanilla.usage for r in runs])
     mcp_usage_total = _sum_usages([r.mcp.usage for r in runs])
     judge_usage_total = _sum_usages([r.verdict.total_usage for r in runs])
 
-    def _row(label: str, usage: dict[str, int], pricing_table: dict[str, float]) -> dict[str, Any]:
+    def _numeric_row(label: str, usage: dict[str, int], pricing_table: dict[str, float]) -> dict[str, Any]:
         split = _cost_split(usage, pricing_table)
         return {
             "label": label,
@@ -450,37 +467,44 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
             "output_tokens": usage["output_tokens"],
             "cache_read_tokens": usage["cache_read_input_tokens"],
             "cache_creation_tokens": usage["cache_creation_input_tokens"],
-            "input_usd": f"{split['input_usd']:.4f}",
-            "output_usd": f"{split['output_usd']:.4f}",
-            "cache_read_usd": f"{split['cache_read_usd']:.4f}",
-            "cache_creation_usd": f"{split['cache_creation_usd']:.4f}",
-            "total_usd": f"{sum(split.values()):.4f}",
+            "_input_usd": split["input_usd"],
+            "_output_usd": split["output_usd"],
+            "_cache_read_usd": split["cache_read_usd"],
+            "_cache_creation_usd": split["cache_creation_usd"],
+            "_total_usd": sum(split.values()),
         }
 
-    vanilla_row = _row("Vanilla (arm)", vanilla_usage_total, arm_pricing)
-    mcp_row = _row("MCP (arm)", mcp_usage_total, arm_pricing)
-    judge_row = _row("Judge (×2 swap)", judge_usage_total, judge_pricing)
+    def _format_row(r: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "label": r["label"],
+            "input_tokens": r["input_tokens"],
+            "output_tokens": r["output_tokens"],
+            "cache_read_tokens": r["cache_read_tokens"],
+            "cache_creation_tokens": r["cache_creation_tokens"],
+            "input_usd": f"{r['_input_usd']:.4f}",
+            "output_usd": f"{r['_output_usd']:.4f}",
+            "cache_read_usd": f"{r['_cache_read_usd']:.4f}",
+            "cache_creation_usd": f"{r['_cache_creation_usd']:.4f}",
+            "total_usd": f"{r['_total_usd']:.4f}",
+        }
 
-    # TOTAL aggregates the dollars from the three rows (which were each charged
-    # at their correct per-role rate). Re-pricing the summed tokens at a single
-    # table would silently mis-bill cross-provider runs.
-    def _sum_floats(*rows: dict[str, Any], key: str) -> float:
-        return sum(float(r[key]) for r in rows)
+    vanilla_num = _numeric_row("Vanilla (arm)", vanilla_usage_total, arm_pricing)
+    mcp_num = _numeric_row("MCP (arm)", mcp_usage_total, arm_pricing)
+    judge_num = _numeric_row("Judge (×2 swap)", judge_usage_total, judge_pricing)
 
-    total_row = {
+    total_num = {
         "label": "TOTAL",
-        "input_tokens": vanilla_usage_total["input_tokens"] + mcp_usage_total["input_tokens"] + judge_usage_total["input_tokens"],
-        "output_tokens": vanilla_usage_total["output_tokens"] + mcp_usage_total["output_tokens"] + judge_usage_total["output_tokens"],
-        "cache_read_tokens": vanilla_usage_total["cache_read_input_tokens"] + mcp_usage_total["cache_read_input_tokens"] + judge_usage_total["cache_read_input_tokens"],
-        "cache_creation_tokens": vanilla_usage_total["cache_creation_input_tokens"] + mcp_usage_total["cache_creation_input_tokens"] + judge_usage_total["cache_creation_input_tokens"],
-        "input_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='input_usd'):.4f}",
-        "output_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='output_usd'):.4f}",
-        "cache_read_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='cache_read_usd'):.4f}",
-        "cache_creation_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='cache_creation_usd'):.4f}",
-        "total_usd": f"{total_cost:.4f}",
+        "input_tokens": sum(r["input_tokens"] for r in (vanilla_num, mcp_num, judge_num)),
+        "output_tokens": sum(r["output_tokens"] for r in (vanilla_num, mcp_num, judge_num)),
+        "cache_read_tokens": sum(r["cache_read_tokens"] for r in (vanilla_num, mcp_num, judge_num)),
+        "cache_creation_tokens": sum(r["cache_creation_tokens"] for r in (vanilla_num, mcp_num, judge_num)),
+        "_input_usd": sum(r["_input_usd"] for r in (vanilla_num, mcp_num, judge_num)),
+        "_output_usd": sum(r["_output_usd"] for r in (vanilla_num, mcp_num, judge_num)),
+        "_cache_read_usd": sum(r["_cache_read_usd"] for r in (vanilla_num, mcp_num, judge_num)),
+        "_cache_creation_usd": sum(r["_cache_creation_usd"] for r in (vanilla_num, mcp_num, judge_num)),
+        "_total_usd": total_cost,
     }
-
-    cost_breakdown = [vanilla_row, mcp_row, judge_row, total_row]
+    cost_breakdown = [_format_row(r) for r in (vanilla_num, mcp_num, judge_num, total_num)]
 
     agents = [r.mcp.mcp_meta["agent"] for r in runs if r.mcp.mcp_meta]
     agent_counts = dict(Counter(agents))
@@ -673,8 +697,8 @@ async def main_async(args: argparse.Namespace) -> int:
         f"concurrency={args.concurrency}",
         file=sys.stderr,
     )
-    for i, (src_idx, q) in enumerate(queries, 1):
-        print(f"  [{i:>2}] (src={src_idx}) {q[:100]}{'…' if len(q) > 100 else ''}", file=sys.stderr)
+    for i, (s_idx, q) in enumerate(queries, 1):
+        print(f"  [{i:>2}] (stream={s_idx}) {q[:100]}{'…' if len(q) > 100 else ''}", file=sys.stderr)
 
     if args.dry_run:
         print(f"[bench] --dry-run: skipping API calls", file=sys.stderr)
@@ -705,7 +729,7 @@ async def main_async(args: argparse.Namespace) -> int:
     runs = await asyncio.gather(*[
         run_one_query(
             idx=i,
-            source_idx=src_idx,
+            stream_idx=s_idx,
             query=q,
             provider=provider,
             async_client=async_client,
@@ -717,7 +741,7 @@ async def main_async(args: argparse.Namespace) -> int:
             judge_max_tokens=args.judge_max_tokens,
             semaphore=semaphore,
         )
-        for i, (src_idx, q) in enumerate(queries, 1)
+        for i, (s_idx, q) in enumerate(queries, 1)
     ])
     wall = time.perf_counter() - t0
 
@@ -769,7 +793,7 @@ async def main_async(args: argparse.Namespace) -> int:
             "runs": [
                 {
                     "idx": r.idx,
-                    "source_idx": r.source_idx,
+                    "stream_idx": r.stream_idx,
                     "query": r.query,
                     "vanilla": asdict(r.vanilla),
                     "mcp": asdict(r.mcp),

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -84,7 +84,10 @@ class BenchmarkResult:
     runs: list[QueryRun]
     dataset_hash: str
     wall_time_s: float
-    pricing: dict[str, float]
+    # Pricing is split per role so cross-provider / different-model judge runs
+    # bill arm tokens and judge tokens against the correct per-1M rates.
+    arm_pricing: dict[str, float]
+    judge_pricing: dict[str, float]
     generated_at: str = field(
         default_factory=lambda: dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     )
@@ -415,7 +418,8 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
     vanilla_wins = sum(1 for r in runs if r.verdict.final == "vanilla")
     ties = sum(1 for r in runs if r.verdict.final == "tie")
     contradictions = sum(1 for r in runs if r.verdict.contradicted)
-    pricing = result.pricing
+    arm_pricing = result.arm_pricing
+    judge_pricing = result.judge_pricing
 
     def tot(usage_key: str, arm: str) -> int:
         return sum(getattr(r, arm).usage[usage_key] for r in runs)
@@ -428,36 +432,55 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
     token_overhead_abs = avg_tokens_mcp - avg_tokens_vanilla
     token_overhead_pct = round(100 * token_overhead_abs / avg_tokens_vanilla, 1) if avg_tokens_vanilla else 0
 
-    cost_vanilla = sum(_cost_usd(r.vanilla.usage, pricing) for r in runs)
-    cost_mcp = sum(_cost_usd(r.mcp.usage, pricing) for r in runs)
-    cost_judge = sum(_cost_usd(r.verdict.total_usage, pricing) for r in runs)
+    cost_vanilla = sum(_cost_usd(r.vanilla.usage, arm_pricing) for r in runs)
+    cost_mcp = sum(_cost_usd(r.mcp.usage, arm_pricing) for r in runs)
+    cost_judge = sum(_cost_usd(r.verdict.total_usage, judge_pricing) for r in runs)
     total_cost = cost_vanilla + cost_mcp + cost_judge
 
     # Per-arm aggregate usage + per-component cost split, surfaced as table rows.
     vanilla_usage_total = _sum_usages([r.vanilla.usage for r in runs])
     mcp_usage_total = _sum_usages([r.mcp.usage for r in runs])
     judge_usage_total = _sum_usages([r.verdict.total_usage for r in runs])
-    total_usage = _sum_usages([vanilla_usage_total, mcp_usage_total, judge_usage_total])
 
-    def _row(label: str, usage: dict[str, int]) -> dict[str, Any]:
-        split = _cost_split(usage, pricing)
+    def _row(label: str, usage: dict[str, int], pricing_table: dict[str, float]) -> dict[str, Any]:
+        split = _cost_split(usage, pricing_table)
         return {
             "label": label,
             "input_tokens": usage["input_tokens"],
             "output_tokens": usage["output_tokens"],
             "cache_read_tokens": usage["cache_read_input_tokens"],
+            "cache_creation_tokens": usage["cache_creation_input_tokens"],
             "input_usd": f"{split['input_usd']:.4f}",
             "output_usd": f"{split['output_usd']:.4f}",
             "cache_read_usd": f"{split['cache_read_usd']:.4f}",
+            "cache_creation_usd": f"{split['cache_creation_usd']:.4f}",
             "total_usd": f"{sum(split.values()):.4f}",
         }
 
-    cost_breakdown = [
-        _row("Vanilla (arm)", vanilla_usage_total),
-        _row("MCP (arm)", mcp_usage_total),
-        _row("Judge (×2 swap)", judge_usage_total),
-        _row("TOTAL", total_usage),
-    ]
+    vanilla_row = _row("Vanilla (arm)", vanilla_usage_total, arm_pricing)
+    mcp_row = _row("MCP (arm)", mcp_usage_total, arm_pricing)
+    judge_row = _row("Judge (×2 swap)", judge_usage_total, judge_pricing)
+
+    # TOTAL aggregates the dollars from the three rows (which were each charged
+    # at their correct per-role rate). Re-pricing the summed tokens at a single
+    # table would silently mis-bill cross-provider runs.
+    def _sum_floats(*rows: dict[str, Any], key: str) -> float:
+        return sum(float(r[key]) for r in rows)
+
+    total_row = {
+        "label": "TOTAL",
+        "input_tokens": vanilla_usage_total["input_tokens"] + mcp_usage_total["input_tokens"] + judge_usage_total["input_tokens"],
+        "output_tokens": vanilla_usage_total["output_tokens"] + mcp_usage_total["output_tokens"] + judge_usage_total["output_tokens"],
+        "cache_read_tokens": vanilla_usage_total["cache_read_input_tokens"] + mcp_usage_total["cache_read_input_tokens"] + judge_usage_total["cache_read_input_tokens"],
+        "cache_creation_tokens": vanilla_usage_total["cache_creation_input_tokens"] + mcp_usage_total["cache_creation_input_tokens"] + judge_usage_total["cache_creation_input_tokens"],
+        "input_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='input_usd'):.4f}",
+        "output_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='output_usd'):.4f}",
+        "cache_read_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='cache_read_usd'):.4f}",
+        "cache_creation_usd": f"{_sum_floats(vanilla_row, mcp_row, judge_row, key='cache_creation_usd'):.4f}",
+        "total_usd": f"{total_cost:.4f}",
+    }
+
+    cost_breakdown = [vanilla_row, mcp_row, judge_row, total_row]
 
     agents = [r.mcp.mcp_meta["agent"] for r in runs if r.mcp.mcp_meta]
     agent_counts = {a: agents.count(a) for a in set(agents)}
@@ -588,7 +611,9 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
         "dataset_hash": result.dataset_hash,
         "generated_at": result.generated_at,
         "wall_time_s": round(result.wall_time_s, 1),
-        "pricing": pricing,
+        "arm_pricing": arm_pricing,
+        "judge_pricing": judge_pricing,
+        "cross_provider_pricing": arm_pricing != judge_pricing,
     }
 
 
@@ -687,8 +712,11 @@ async def main_async(args: argparse.Namespace) -> int:
     ])
     wall = time.perf_counter() - t0
 
-    # Use the per-model pricing table — falls back to provider-level if unknown.
-    pricing = get_pricing(model)
+    # Per-model pricing table — falls back to provider-level if unknown.
+    # Arm vs judge pricing is split so cross-provider / different-model judge
+    # runs bill each role against the correct per-1M rates.
+    arm_pricing = get_pricing(model)
+    judge_pricing = get_pricing(judge_model)
     result = BenchmarkResult(
         config={
             "provider": provider.name,
@@ -706,7 +734,8 @@ async def main_async(args: argparse.Namespace) -> int:
         runs=runs,
         dataset_hash=ds_hash,
         wall_time_s=wall,
-        pricing=pricing,
+        arm_pricing=arm_pricing,
+        judge_pricing=judge_pricing,
     )
 
     template_path = REPO_ROOT / "evals" / "templates" / "report.html.j2"
@@ -726,7 +755,8 @@ async def main_async(args: argparse.Namespace) -> int:
             "dataset_hash": result.dataset_hash,
             "wall_time_s": result.wall_time_s,
             "generated_at": result.generated_at,
-            "pricing": result.pricing,
+            "arm_pricing": result.arm_pricing,
+            "judge_pricing": result.judge_pricing,
             "runs": [
                 {
                     "idx": r.idx,

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -39,6 +39,7 @@ import statistics
 import subprocess
 import sys
 import time
+from collections import Counter
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any, Literal
@@ -347,7 +348,6 @@ async def run_one_query(
     query: str,
     provider: ProviderImpl,
     async_client,
-    sync_client,
     judge_provider: ProviderImpl,
     judge_sync_client,
     model: str,
@@ -483,7 +483,7 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
     cost_breakdown = [vanilla_row, mcp_row, judge_row, total_row]
 
     agents = [r.mcp.mcp_meta["agent"] for r in runs if r.mcp.mcp_meta]
-    agent_counts = {a: agents.count(a) for a in set(agents)}
+    agent_counts = dict(Counter(agents))
     routing_summary = ", ".join(f"{a}×{c}" for a, c in sorted(agent_counts.items(), key=lambda kv: -kv[1])[:4])
 
     def median_lat(arm: str) -> int:
@@ -686,9 +686,14 @@ async def main_async(args: argparse.Namespace) -> int:
         raise SystemExit(f"{judge_provider.env_key} not set in env (required for --judge-provider {judge_provider.name})")
 
     async_client = provider.make_async_client()
-    sync_client = provider.make_sync_client()
-    # When judge_provider == provider, reuse the sync_client to save resources.
-    judge_sync_client = sync_client if judge_provider.name == provider.name else judge_provider.make_sync_client()
+    # Arms use only the async client; the judge runs synchronously inside
+    # `asyncio.to_thread`, so it needs a sync client of the judge provider.
+    # If judge_provider == arm provider, sharing one sync client is cheaper;
+    # otherwise the arm's sync client would be created and never used.
+    if judge_provider.name == provider.name:
+        judge_sync_client = provider.make_sync_client()
+    else:
+        judge_sync_client = judge_provider.make_sync_client()
     semaphore = asyncio.Semaphore(args.concurrency)
 
     t0 = time.perf_counter()
@@ -699,7 +704,6 @@ async def main_async(args: argparse.Namespace) -> int:
             query=q,
             provider=provider,
             async_client=async_client,
-            sync_client=sync_client,
             judge_provider=judge_provider,
             judge_sync_client=judge_sync_client,
             model=model,

--- a/evals/scripts/fetch.py
+++ b/evals/scripts/fetch.py
@@ -104,6 +104,26 @@ def _extract_clinc_meta(row: dict[str, Any]) -> dict[str, Any]:
     return {"intent": row.get("intent")}
 
 
+def _extract_lmsys_query(row: dict[str, Any]) -> str:
+    """lmsys-chat-1m: `conversation` is a list of {role, content}; first user turn is the query."""
+    convo = row.get("conversation") or []
+    for turn in convo:
+        if isinstance(turn, dict) and turn.get("role") == "user":
+            content = turn.get("content")
+            if isinstance(content, str) and content.strip():
+                return content
+    raise ValueError(f"no user turn in conversation: keys={list(row)}")
+
+
+def _extract_lmsys_meta(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model": row.get("model"),
+        "language": row.get("language"),
+        "turn": row.get("turn"),
+        "openai_moderation": row.get("openai_moderation"),
+    }
+
+
 DATASETS: dict[str, DatasetSpec] = {
     "wildbench": DatasetSpec(
         key="wildbench",
@@ -159,6 +179,17 @@ DATASETS: dict[str, DatasetSpec] = {
         license="CC-BY-3.0",
         license_url="https://huggingface.co/datasets/clinc_oos",
         notes="Out-of-scope subset filtered downstream where intent label corresponds to 'oos'.",
+    ),
+    "lmsys_chat_1m": DatasetSpec(
+        key="lmsys_chat_1m",
+        hf_id="lmsys/lmsys-chat-1m",
+        config=None,
+        split="train",
+        extract_query=_extract_lmsys_query,
+        extract_meta=_extract_lmsys_meta,
+        license="LMSYS-Chat-1M License (research-only, gated)",
+        license_url="https://huggingface.co/datasets/lmsys/lmsys-chat-1m",
+        notes="Real-world user/LLM chats. Requires HF_TOKEN with dataset access granted. First user turn used as query.",
     ),
 }
 

--- a/evals/templates/report.html.j2
+++ b/evals/templates/report.html.j2
@@ -115,6 +115,9 @@
     <span class="label">Routing breakdown</span>
     <span class="value">{{ summary.routing_unique_agents }} agents</span>
     <span class="delta">{{ summary.routing_summary }}</span>
+    <span class="delta" title="cache_hit / keyword_override_cached / meta_query reflect production routing; keyword_fallback* are bench stand-ins for the LLM-picker step that production would invoke on cache miss.">
+      paths: {{ summary.routing_path_summary }}
+    </span>
   </div>
   <div class="card kpi">
     <span class="label">Judge contradictions</span>
@@ -201,6 +204,7 @@
 
     <p class="meta">
       Routing: <code>{{ r.mcp_meta.agent }}</code> · tier <code>{{ r.mcp_meta.tier }}</code> ·
+      path <code>{{ r.mcp_meta.routing_path }}</code> ·
       skills <code>{{ r.mcp_meta.skills_loaded | join(", ") or "—" }}</code> ·
       implants <code>{{ r.mcp_meta.implants_loaded | join(", ") or "—" }}</code> ·
       rules <code>{{ r.mcp_meta.rules_loaded | join(", ") or "—" }}</code>

--- a/evals/templates/report.html.j2
+++ b/evals/templates/report.html.j2
@@ -137,9 +137,11 @@
         <th class="num">Input tokens (sent)</th>
         <th class="num">Output tokens (received)</th>
         <th class="num">Cache read</th>
+        <th class="num">Cache create</th>
         <th class="num">Input $$</th>
         <th class="num">Output $$</th>
         <th class="num">Cache read $$</th>
+        <th class="num">Cache create $$</th>
         <th class="num">Total $$</th>
       </tr>
     </thead>
@@ -150,9 +152,11 @@
         <td class="num">{{ "{:,}".format(row.input_tokens) }}</td>
         <td class="num">{{ "{:,}".format(row.output_tokens) }}</td>
         <td class="num">{{ "{:,}".format(row.cache_read_tokens) }}</td>
+        <td class="num">{{ "{:,}".format(row.cache_creation_tokens) }}</td>
         <td class="num">${{ row.input_usd }}</td>
         <td class="num">${{ row.output_usd }}</td>
         <td class="num">${{ row.cache_read_usd }}</td>
+        <td class="num">${{ row.cache_creation_usd }}</td>
         <td class="num">${{ row.total_usd }}</td>
       </tr>
     {% endfor %}
@@ -160,10 +164,16 @@
   </table>
 </div>
 <p class="meta" style="margin-top: 8px;">
-  Pricing (per 1M tokens) — input <code>${{ pricing.input }}</code> ·
-  output <code>${{ pricing.output }}</code> ·
-  cache_read <code>${{ pricing.cache_read }}</code> ·
-  cache_creation <code>${{ pricing.cache_creation }}</code>.
+  Arm pricing (per 1M tokens) — input <code>${{ arm_pricing.input }}</code> ·
+  output <code>${{ arm_pricing.output }}</code> ·
+  cache_read <code>${{ arm_pricing.cache_read }}</code> ·
+  cache_creation <code>${{ arm_pricing.cache_creation }}</code>.
+  {% if cross_provider_pricing %}<br>
+  Judge pricing (per 1M tokens) — input <code>${{ judge_pricing.input }}</code> ·
+  output <code>${{ judge_pricing.output }}</code> ·
+  cache_read <code>${{ judge_pricing.cache_read }}</code> ·
+  cache_creation <code>${{ judge_pricing.cache_creation }}</code>.
+  {% endif %}<br>
   Output tokens are typically much more expensive than input — when MCP wins by writing longer answers, look at output $$.
 </p>
 
@@ -246,9 +256,13 @@
   Dataset sha256: <code>{{ dataset_hash }}</code> ·
   generated: <code>{{ generated_at }}</code> ·
   total wall time: <code>{{ wall_time_s }}s</code><br>
-  pricing assumptions (USD per 1M tokens): input ${{ pricing.input }}, output ${{ pricing.output }},
-  cache_read ${{ pricing.cache_read }}, cache_creation ${{ pricing.cache_creation }} —
-  if these are stale, costs shown above are an estimate, not a billing fact.
+  arm pricing assumptions (USD per 1M tokens): input ${{ arm_pricing.input }}, output ${{ arm_pricing.output }},
+  cache_read ${{ arm_pricing.cache_read }}, cache_creation ${{ arm_pricing.cache_creation }}.
+  {% if cross_provider_pricing %}<br>
+  judge pricing assumptions (USD per 1M tokens): input ${{ judge_pricing.input }}, output ${{ judge_pricing.output }},
+  cache_read ${{ judge_pricing.cache_read }}, cache_creation ${{ judge_pricing.cache_creation }}.
+  {% endif %}<br>
+  If these are stale, costs shown above are an estimate, not a billing fact.
 </footer>
 
 <script>

--- a/evals/templates/report.html.j2
+++ b/evals/templates/report.html.j2
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Agents-Core MCP vs Vanilla — {{ date }}</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<style>
+  :root {
+    --bg: #0b0d12; --card: #131722; --fg: #e6edf3; --muted: #8b949e;
+    --accent: #58a6ff; --good: #3fb950; --bad: #f85149; --tie: #d29922;
+    --border: #30363d;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 24px; background: var(--bg); color: var(--fg);
+         font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  h1 { margin: 0 0 4px; font-size: 22px; }
+  h2 { margin: 32px 0 12px; font-size: 18px; border-bottom: 1px solid var(--border); padding-bottom: 6px; }
+  h3 { margin: 18px 0 8px; font-size: 15px; }
+  .subtitle { color: var(--muted); margin-bottom: 24px; }
+  .grid { display: grid; gap: 16px; }
+  .grid-3 { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+  .grid-2 { grid-template-columns: 1fr 1fr; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+  .kpi { display: flex; flex-direction: column; gap: 4px; }
+  .kpi .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .kpi .value { font-size: 24px; font-weight: 600; }
+  .kpi .delta { font-size: 12px; }
+  .delta.good { color: var(--good); }
+  .delta.bad { color: var(--bad); }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { padding: 8px 10px; text-align: left; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
+  tr:last-child td { border-bottom: 0; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  details { background: var(--card); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 12px; }
+  details > summary { padding: 12px 16px; cursor: pointer; user-select: none; list-style: none; }
+  details > summary::before { content: "▸ "; color: var(--muted); }
+  details[open] > summary::before { content: "▾ "; }
+  details > summary > .q-preview { color: var(--muted); margin-left: 8px; }
+  details > .body { padding: 0 16px 16px; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px;
+           background: var(--border); color: var(--fg); margin-right: 4px; }
+  .badge.win-mcp { background: var(--good); color: #0b0d12; }
+  .badge.win-vanilla { background: var(--bad); color: #fff; }
+  .badge.win-tie { background: var(--tie); color: #0b0d12; }
+  .badge.contradicted { background: #6e40c9; color: #fff; }
+  .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 8px; }
+  .pair .col { background: #0b0d12; border: 1px solid var(--border); border-radius: 6px; padding: 12px; }
+  .pair .col h4 { margin: 0 0 8px; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  pre.response { white-space: pre-wrap; word-break: break-word; margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; }
+  .meta { color: var(--muted); font-size: 12px; margin-top: 6px; }
+  .meta code { background: #0b0d12; padding: 1px 4px; border-radius: 3px; }
+  .judge-block { margin-top: 10px; padding: 10px; background: #0b0d12; border-radius: 6px; border: 1px solid var(--border); }
+  .judge-block .reason { font-style: italic; color: var(--muted); }
+  footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 12px; }
+  canvas { max-width: 100%; }
+</style>
+</head>
+<body>
+
+<h1>Agents-Core MCP vs Vanilla LLM</h1>
+<p class="subtitle">
+  {{ date }} · arms: <code>{{ provider }}/{{ model }}</code> ·
+  judge: <code>{{ judge_provider }}/{{ judge_model }}</code>
+  {% if cross_provider_judge %}<span class="badge" style="background: #6e40c9; color: #fff;">cross-provider</span>{% endif %}
+  · N={{ n }} · seed={{ seed }} · source <code>{{ dataset_key }}</code> · commit <code>{{ commit_sha }}</code>
+</p>
+<div class="card" style="margin-bottom: 24px; border-left: 3px solid var(--tie);">
+  <strong>Provider note:</strong> {{ provider_notes }}
+</div>
+
+<h2>Summary</h2>
+
+<div class="card" style="border-left: 6px solid {% if summary.overall_winner == 'mcp' %}var(--good){% elif summary.overall_winner == 'vanilla' %}var(--bad){% else %}var(--tie){% endif %}; margin-bottom: 16px; display: flex; align-items: center; justify-content: space-between; gap: 16px;">
+  <div>
+    <div class="label" style="color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px;">Overall winner</div>
+    <div style="font-size: 28px; font-weight: 700; margin-top: 4px;">{{ summary.overall_winner_label }}</div>
+    <div style="color: var(--muted); margin-top: 4px;">{{ summary.overall_winner_margin }}</div>
+  </div>
+  <div style="text-align: right; color: var(--muted); font-size: 13px;">
+    Token overhead: <strong style="color: var(--fg);">{{ summary.token_overhead_pct }}%</strong><br>
+    Cost: <strong style="color: var(--fg);">${{ summary.total_cost_usd }}</strong>
+  </div>
+</div>
+
+<div class="grid grid-3">
+  <div class="card kpi">
+    <span class="label">MCP win-rate</span>
+    <span class="value">{{ summary.mcp_win_pct }}%</span>
+    <span class="delta {% if summary.mcp_wins > summary.vanilla_wins %}good{% elif summary.mcp_wins < summary.vanilla_wins %}bad{% endif %}">
+      {{ summary.mcp_wins }} wins · {{ summary.vanilla_wins }} losses · {{ summary.ties }} ties
+    </span>
+  </div>
+  <div class="card kpi">
+    <span class="label">Tokens per query (avg)</span>
+    <span class="value">{{ summary.avg_tokens_mcp }} / {{ summary.avg_tokens_vanilla }}</span>
+    <span class="delta {% if summary.token_overhead_pct <= 0 %}good{% else %}bad{% endif %}">
+      MCP overhead: {{ summary.token_overhead_pct }}% ({{ summary.token_overhead_abs }} tokens)
+    </span>
+  </div>
+  <div class="card kpi">
+    <span class="label">Total cost (USD)</span>
+    <span class="value">${{ summary.total_cost_usd }}</span>
+    <span class="delta">arms ${{ summary.cost_arms_usd }} · judge ${{ summary.cost_judge_usd }}</span>
+  </div>
+  <div class="card kpi">
+    <span class="label">Median latency (ms)</span>
+    <span class="value">{{ summary.median_latency_mcp_ms }} / {{ summary.median_latency_vanilla_ms }}</span>
+    <span class="delta">MCP / Vanilla</span>
+  </div>
+  <div class="card kpi">
+    <span class="label">Routing breakdown</span>
+    <span class="value">{{ summary.routing_unique_agents }} agents</span>
+    <span class="delta">{{ summary.routing_summary }}</span>
+  </div>
+  <div class="card kpi">
+    <span class="label">Judge contradictions</span>
+    <span class="value">{{ summary.contradictions }}/{{ n }}</span>
+    <span class="delta">(swap returned opposite verdicts → TIE)</span>
+  </div>
+  <div class="card kpi">
+    <span class="label">Truncated responses</span>
+    <span class="value">{{ summary.truncation_count }}/{{ n }}</span>
+    <span class="delta">
+      arm cap: <code>{{ summary.arm_max_tokens }}</code> tokens.
+      {% if summary.truncation_count > 0 %}Some responses hit the cap mid-sentence — bump --max-tokens.{% endif %}
+    </span>
+  </div>
+</div>
+
+<h2>Cost breakdown</h2>
+<div class="card" style="padding: 0; overflow-x: auto;">
+  <table>
+    <thead>
+      <tr>
+        <th>Source</th>
+        <th class="num">Input tokens (sent)</th>
+        <th class="num">Output tokens (received)</th>
+        <th class="num">Cache read</th>
+        <th class="num">Input $$</th>
+        <th class="num">Output $$</th>
+        <th class="num">Cache read $$</th>
+        <th class="num">Total $$</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for row in cost_breakdown %}
+      <tr{% if row.label == "TOTAL" %} style="font-weight: 600; background: #0b0d12;"{% endif %}>
+        <td>{{ row.label }}</td>
+        <td class="num">{{ "{:,}".format(row.input_tokens) }}</td>
+        <td class="num">{{ "{:,}".format(row.output_tokens) }}</td>
+        <td class="num">{{ "{:,}".format(row.cache_read_tokens) }}</td>
+        <td class="num">${{ row.input_usd }}</td>
+        <td class="num">${{ row.output_usd }}</td>
+        <td class="num">${{ row.cache_read_usd }}</td>
+        <td class="num">${{ row.total_usd }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+<p class="meta" style="margin-top: 8px;">
+  Pricing (per 1M tokens) — input <code>${{ pricing.input }}</code> ·
+  output <code>${{ pricing.output }}</code> ·
+  cache_read <code>${{ pricing.cache_read }}</code> ·
+  cache_creation <code>${{ pricing.cache_creation }}</code>.
+  Output tokens are typically much more expensive than input — when MCP wins by writing longer answers, look at output $$.
+</p>
+
+<h2>Charts</h2>
+<div class="grid grid-2">
+  <div class="card"><canvas id="winRateChart" height="180"></canvas></div>
+  <div class="card"><canvas id="tokenChart" height="180"></canvas></div>
+</div>
+
+<h2>Per-query results</h2>
+{% for r in per_query %}
+<details>
+  <summary>
+    <span class="badge win-{{ r.final_verdict }}">{{ r.final_verdict | upper }}</span>
+    {% if r.contradicted %}<span class="badge contradicted">SWAP CONTRADICTED</span>{% endif %}
+    <strong>#{{ loop.index }}</strong>
+    <span class="q-preview">{{ r.query_preview }}</span>
+  </summary>
+  <div class="body">
+    <p><strong>Query:</strong></p>
+    <pre class="response">{{ r.query }}</pre>
+
+    <p class="meta">
+      Routing: <code>{{ r.mcp_meta.agent }}</code> · tier <code>{{ r.mcp_meta.tier }}</code> ·
+      skills <code>{{ r.mcp_meta.skills_loaded | join(", ") or "—" }}</code> ·
+      implants <code>{{ r.mcp_meta.implants_loaded | join(", ") or "—" }}</code> ·
+      rules <code>{{ r.mcp_meta.rules_loaded | join(", ") or "—" }}</code>
+    </p>
+
+    <div class="pair">
+      <div class="col">
+        <h4>Vanilla (no system prompt) {% if r.vanilla_truncated %}<span class="badge contradicted">⚠ TRUNCATED</span>{% endif %}</h4>
+        <pre class="response">{{ r.vanilla_response }}</pre>
+        <p class="meta">
+          tokens: in <code>{{ r.vanilla_usage.input_tokens }}</code> ·
+          out <code>{{ r.vanilla_usage.output_tokens }}</code> ·
+          latency <code>{{ r.vanilla_latency_ms }} ms</code>
+        </p>
+      </div>
+      <div class="col">
+        <h4>MCP-enriched {% if r.mcp_truncated %}<span class="badge contradicted">⚠ TRUNCATED</span>{% endif %}</h4>
+        <pre class="response">{{ r.mcp_response }}</pre>
+        <p class="meta">
+          tokens: in <code>{{ r.mcp_usage.input_tokens }}</code> ·
+          out <code>{{ r.mcp_usage.output_tokens }}</code> ·
+          cache_read <code>{{ r.mcp_usage.cache_read_input_tokens }}</code> ·
+          cache_create <code>{{ r.mcp_usage.cache_creation_input_tokens }}</code> ·
+          latency <code>{{ r.mcp_latency_ms }} ms</code>
+        </p>
+      </div>
+    </div>
+
+    <h3>Judge verdicts</h3>
+    {% if r.contradicted %}
+    <div class="judge-block" style="border-left: 3px solid #6e40c9; background: #1a0d2a;">
+      <strong>⚠ Swap contradiction — TIE assigned</strong>
+      <div class="reason" style="color: var(--fg);">
+        Both judge positions picked the same SIDE (left/right) regardless of which arm was placed there →
+        the judge has position bias, not a real preference. The verdict is forced to TIE.
+      </div>
+    </div>
+    {% endif %}
+    <div class="judge-block">
+      <strong>Position 1</strong> — LEFT=vanilla, RIGHT=mcp ·
+      winner: <code>{{ r.judge_pos1.winner }}</code>
+      → <span class="badge win-{{ r.judge_pos1.winner_arm }}">{{ r.judge_pos1.winner_arm | upper }}</span>
+      <div class="reason">{{ r.judge_pos1.reasoning }}</div>
+    </div>
+    <div class="judge-block">
+      <strong>Position 2</strong> — LEFT=mcp, RIGHT=vanilla ·
+      winner: <code>{{ r.judge_pos2.winner }}</code>
+      → <span class="badge win-{{ r.judge_pos2.winner_arm }}">{{ r.judge_pos2.winner_arm | upper }}</span>
+      <div class="reason">{{ r.judge_pos2.reasoning }}</div>
+    </div>
+  </div>
+</details>
+{% endfor %}
+
+<footer>
+  Dataset sha256: <code>{{ dataset_hash }}</code> ·
+  generated: <code>{{ generated_at }}</code> ·
+  total wall time: <code>{{ wall_time_s }}s</code><br>
+  pricing assumptions (USD per 1M tokens): input ${{ pricing.input }}, output ${{ pricing.output }},
+  cache_read ${{ pricing.cache_read }}, cache_creation ${{ pricing.cache_creation }} —
+  if these are stale, costs shown above are an estimate, not a billing fact.
+</footer>
+
+<script>
+  const winRateData = {{ chart_data.win_rate | tojson }};
+  const tokenData = {{ chart_data.tokens | tojson }};
+
+  new Chart(document.getElementById("winRateChart"), {
+    type: "bar",
+    data: {
+      labels: winRateData.labels,
+      datasets: [{
+        label: "Count",
+        data: winRateData.values,
+        backgroundColor: ["#3fb950", "#f85149", "#d29922"],
+      }],
+    },
+    options: {
+      indexAxis: "y",
+      plugins: { title: { display: true, text: "Pairwise verdicts (after swap)", color: "#e6edf3" }, legend: { display: false } },
+      scales: {
+        x: { ticks: { color: "#8b949e", precision: 0 }, grid: { color: "#30363d" } },
+        y: { ticks: { color: "#e6edf3" }, grid: { display: false } },
+      },
+    },
+  });
+
+  new Chart(document.getElementById("tokenChart"), {
+    type: "bar",
+    data: {
+      labels: tokenData.labels,
+      datasets: [
+        { label: "input", data: tokenData.input, backgroundColor: "#58a6ff" },
+        { label: "output", data: tokenData.output, backgroundColor: "#3fb950" },
+        { label: "cache_read", data: tokenData.cache_read, backgroundColor: "#d29922" },
+        { label: "cache_creation", data: tokenData.cache_creation, backgroundColor: "#6e40c9" },
+      ],
+    },
+    options: {
+      plugins: { title: { display: true, text: "Average tokens per query (stacked)", color: "#e6edf3" }, legend: { labels: { color: "#e6edf3" } } },
+      scales: {
+        x: { stacked: true, ticks: { color: "#e6edf3" }, grid: { color: "#30363d" } },
+        y: { stacked: true, ticks: { color: "#8b949e" }, grid: { color: "#30363d" } },
+      },
+    },
+  });
+</script>
+
+</body>
+</html>

--- a/evals/templates/report.html.j2
+++ b/evals/templates/report.html.j2
@@ -3,7 +3,10 @@
 <head>
 <meta charset="utf-8">
 <title>Agents-Core MCP vs Vanilla — {{ date }}</title>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+  integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4"
+  crossorigin="anonymous"></script>
 <style>
   :root {
     --bg: #0b0d12; --card: #131722; --fg: #e6edf3; --muted: #8b949e;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 evals = [
     "datasets>=3.0",
     "pytest>=8.0",
-    "jinja2>=3.1",
+    "jinja2>=3.1.6",
     "openai>=1.40",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
 evals = [
     "datasets>=3.0",
     "pytest>=8.0",
+    "jinja2>=3.1",
+    "openai>=1.40",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ evals = [
     "pytest>=8.0",
     "jinja2>=3.1.6",
     "openai>=1.40",
+    "anthropic>=0.40",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -75,9 +75,13 @@ _bench_local_proxy_url() {
     # Print "scheme://host:port" (no trailing slash, no path) if either
     # OPENAI_BASE_URL or ANTHROPIC_BASE_URL points at a local proxy
     # (localhost / 127.0.0.1). Empty output otherwise.
+    #
+    # The hostname is anchored with a `:` / `/` / end-of-string boundary so
+    # values like `https://localhost.example.com/v1` are NOT misclassified
+    # as a local proxy.
     local url
     for url in "${OPENAI_BASE_URL:-}" "${ANTHROPIC_BASE_URL:-}"; do
-        if [[ "$url" =~ ^(https?://(localhost|127\.0\.0\.1)(:[0-9]+)?) ]]; then
+        if [[ "$url" =~ ^(https?://(localhost|127\.0\.0\.1)(:[0-9]+)?)(/|$) ]]; then
             echo "${BASH_REMATCH[1]}"
             return 0
         fi
@@ -129,6 +133,26 @@ _bench_check_extras() {
     echo -e "${DIM}→ eval extras: ok${NC}"
 }
 
+_bench_models_have_id() {
+    # Structured JSON check: does `data[].id` of the response contain $1?
+    # Avoids the false negatives that `grep "\"id\":\"$model\""` produced on
+    # pretty-printed or reordered JSON output. Echoes "yes" or "no" so
+    # callers can branch without subshell exit-status pitfalls.
+    local target="$1"
+    "$PYTHON_BIN" -c '
+import json, sys
+target = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("no")
+    sys.exit(0)
+items = data.get("data", []) if isinstance(data, dict) else data
+found = any(isinstance(item, dict) and item.get("id") == target for item in (items or []))
+print("yes" if found else "no")
+' "$target" 2>/dev/null || echo "no"
+}
+
 _bench_check_model() {
     local model="$1" connect_hint="$2" models_json
     # Only meaningful when going through a local proxy. Endpoint is derived
@@ -139,7 +163,7 @@ _bench_check_model() {
         echo -e "${RED}❌ Failed to query ${origin}/v1/models.${NC}"
         exit 1
     }
-    if ! echo "$models_json" | grep -qF "\"id\":\"$model\""; then
+    if [ "$(echo "$models_json" | _bench_models_have_id "$model")" != "yes" ]; then
         echo -e "${RED}❌ Model '$model' is not available at ${origin}.${NC}"
         echo "   Hint: connect '${connect_hint}' in your local proxy's settings,"
         echo -e "   or list available models: ${BLUE}curl -s ${origin}/v1/models | python3 -m json.tool${NC}"
@@ -157,8 +181,13 @@ _bench_check_judge_model() {
     local origin; origin="$(_bench_local_proxy_url)"
     [ -z "$origin" ] && return 0
     local models_json
-    models_json=$(curl -sS --max-time 3 "${origin}/v1/models" 2>/dev/null) || return 0
-    if ! echo "$models_json" | grep -qF "\"id\":\"$JUDGE_MODEL\""; then
+    # Fail fast on curl errors — silently returning 0 hid judge preflight
+    # failures and deferred them to runtime. Match `_bench_check_model`.
+    models_json=$(curl -sS --max-time 3 "${origin}/v1/models" 2>/dev/null) || {
+        echo -e "${RED}❌ Failed to query ${origin}/v1/models (judge preflight).${NC}"
+        exit 1
+    }
+    if [ "$(echo "$models_json" | _bench_models_have_id "$JUDGE_MODEL")" != "yes" ]; then
         echo -e "${RED}❌ JUDGE_MODEL='$JUDGE_MODEL' is not available at ${origin}.${NC}"
         echo "   Connect it via your local proxy's settings,"
         echo -e "   or pick a different judge by editing ${BLUE}JUDGE_PROVIDER${NC} / ${BLUE}JUDGE_MODEL${NC} in ${BLUE}.env${NC}."

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -27,14 +27,29 @@ _bench_load_env() {
 }
 
 _bench_resolve_python() {
+    # Matches the fallback chain used by scripts/eval.sh and scripts/run_tests.sh:
+    # prefer a local venv, then the preferred pyenv version, then any non-system
+    # pyenv version so machines without exactly 3.12.4 do not fail unexpectedly.
     if [ -d "$REPO_ROOT/.venv" ]; then
         PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
     elif [ -d "$REPO_ROOT/venv" ]; then
         PYTHON_BIN="$REPO_ROOT/venv/bin/python"
-    elif command -v pyenv >/dev/null 2>&1 && [ -f "$HOME/.pyenv/versions/3.12.4/bin/python" ]; then
-        PYTHON_BIN="$HOME/.pyenv/versions/3.12.4/bin/python"
+    elif command -v pyenv >/dev/null 2>&1; then
+        if [ -f "$HOME/.pyenv/versions/3.12.4/bin/python" ]; then
+            PYTHON_BIN="$HOME/.pyenv/versions/3.12.4/bin/python"
+        else
+            local available_version
+            available_version="$(pyenv versions --bare | grep -v '^system$' | head -n 1 || echo '')"
+            if [ -n "$available_version" ] && [ -f "$HOME/.pyenv/versions/$available_version/bin/python" ]; then
+                PYTHON_BIN="$HOME/.pyenv/versions/$available_version/bin/python"
+            else
+                echo -e "${RED}❌ No pyenv Python versions found (excluding system).${NC}"
+                echo "Install one: pyenv install 3.12.4"
+                exit 1
+            fi
+        fi
     else
-        echo -e "${RED}❌ No Python venv found.${NC}"
+        echo -e "${RED}❌ No Python venv found and pyenv not available.${NC}"
         exit 1
     fi
     echo -e "${DIM}→ python: $PYTHON_BIN${NC}"
@@ -130,9 +145,16 @@ _bench_run() {
 
 _bench_open_report() {
     local out_path="$1"; shift
+    # Honour CLI overrides: a user-supplied --out FILE or --out=FILE replaces
+    # the default path passed in by the caller. Without this, custom outputs
+    # are never opened.
+    local expect_out=""
     for arg in "$@"; do
         case "$arg" in
             --dry-run|--dry_run) echo -e "${YELLOW}→ --dry-run: no report to open${NC}"; return 0 ;;
+            --out=*) out_path="${arg#--out=}" ;;
+            --out) expect_out=1 ;;
+            *) if [ -n "$expect_out" ]; then out_path="$arg"; expect_out=""; fi ;;
         esac
     done
     if [ -f "$out_path" ]; then

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -71,18 +71,39 @@ _bench_print_endpoints() {
     echo -e "${DIM}→ JUDGE: ${JUDGE_PROVIDER:-(arm provider)} / ${JUDGE_MODEL:-(provider default)}${NC}"
 }
 
+_bench_match_local_origin() {
+    # If $1 is an `http(s)://(localhost|127.0.0.1)[:port]…` URL, print the
+    # `scheme://host[:port]` prefix. Empty output otherwise. The hostname is
+    # anchored with `:` / `/` / end-of-string so `localhost.example.com` is
+    # NOT misclassified as a local proxy.
+    local url="${1:-}"
+    if [[ "$url" =~ ^(https?://(localhost|127\.0\.0\.1)(:[0-9]+)?)(/|$) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    fi
+}
+
+_bench_local_proxy_url_for() {
+    # Provider-specific lookup. Reads the matching `*_BASE_URL` from .env so
+    # split-proxy setups (e.g. OpenAI on one local port, Anthropic on another)
+    # do not collapse onto whichever was listed first.
+    case "${1:-}" in
+        openai)    _bench_match_local_origin "${OPENAI_BASE_URL:-}" ;;
+        anthropic) _bench_match_local_origin "${ANTHROPIC_BASE_URL:-}" ;;
+        *)         _bench_local_proxy_url ;;
+    esac
+}
+
 _bench_local_proxy_url() {
-    # Print "scheme://host:port" (no trailing slash, no path) if either
-    # OPENAI_BASE_URL or ANTHROPIC_BASE_URL points at a local proxy
-    # (localhost / 127.0.0.1). Empty output otherwise.
-    #
-    # The hostname is anchored with a `:` / `/` / end-of-string boundary so
-    # values like `https://localhost.example.com/v1` are NOT misclassified
-    # as a local proxy.
+    # Print the first local origin found among OPENAI_BASE_URL /
+    # ANTHROPIC_BASE_URL. Used when no provider hint is available (e.g.
+    # `_bench_probe_endpoint` only needs to know whether SOMETHING points at
+    # a local proxy). Prefer `_bench_local_proxy_url_for <provider>` when
+    # the caller knows which side of the bench it is checking.
     local url
     for url in "${OPENAI_BASE_URL:-}" "${ANTHROPIC_BASE_URL:-}"; do
-        if [[ "$url" =~ ^(https?://(localhost|127\.0\.0\.1)(:[0-9]+)?)(/|$) ]]; then
-            echo "${BASH_REMATCH[1]}"
+        local origin; origin="$(_bench_match_local_origin "$url")"
+        if [ -n "$origin" ]; then
+            echo "$origin"
             return 0
         fi
     done
@@ -154,10 +175,19 @@ print("yes" if found else "no")
 }
 
 _bench_check_model() {
-    local model="$1" connect_hint="$2" models_json
+    local model="$1" connect_hint="$2" arm_provider="${3:-}" models_json
     # Only meaningful when going through a local proxy. Endpoint is derived
-    # from .env *_BASE_URL — there is no hardcoded host here.
-    local origin; origin="$(_bench_local_proxy_url)"
+    # from .env *_BASE_URL — there is no hardcoded host here. When the caller
+    # passes the arm provider, we look up THAT provider's BASE_URL so a
+    # split-proxy setup (OpenAI on one local port, Anthropic on another)
+    # queries the right side. Falls back to "first local match" otherwise
+    # for backwards compatibility with older bench scripts.
+    local origin
+    if [ -n "$arm_provider" ]; then
+        origin="$(_bench_local_proxy_url_for "$arm_provider")"
+    else
+        origin="$(_bench_local_proxy_url)"
+    fi
     [ -z "$origin" ] && return 0
     models_json=$(curl -sS --max-time 3 "${origin}/v1/models" 2>/dev/null) || {
         echo -e "${RED}❌ Failed to query ${origin}/v1/models.${NC}"
@@ -178,7 +208,15 @@ _bench_check_judge_model() {
         echo -e "${DIM}→ JUDGE_MODEL not set in .env — runner will use arm provider's default judge${NC}"
         return 0
     fi
-    local origin; origin="$(_bench_local_proxy_url)"
+    # JUDGE_PROVIDER (from .env) tells us which *_BASE_URL the judge uses;
+    # this matters when arm and judge live on different local proxies.
+    # Falls back to the first-local-match helper if JUDGE_PROVIDER is unset.
+    local origin
+    if [ -n "${JUDGE_PROVIDER:-}" ]; then
+        origin="$(_bench_local_proxy_url_for "$JUDGE_PROVIDER")"
+    else
+        origin="$(_bench_local_proxy_url)"
+    fi
     [ -z "$origin" ] && return 0
     local models_json
     # Fail fast on curl errors — silently returning 0 hid judge preflight

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Shared bench helpers. Source from bench_*.sh scripts. Not directly runnable.
+#
+# Functions exposed (all start with _bench_):
+#   _bench_load_env             — load .env (sources it, exports all KEY=VAL)
+#   _bench_resolve_python       — find Python (.venv / venv / pyenv)
+#   _bench_print_endpoints      — echo current OPENAI_BASE_URL, ANTHROPIC_BASE_URL, JUDGE
+#   _bench_probe_endpoint       — TCP probe :8317 if a base_url points to localhost
+#   _bench_check_extras <mods…> — verify Python modules are importable
+#   _bench_check_model <id> <hint> — verify model is present at /v1/models
+#   _bench_check_judge_model    — same for the JUDGE_MODEL env var
+#   _bench_warn_if_gemini_judge — soft-warn if JUDGE_MODEL is a Gemini alias
+#   _bench_run <label> <args…>  — invoke the Python runner with args
+#   _bench_open_report <path> <orig args…> — auto-open HTML unless --dry-run
+
+# Colours expected to be defined by the caller. Fallback if not.
+: "${GREEN:=\033[0;32m}"; : "${YELLOW:=\033[1;33m}"; : "${RED:=\033[0;31m}"
+: "${BLUE:=\033[0;34m}"; : "${DIM:=\033[2m}"; : "${NC:=\033[0m}"
+
+_bench_load_env() {
+    if [ -f "$REPO_ROOT/.env" ]; then
+        set -a
+        # shellcheck disable=SC1091
+        . "$REPO_ROOT/.env"
+        set +a
+    fi
+}
+
+_bench_resolve_python() {
+    if [ -d "$REPO_ROOT/.venv" ]; then
+        PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
+    elif [ -d "$REPO_ROOT/venv" ]; then
+        PYTHON_BIN="$REPO_ROOT/venv/bin/python"
+    elif command -v pyenv >/dev/null 2>&1 && [ -f "$HOME/.pyenv/versions/3.12.4/bin/python" ]; then
+        PYTHON_BIN="$HOME/.pyenv/versions/3.12.4/bin/python"
+    else
+        echo -e "${RED}❌ No Python venv found.${NC}"
+        exit 1
+    fi
+    echo -e "${DIM}→ python: $PYTHON_BIN${NC}"
+}
+
+_bench_print_endpoints() {
+    echo -e "${DIM}→ OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1 (default)}${NC}"
+    echo -e "${DIM}→ ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com (default)}${NC}"
+    echo -e "${DIM}→ GEMINI_BASE_URL: ${GEMINI_BASE_URL:-(unset — Gemini arms route via OPENAI_BASE_URL when proxied)}${NC}"
+    echo -e "${DIM}→ JUDGE: ${JUDGE_PROVIDER:-(arm provider)} / ${JUDGE_MODEL:-(provider default)}${NC}"
+}
+
+_bench_probe_endpoint() {
+    # Only probe if any base_url targets a local proxy on :8317.
+    if [[ "${OPENAI_BASE_URL:-}" == *localhost:8317* ]] || [[ "${ANTHROPIC_BASE_URL:-}" == *localhost:8317* ]]; then
+        if ! (echo > /dev/tcp/localhost/8317) 2>/dev/null; then
+            echo -e "${RED}❌ Configured endpoint not reachable on localhost:8317.${NC}"
+            echo "   Start your local proxy, or change *_BASE_URL in .env to a direct provider endpoint."
+            exit 1
+        fi
+        echo -e "${DIM}→ Local proxy: reachable on :8317${NC}"
+    fi
+}
+
+_bench_check_extras() {
+    local MISSING=""
+    for mod in "$@"; do
+        "$PYTHON_BIN" -c "import $mod" >/dev/null 2>&1 || MISSING="$MISSING $mod"
+    done
+    if [ -n "$MISSING" ]; then
+        echo -e "${RED}❌ Missing Python packages:${NC}$MISSING"
+        echo -e "   Install: ${BLUE}$PYTHON_BIN -m pip install -e '.[evals]'${NC}"
+        exit 1
+    fi
+    echo -e "${DIM}→ eval extras: ok${NC}"
+}
+
+_bench_check_model() {
+    local model="$1" connect_hint="$2" models_json
+    # Only meaningful when going through a local proxy at :8317.
+    if [[ "${OPENAI_BASE_URL:-}" != *localhost:8317* ]] && [[ "${ANTHROPIC_BASE_URL:-}" != *localhost:8317* ]]; then
+        return 0
+    fi
+    models_json=$(curl -sS --max-time 3 http://localhost:8317/v1/models 2>/dev/null) || {
+        echo -e "${RED}❌ Failed to query /v1/models on the configured endpoint.${NC}"
+        exit 1
+    }
+    if ! echo "$models_json" | grep -qF "\"id\":\"$model\""; then
+        echo -e "${RED}❌ Model '$model' is not available at the configured endpoint.${NC}"
+        echo "   Hint: connect '${connect_hint}' in your local proxy's settings,"
+        echo -e "   or list available models: ${BLUE}curl -s http://localhost:8317/v1/models | python3 -m json.tool${NC}"
+        exit 1
+    fi
+    echo -e "${DIM}→ Endpoint: '$model' available (arm)${NC}"
+}
+
+_bench_check_judge_model() {
+    # Read JUDGE_MODEL from env. If unset, runner uses provider default — skip check.
+    if [ -z "${JUDGE_MODEL:-}" ]; then
+        echo -e "${DIM}→ JUDGE_MODEL not set in .env — runner will use arm provider's default judge${NC}"
+        return 0
+    fi
+    if [[ "${OPENAI_BASE_URL:-}" != *localhost:8317* ]] && [[ "${ANTHROPIC_BASE_URL:-}" != *localhost:8317* ]]; then
+        return 0
+    fi
+    local models_json
+    models_json=$(curl -sS --max-time 3 http://localhost:8317/v1/models 2>/dev/null) || return 0
+    if ! echo "$models_json" | grep -qF "\"id\":\"$JUDGE_MODEL\""; then
+        echo -e "${RED}❌ JUDGE_MODEL='$JUDGE_MODEL' is not available at the configured endpoint.${NC}"
+        echo "   Connect it via your local proxy's settings,"
+        echo -e "   or pick a different judge: ${BLUE}./scripts/set_judge.sh <preset>${NC}"
+        exit 1
+    fi
+    echo -e "${DIM}→ Endpoint: '$JUDGE_MODEL' available (judge)${NC}"
+}
+
+_bench_warn_if_gemini_judge() {
+    if [[ "${JUDGE_MODEL:-}" == gemini-* ]]; then
+        echo -e "${YELLOW}⚠  JUDGE_MODEL='$JUDGE_MODEL' — Gemini-as-judge is unreliable via OpenAI-compat layers (malformed function call / schema ignored).${NC}"
+        echo -e "   ${YELLOW}Recommended: ./scripts/set_judge.sh claude  (or any non-Gemini)${NC}"
+    fi
+}
+
+_bench_run() {
+    local label="$1"; shift
+    echo ""
+    echo -e "${GREEN}▶ Bench: MCP vs vanilla on $label${NC}"
+    echo "================================================"
+    echo -e "${DIM}args: $*${NC}"
+    echo ""
+    "$PYTHON_BIN" -m evals.runners.run_mcp_vs_vanilla "$@"
+}
+
+_bench_open_report() {
+    local out_path="$1"; shift
+    for arg in "$@"; do
+        case "$arg" in
+            --dry-run|--dry_run) echo -e "${YELLOW}→ --dry-run: no report to open${NC}"; return 0 ;;
+        esac
+    done
+    if [ -f "$out_path" ]; then
+        echo -e "${GREEN}✓ Report:${NC} $out_path"
+        if command -v open >/dev/null 2>&1; then
+            open "$out_path"
+        elif command -v xdg-open >/dev/null 2>&1; then
+            xdg-open "$out_path" >/dev/null 2>&1 &
+        fi
+    fi
+}

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # Shared bench helpers. Source from bench_*.sh scripts. Not directly runnable.
 #
+# All proxy endpoint values come from .env (OPENAI_BASE_URL / ANTHROPIC_BASE_URL).
+# This file derives the local-proxy URL by parsing those env vars — there is no
+# hardcoded host:port in the script. If neither base URL points at a localhost /
+# 127.0.0.1 address, the proxy-specific preflight checks no-op.
+#
 # Functions exposed (all start with _bench_):
 #   _bench_load_env             — load .env (sources it, exports all KEY=VAL)
 #   _bench_resolve_python       — find Python (.venv / venv / pyenv)
+#   _bench_local_proxy_url      — print the local proxy origin (scheme://host:port) derived from *_BASE_URL, empty if none
 #   _bench_print_endpoints      — echo current OPENAI_BASE_URL, ANTHROPIC_BASE_URL, JUDGE
-#   _bench_probe_endpoint       — TCP probe :8317 if a base_url points to localhost
+#   _bench_probe_endpoint       — TCP probe the local proxy when a base_url points there
 #   _bench_check_extras <mods…> — verify Python modules are importable
 #   _bench_check_model <id> <hint> — verify model is present at /v1/models
 #   _bench_check_judge_model    — same for the JUDGE_MODEL env var
@@ -65,16 +71,49 @@ _bench_print_endpoints() {
     echo -e "${DIM}→ JUDGE: ${JUDGE_PROVIDER:-(arm provider)} / ${JUDGE_MODEL:-(provider default)}${NC}"
 }
 
-_bench_probe_endpoint() {
-    # Only probe if any base_url targets a local proxy on :8317.
-    if [[ "${OPENAI_BASE_URL:-}" == *localhost:8317* ]] || [[ "${ANTHROPIC_BASE_URL:-}" == *localhost:8317* ]]; then
-        if ! (echo > /dev/tcp/localhost/8317) 2>/dev/null; then
-            echo -e "${RED}❌ Configured endpoint not reachable on localhost:8317.${NC}"
-            echo "   Start your local proxy, or change *_BASE_URL in .env to a direct provider endpoint."
-            exit 1
+_bench_local_proxy_url() {
+    # Print "scheme://host:port" (no trailing slash, no path) if either
+    # OPENAI_BASE_URL or ANTHROPIC_BASE_URL points at a local proxy
+    # (localhost / 127.0.0.1). Empty output otherwise.
+    local url
+    for url in "${OPENAI_BASE_URL:-}" "${ANTHROPIC_BASE_URL:-}"; do
+        if [[ "$url" =~ ^(https?://(localhost|127\.0\.0\.1)(:[0-9]+)?) ]]; then
+            echo "${BASH_REMATCH[1]}"
+            return 0
         fi
-        echo -e "${DIM}→ Local proxy: reachable on :8317${NC}"
+    done
+}
+
+_bench_local_proxy_host_port() {
+    # "host:port" form, used for bash's /dev/tcp probe.
+    local origin; origin="$(_bench_local_proxy_url)"
+    [ -z "$origin" ] && return 0
+    # Strip scheme.
+    echo "${origin#*://}"
+}
+
+_bench_probe_endpoint() {
+    # Only probe if any *_BASE_URL targets a local proxy. The host:port is
+    # whatever the user put in .env — there is no hardcoded value here.
+    local origin; origin="$(_bench_local_proxy_url)"
+    [ -z "$origin" ] && return 0
+    local hp; hp="$(_bench_local_proxy_host_port)"
+    local host="${hp%:*}"
+    local port="${hp##*:}"
+    # If the URL had no explicit port, `hp` equals `host` and `port` ends up
+    # the same — fall back to the scheme default so the probe is meaningful.
+    if [ "$host" = "$port" ]; then
+        case "$origin" in
+            https://*) port=443 ;;
+            *) port=80 ;;
+        esac
     fi
+    if ! (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; then
+        echo -e "${RED}❌ Configured endpoint not reachable on ${host}:${port}.${NC}"
+        echo "   Start your local proxy, or change *_BASE_URL in .env to a direct provider endpoint."
+        exit 1
+    fi
+    echo -e "${DIM}→ Local proxy: reachable on ${host}:${port}${NC}"
 }
 
 _bench_check_extras() {
@@ -92,18 +131,18 @@ _bench_check_extras() {
 
 _bench_check_model() {
     local model="$1" connect_hint="$2" models_json
-    # Only meaningful when going through a local proxy at :8317.
-    if [[ "${OPENAI_BASE_URL:-}" != *localhost:8317* ]] && [[ "${ANTHROPIC_BASE_URL:-}" != *localhost:8317* ]]; then
-        return 0
-    fi
-    models_json=$(curl -sS --max-time 3 http://localhost:8317/v1/models 2>/dev/null) || {
-        echo -e "${RED}❌ Failed to query /v1/models on the configured endpoint.${NC}"
+    # Only meaningful when going through a local proxy. Endpoint is derived
+    # from .env *_BASE_URL — there is no hardcoded host here.
+    local origin; origin="$(_bench_local_proxy_url)"
+    [ -z "$origin" ] && return 0
+    models_json=$(curl -sS --max-time 3 "${origin}/v1/models" 2>/dev/null) || {
+        echo -e "${RED}❌ Failed to query ${origin}/v1/models.${NC}"
         exit 1
     }
     if ! echo "$models_json" | grep -qF "\"id\":\"$model\""; then
-        echo -e "${RED}❌ Model '$model' is not available at the configured endpoint.${NC}"
+        echo -e "${RED}❌ Model '$model' is not available at ${origin}.${NC}"
         echo "   Hint: connect '${connect_hint}' in your local proxy's settings,"
-        echo -e "   or list available models: ${BLUE}curl -s http://localhost:8317/v1/models | python3 -m json.tool${NC}"
+        echo -e "   or list available models: ${BLUE}curl -s ${origin}/v1/models | python3 -m json.tool${NC}"
         exit 1
     fi
     echo -e "${DIM}→ Endpoint: '$model' available (arm)${NC}"
@@ -115,13 +154,12 @@ _bench_check_judge_model() {
         echo -e "${DIM}→ JUDGE_MODEL not set in .env — runner will use arm provider's default judge${NC}"
         return 0
     fi
-    if [[ "${OPENAI_BASE_URL:-}" != *localhost:8317* ]] && [[ "${ANTHROPIC_BASE_URL:-}" != *localhost:8317* ]]; then
-        return 0
-    fi
+    local origin; origin="$(_bench_local_proxy_url)"
+    [ -z "$origin" ] && return 0
     local models_json
-    models_json=$(curl -sS --max-time 3 http://localhost:8317/v1/models 2>/dev/null) || return 0
+    models_json=$(curl -sS --max-time 3 "${origin}/v1/models" 2>/dev/null) || return 0
     if ! echo "$models_json" | grep -qF "\"id\":\"$JUDGE_MODEL\""; then
-        echo -e "${RED}❌ JUDGE_MODEL='$JUDGE_MODEL' is not available at the configured endpoint.${NC}"
+        echo -e "${RED}❌ JUDGE_MODEL='$JUDGE_MODEL' is not available at ${origin}.${NC}"
         echo "   Connect it via your local proxy's settings,"
         echo -e "   or pick a different judge by editing ${BLUE}JUDGE_PROVIDER${NC} / ${BLUE}JUDGE_MODEL${NC} in ${BLUE}.env${NC}."
         exit 1

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -117,28 +117,50 @@ _bench_local_proxy_host_port() {
     echo "${origin#*://}"
 }
 
-_bench_probe_endpoint() {
-    # Only probe if any *_BASE_URL targets a local proxy. The host:port is
-    # whatever the user put in .env — there is no hardcoded value here.
-    local origin; origin="$(_bench_local_proxy_url)"
+_bench_origin_to_host_port() {
+    # Translate "scheme://host[:port]" to "host port" — explicit port falls
+    # back to 80 / 443 by scheme when omitted. Echoes the pair separated by
+    # a space so the caller can `read host port`.
+    local origin="${1:-}"
     [ -z "$origin" ] && return 0
-    local hp; hp="$(_bench_local_proxy_host_port)"
+    local hp="${origin#*://}"
     local host="${hp%:*}"
     local port="${hp##*:}"
-    # If the URL had no explicit port, `hp` equals `host` and `port` ends up
-    # the same — fall back to the scheme default so the probe is meaningful.
     if [ "$host" = "$port" ]; then
         case "$origin" in
             https://*) port=443 ;;
             *) port=80 ;;
         esac
     fi
-    if ! (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; then
-        echo -e "${RED}❌ Configured endpoint not reachable on ${host}:${port}.${NC}"
-        echo "   Start your local proxy, or change *_BASE_URL in .env to a direct provider endpoint."
-        exit 1
-    fi
-    echo -e "${DIM}→ Local proxy: reachable on ${host}:${port}${NC}"
+    echo "$host $port"
+}
+
+_bench_probe_endpoint() {
+    # Probe EVERY distinct local origin among OPENAI_BASE_URL /
+    # ANTHROPIC_BASE_URL. In split-proxy setups (different ports), both
+    # need to be reachable; checking only the first matched origin would
+    # mask the other side being down.
+    local origins=()
+    local seen=""
+    local url origin
+    for url in "${OPENAI_BASE_URL:-}" "${ANTHROPIC_BASE_URL:-}"; do
+        origin="$(_bench_match_local_origin "$url")"
+        if [ -n "$origin" ] && [[ "$seen" != *"|${origin}|"* ]]; then
+            seen="${seen}|${origin}|"
+            origins+=("$origin")
+        fi
+    done
+    [ "${#origins[@]}" -eq 0 ] && return 0
+    for origin in "${origins[@]}"; do
+        local host port
+        read -r host port < <(_bench_origin_to_host_port "$origin")
+        if ! (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; then
+            echo -e "${RED}❌ Configured endpoint not reachable on ${host}:${port}.${NC}"
+            echo "   Start your local proxy, or change *_BASE_URL in .env to a direct provider endpoint."
+            exit 1
+        fi
+        echo -e "${DIM}→ Local proxy: reachable on ${host}:${port}${NC}"
+    done
 }
 
 _bench_check_extras() {

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -30,18 +30,21 @@ _bench_resolve_python() {
     # Matches the fallback chain used by scripts/eval.sh and scripts/run_tests.sh:
     # prefer a local venv, then the preferred pyenv version, then any non-system
     # pyenv version so machines without exactly 3.12.4 do not fail unexpectedly.
+    # `pyenv root` is honored so a custom PYENV_ROOT (e.g. /opt/pyenv) works.
     if [ -d "$REPO_ROOT/.venv" ]; then
         PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
     elif [ -d "$REPO_ROOT/venv" ]; then
         PYTHON_BIN="$REPO_ROOT/venv/bin/python"
     elif command -v pyenv >/dev/null 2>&1; then
-        if [ -f "$HOME/.pyenv/versions/3.12.4/bin/python" ]; then
-            PYTHON_BIN="$HOME/.pyenv/versions/3.12.4/bin/python"
+        local pyenv_root
+        pyenv_root="$(pyenv root 2>/dev/null || echo "$HOME/.pyenv")"
+        if [ -f "$pyenv_root/versions/3.12.4/bin/python" ]; then
+            PYTHON_BIN="$pyenv_root/versions/3.12.4/bin/python"
         else
             local available_version
             available_version="$(pyenv versions --bare | grep -v '^system$' | head -n 1 || echo '')"
-            if [ -n "$available_version" ] && [ -f "$HOME/.pyenv/versions/$available_version/bin/python" ]; then
-                PYTHON_BIN="$HOME/.pyenv/versions/$available_version/bin/python"
+            if [ -n "$available_version" ] && [ -f "$pyenv_root/versions/$available_version/bin/python" ]; then
+                PYTHON_BIN="$pyenv_root/versions/$available_version/bin/python"
             else
                 echo -e "${RED}❌ No pyenv Python versions found (excluding system).${NC}"
                 echo "Install one: pyenv install 3.12.4"
@@ -120,7 +123,7 @@ _bench_check_judge_model() {
     if ! echo "$models_json" | grep -qF "\"id\":\"$JUDGE_MODEL\""; then
         echo -e "${RED}❌ JUDGE_MODEL='$JUDGE_MODEL' is not available at the configured endpoint.${NC}"
         echo "   Connect it via your local proxy's settings,"
-        echo -e "   or pick a different judge: ${BLUE}./scripts/set_judge.sh <preset>${NC}"
+        echo -e "   or pick a different judge by editing ${BLUE}JUDGE_PROVIDER${NC} / ${BLUE}JUDGE_MODEL${NC} in ${BLUE}.env${NC}."
         exit 1
     fi
     echo -e "${DIM}→ Endpoint: '$JUDGE_MODEL' available (judge)${NC}"
@@ -129,7 +132,7 @@ _bench_check_judge_model() {
 _bench_warn_if_gemini_judge() {
     if [[ "${JUDGE_MODEL:-}" == gemini-* ]]; then
         echo -e "${YELLOW}⚠  JUDGE_MODEL='$JUDGE_MODEL' — Gemini-as-judge is unreliable via OpenAI-compat layers (malformed function call / schema ignored).${NC}"
-        echo -e "   ${YELLOW}Recommended: ./scripts/set_judge.sh claude  (or any non-Gemini)${NC}"
+        echo -e "   ${YELLOW}Recommended: set ${BLUE}JUDGE_PROVIDER=anthropic${YELLOW} and ${BLUE}JUDGE_MODEL=claude-sonnet-4-6${YELLOW} (or any non-Gemini) in .env.${NC}"
     fi
 }
 

--- a/scripts/_bench_common.sh
+++ b/scripts/_bench_common.sh
@@ -176,6 +176,20 @@ _bench_check_extras() {
     echo -e "${DIM}→ eval extras: ok${NC}"
 }
 
+_bench_required_sdk_modules() {
+    # Echo provider SDK module names required for THIS run, given the arm
+    # provider as $1. Includes the judge provider (from env JUDGE_PROVIDER,
+    # falling back to the arm) when it differs. The provider name maps 1:1
+    # to the SDK module name (`openai`, `anthropic`). No duplicates.
+    local arm="${1:-}"
+    [ -z "$arm" ] && return 0
+    echo "$arm"
+    local judge="${JUDGE_PROVIDER:-$arm}"
+    if [ -n "$judge" ] && [ "$judge" != "$arm" ]; then
+        echo "$judge"
+    fi
+}
+
 _bench_models_have_id() {
     # Structured JSON check: does `data[].id` of the response contain $1?
     # Avoids the false negatives that `grep "\"id\":\"$model\""` produced on

--- a/scripts/bench_gemini_3_1_pro_low.sh
+++ b/scripts/bench_gemini_3_1_pro_low.sh
@@ -32,7 +32,7 @@ _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
 _bench_check_extras datasets jinja2 openai anthropic
-_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 _bench_warn_if_gemini_judge
 

--- a/scripts/bench_gemini_3_1_pro_low.sh
+++ b/scripts/bench_gemini_3_1_pro_low.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ---HELP-BEGIN---
+# Bench MCP vs vanilla on Google Gemini 3.1 Pro (low) (arms).
+#
+# Endpoints, API keys, and judge are all controlled by .env — this script only
+# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+#
+# IMPORTANT: Gemini cannot be the judge — its structured-output via the
+# OpenAI-compat layer is unreliable (malformed_function_call / ignores schema).
+# Ensure .env has JUDGE_PROVIDER != openai/gemini OR JUDGE_MODEL is a Claude/GPT model.
+#
+# Defaults: --provider openai --model gemini-3.1-pro-low --dataset wildbench --n 1
+# ---HELP-END---
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODEL="gemini-3.1-pro-low"
+PROVIDER="openai"
+LABEL="Gemini 3.1 Pro (low)"
+CONNECT_HINT="Gemini"
+OUT_SLUG="gemini"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; DIM='\033[2m'; NC='\033[0m'
+usage() { awk '/^# ---HELP-BEGIN---$/{f=1;next} /^# ---HELP-END---$/{f=0} f{sub(/^# ?/,"");print}' "$0"; }
+case "${1:-}" in -h|--help|help) usage; exit 0 ;; esac
+
+source "$REPO_ROOT/scripts/_bench_common.sh"
+_bench_load_env
+_bench_resolve_python
+_bench_print_endpoints
+_bench_probe_endpoint
+_bench_check_extras datasets jinja2 openai anthropic
+_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_judge_model
+_bench_warn_if_gemini_judge
+
+OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"
+DEFAULT_ARGS=(--provider "$PROVIDER" --model "$MODEL" --dataset wildbench --n 1 --out "$OUT")
+
+_bench_run "$LABEL" "${DEFAULT_ARGS[@]}" "$@"
+_bench_open_report "$OUT" "$@"

--- a/scripts/bench_gemini_3_1_pro_low.sh
+++ b/scripts/bench_gemini_3_1_pro_low.sh
@@ -31,7 +31,7 @@ _bench_load_env
 _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
-_bench_check_extras datasets jinja2 openai anthropic
+_bench_check_extras datasets jinja2 $(_bench_required_sdk_modules "$PROVIDER")
 _bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 _bench_warn_if_gemini_judge

--- a/scripts/bench_gemini_3_1_pro_low.sh
+++ b/scripts/bench_gemini_3_1_pro_low.sh
@@ -3,7 +3,7 @@
 # Bench MCP vs vanilla on Google Gemini 3.1 Pro (low) (arms).
 #
 # Endpoints, API keys, and judge are all controlled by .env — this script only
-# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+# picks the arm model. Switch judge by setting JUDGE_PROVIDER/JUDGE_MODEL in .env.
 #
 # IMPORTANT: Gemini cannot be the judge — its structured-output via the
 # OpenAI-compat layer is unreliable (malformed_function_call / ignores schema).

--- a/scripts/bench_gpt_5_5.sh
+++ b/scripts/bench_gpt_5_5.sh
@@ -28,7 +28,7 @@ _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
 _bench_check_extras datasets jinja2 openai anthropic
-_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 
 OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"

--- a/scripts/bench_gpt_5_5.sh
+++ b/scripts/bench_gpt_5_5.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ---HELP-BEGIN---
+# Bench MCP vs vanilla on OpenAI gpt-5.5 (arms).
+#
+# Endpoints, API keys, and judge are all controlled by .env — this script only
+# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+#
+# Defaults: --provider openai --model gpt-5.5 --dataset wildbench --n 1
+# ---HELP-END---
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODEL="gpt-5.5"
+PROVIDER="openai"
+LABEL="gpt-5.5"
+CONNECT_HINT="ChatGPT (Codex)"
+OUT_SLUG="gpt55"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; DIM='\033[2m'; NC='\033[0m'
+usage() { awk '/^# ---HELP-BEGIN---$/{f=1;next} /^# ---HELP-END---$/{f=0} f{sub(/^# ?/,"");print}' "$0"; }
+case "${1:-}" in -h|--help|help) usage; exit 0 ;; esac
+
+source "$REPO_ROOT/scripts/_bench_common.sh"
+_bench_load_env
+_bench_resolve_python
+_bench_print_endpoints
+_bench_probe_endpoint
+_bench_check_extras datasets jinja2 openai anthropic
+_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_judge_model
+
+OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"
+DEFAULT_ARGS=(--provider "$PROVIDER" --model "$MODEL" --dataset wildbench --n 1 --out "$OUT")
+
+_bench_run "$LABEL" "${DEFAULT_ARGS[@]}" "$@"
+_bench_open_report "$OUT" "$@"

--- a/scripts/bench_gpt_5_5.sh
+++ b/scripts/bench_gpt_5_5.sh
@@ -3,7 +3,7 @@
 # Bench MCP vs vanilla on OpenAI gpt-5.5 (arms).
 #
 # Endpoints, API keys, and judge are all controlled by .env — this script only
-# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+# picks the arm model. Switch judge by setting JUDGE_PROVIDER/JUDGE_MODEL in .env.
 #
 # Defaults: --provider openai --model gpt-5.5 --dataset wildbench --n 1
 # ---HELP-END---

--- a/scripts/bench_gpt_5_5.sh
+++ b/scripts/bench_gpt_5_5.sh
@@ -27,7 +27,7 @@ _bench_load_env
 _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
-_bench_check_extras datasets jinja2 openai anthropic
+_bench_check_extras datasets jinja2 $(_bench_required_sdk_modules "$PROVIDER")
 _bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 

--- a/scripts/bench_opus_4_7.sh
+++ b/scripts/bench_opus_4_7.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ---HELP-BEGIN---
+# Bench MCP vs vanilla on Claude Opus 4.7 (arms).
+#
+# Endpoints, API keys, and judge are all controlled by .env — this script only
+# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+#
+# Defaults: --provider anthropic --model claude-opus-4-7 --dataset wildbench --n 1
+# ---HELP-END---
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODEL="claude-opus-4-7"
+PROVIDER="anthropic"
+LABEL="Opus 4.7"
+CONNECT_HINT="Claude Code"
+OUT_SLUG="opus"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; DIM='\033[2m'; NC='\033[0m'
+usage() { awk '/^# ---HELP-BEGIN---$/{f=1;next} /^# ---HELP-END---$/{f=0} f{sub(/^# ?/,"");print}' "$0"; }
+case "${1:-}" in -h|--help|help) usage; exit 0 ;; esac
+
+source "$REPO_ROOT/scripts/_bench_common.sh"
+_bench_load_env
+_bench_resolve_python
+_bench_print_endpoints
+_bench_probe_endpoint
+_bench_check_extras datasets jinja2 anthropic openai
+_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_judge_model
+
+OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"
+DEFAULT_ARGS=(--provider "$PROVIDER" --model "$MODEL" --dataset wildbench --n 1 --out "$OUT")
+
+_bench_run "$LABEL" "${DEFAULT_ARGS[@]}" "$@"
+_bench_open_report "$OUT" "$@"

--- a/scripts/bench_opus_4_7.sh
+++ b/scripts/bench_opus_4_7.sh
@@ -27,7 +27,8 @@ _bench_load_env
 _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
-_bench_check_extras datasets jinja2 anthropic openai
+# Required SDKs depend on PROVIDER + JUDGE_PROVIDER (.env) — no over-requirement.
+_bench_check_extras datasets jinja2 $(_bench_required_sdk_modules "$PROVIDER")
 _bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 

--- a/scripts/bench_opus_4_7.sh
+++ b/scripts/bench_opus_4_7.sh
@@ -28,7 +28,7 @@ _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
 _bench_check_extras datasets jinja2 anthropic openai
-_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 
 OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"

--- a/scripts/bench_opus_4_7.sh
+++ b/scripts/bench_opus_4_7.sh
@@ -3,7 +3,7 @@
 # Bench MCP vs vanilla on Claude Opus 4.7 (arms).
 #
 # Endpoints, API keys, and judge are all controlled by .env — this script only
-# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+# picks the arm model. Switch judge by setting JUDGE_PROVIDER/JUDGE_MODEL in .env.
 #
 # Defaults: --provider anthropic --model claude-opus-4-7 --dataset wildbench --n 1
 # ---HELP-END---

--- a/scripts/bench_sonnet_4_6.sh
+++ b/scripts/bench_sonnet_4_6.sh
@@ -30,7 +30,7 @@ _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
 _bench_check_extras datasets jinja2 anthropic openai
-_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 
 OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"

--- a/scripts/bench_sonnet_4_6.sh
+++ b/scripts/bench_sonnet_4_6.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# ---HELP-BEGIN---
+# Bench MCP vs vanilla on Claude Sonnet 4.6 (arms).
+#
+# Endpoints, API keys, and judge are all controlled by .env — this script only
+# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+#
+# Defaults: --provider anthropic --model claude-sonnet-4-6 --dataset wildbench --n 1
+# Override anything via CLI:  ./scripts/bench_sonnet_4_6.sh --n 30 --save-json
+# ---HELP-END---
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Single source of model truth for this script.
+MODEL="claude-sonnet-4-6"
+PROVIDER="anthropic"
+LABEL="Sonnet 4.6"
+CONNECT_HINT="Claude Code"
+OUT_SLUG="sonnet"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; DIM='\033[2m'; NC='\033[0m'
+usage() { awk '/^# ---HELP-BEGIN---$/{f=1;next} /^# ---HELP-END---$/{f=0} f{sub(/^# ?/,"");print}' "$0"; }
+case "${1:-}" in -h|--help|help) usage; exit 0 ;; esac
+
+source "$REPO_ROOT/scripts/_bench_common.sh"
+_bench_load_env
+_bench_resolve_python
+_bench_print_endpoints
+_bench_probe_endpoint
+_bench_check_extras datasets jinja2 anthropic openai
+_bench_check_model "$MODEL" "$CONNECT_HINT"
+_bench_check_judge_model
+
+OUT="$REPO_ROOT/evals/reports/$(date +%F)_mcp_vs_vanilla_${OUT_SLUG}.html"
+DEFAULT_ARGS=(--provider "$PROVIDER" --model "$MODEL" --dataset wildbench --n 1 --out "$OUT")
+
+_bench_run "$LABEL" "${DEFAULT_ARGS[@]}" "$@"
+_bench_open_report "$OUT" "$@"

--- a/scripts/bench_sonnet_4_6.sh
+++ b/scripts/bench_sonnet_4_6.sh
@@ -29,7 +29,8 @@ _bench_load_env
 _bench_resolve_python
 _bench_print_endpoints
 _bench_probe_endpoint
-_bench_check_extras datasets jinja2 anthropic openai
+# Required SDKs depend on PROVIDER + JUDGE_PROVIDER (.env) — no over-requirement.
+_bench_check_extras datasets jinja2 $(_bench_required_sdk_modules "$PROVIDER")
 _bench_check_model "$MODEL" "$CONNECT_HINT" "$PROVIDER"
 _bench_check_judge_model
 

--- a/scripts/bench_sonnet_4_6.sh
+++ b/scripts/bench_sonnet_4_6.sh
@@ -3,7 +3,7 @@
 # Bench MCP vs vanilla on Claude Sonnet 4.6 (arms).
 #
 # Endpoints, API keys, and judge are all controlled by .env — this script only
-# picks the arm model. Switch judge via:  ./scripts/set_judge.sh <preset>
+# picks the arm model. Switch judge by setting JUDGE_PROVIDER/JUDGE_MODEL in .env.
 #
 # Defaults: --provider anthropic --model claude-sonnet-4-6 --dataset wildbench --n 1
 # Override anything via CLI:  ./scripts/bench_sonnet_4_6.sh --n 30 --save-json

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -37,18 +37,20 @@ RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-# ---- venv discovery (mirrors scripts/run_tests.sh) ----
+# ---- venv discovery (mirrors scripts/_bench_common.sh::_bench_resolve_python) ----
+# `pyenv root` is honored so a custom PYENV_ROOT (e.g. /opt/pyenv) works.
 if [ -d ".venv" ]; then
     PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
 elif [ -d "venv" ]; then
     PYTHON_BIN="$REPO_ROOT/venv/bin/python"
 elif command -v pyenv &> /dev/null; then
-    if [ -f "$HOME/.pyenv/versions/3.12.4/bin/python" ]; then
-        PYTHON_BIN="$HOME/.pyenv/versions/3.12.4/bin/python"
+    PYENV_ROOT_DIR="$(pyenv root 2>/dev/null || echo "$HOME/.pyenv")"
+    if [ -f "$PYENV_ROOT_DIR/versions/3.12.4/bin/python" ]; then
+        PYTHON_BIN="$PYENV_ROOT_DIR/versions/3.12.4/bin/python"
     else
         AVAILABLE_VERSION="$(pyenv versions --bare | grep -v '^system$' | head -n 1 || echo '')"
-        if [ -n "$AVAILABLE_VERSION" ]; then
-            PYTHON_BIN="$HOME/.pyenv/versions/$AVAILABLE_VERSION/bin/python"
+        if [ -n "$AVAILABLE_VERSION" ] && [ -f "$PYENV_ROOT_DIR/versions/$AVAILABLE_VERSION/bin/python" ]; then
+            PYTHON_BIN="$PYENV_ROOT_DIR/versions/$AVAILABLE_VERSION/bin/python"
         else
             echo -e "${RED}❌ No pyenv Python versions found (excluding system).${NC}"
             echo "Install one: pyenv install 3.12.4"
@@ -166,12 +168,26 @@ case "$cmd" in
         # The thin scripts/bench_*.sh wrappers do this via _bench_load_env; the
         # `eval.sh bench` path needs the same so it doesn't fail preflight
         # purely because .env was not exported into the calling shell.
-        if [ -f "$REPO_ROOT/.env" ]; then
-            set -a
-            # shellcheck disable=SC1091
-            . "$REPO_ROOT/.env"
-            set +a
-        fi
+        # shellcheck disable=SC1091
+        source "$REPO_ROOT/scripts/_bench_common.sh"
+        _bench_load_env
+        # Reuse the bench common preflight so dependency / proxy mistakes fail
+        # at the script edge rather than mid-run with a Python traceback.
+        # Provider-specific model checks need to know --provider, which is
+        # inside "$@" — we parse it out without disturbing the original args.
+        BENCH_PROVIDER="openai"  # matches run_mcp_vs_vanilla.parse_args default
+        prev=""
+        for arg in "$@"; do
+            if [ "$prev" = "--provider" ]; then BENCH_PROVIDER="$arg"; prev=""; continue; fi
+            case "$arg" in
+                --provider=*) BENCH_PROVIDER="${arg#--provider=}" ;;
+                --provider)   prev="--provider" ;;
+            esac
+        done
+        _bench_print_endpoints
+        _bench_probe_endpoint
+        # shellcheck disable=SC2046
+        _bench_check_extras datasets jinja2 $(_bench_required_sdk_modules "$BENCH_PROVIDER")
         echo -e "${GREEN}▶ Benchmarking MCP vs vanilla LLM${NC}"
         echo "================================================"
         "$PYTHON_BIN" -m evals.runners.run_mcp_vs_vanilla "$@"

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -176,18 +176,30 @@ case "$cmd" in
         # Provider-specific model checks need to know --provider, which is
         # inside "$@" — we parse it out without disturbing the original args.
         BENCH_PROVIDER="openai"  # matches run_mcp_vs_vanilla.parse_args default
+        BENCH_MODEL=""
         prev=""
         for arg in "$@"; do
             if [ "$prev" = "--provider" ]; then BENCH_PROVIDER="$arg"; prev=""; continue; fi
+            if [ "$prev" = "--model" ]; then BENCH_MODEL="$arg"; prev=""; continue; fi
             case "$arg" in
                 --provider=*) BENCH_PROVIDER="${arg#--provider=}" ;;
                 --provider)   prev="--provider" ;;
+                --model=*)    BENCH_MODEL="${arg#--model=}" ;;
+                --model)      prev="--model" ;;
             esac
         done
         _bench_print_endpoints
         _bench_probe_endpoint
         # shellcheck disable=SC2046
         _bench_check_extras datasets jinja2 $(_bench_required_sdk_modules "$BENCH_PROVIDER")
+        # When --model is provided AND the configured base_url points at a
+        # local proxy, check the model is registered there. If --model is
+        # omitted, the runner picks the provider's default and we skip the
+        # check (the runner will fail clearly if that default isn't served).
+        if [ -n "$BENCH_MODEL" ]; then
+            _bench_check_model "$BENCH_MODEL" "$BENCH_MODEL" "$BENCH_PROVIDER"
+        fi
+        _bench_check_judge_model
         echo -e "${GREEN}▶ Benchmarking MCP vs vanilla LLM${NC}"
         echo "================================================"
         "$PYTHON_BIN" -m evals.runners.run_mcp_vs_vanilla "$@"

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -13,6 +13,9 @@
 #   validate         Probe the configured HuggingFace datasets (no API).
 #   prepare          Re-sample queries → evals/datasets/_unlabeled.jsonl and refresh batches.
 #   aggregate        Join labeled batches into evals/datasets/routing.jsonl (run after labeling).
+#   bench [args]     Benchmark MCP vs vanilla LLM on N queries; render HTML report.
+#                    Provider via --provider openai (default) | anthropic.
+#                    Passes args through (e.g. --n 10 --dataset wildbench --dry-run).
 #   show [path]      cat the report at <path> (default: evals/reports/baseline.md).
 #   diff <new>       Show unified diff of baseline.md vs <new>.
 #   help             Print this message.
@@ -154,6 +157,13 @@ case "$cmd" in
         echo -e "${GREEN}▶ Aggregating batch labels → routing.jsonl${NC}"
         echo "================================================"
         "$PYTHON_BIN" -m evals.scripts.aggregate_labels "$@"
+        ;;
+
+    bench)
+        require_datasets
+        echo -e "${GREEN}▶ Benchmarking MCP vs vanilla LLM${NC}"
+        echo "================================================"
+        "$PYTHON_BIN" -m evals.runners.run_mcp_vs_vanilla "$@"
         ;;
 
     show)

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -161,6 +161,17 @@ case "$cmd" in
 
     bench)
         require_datasets
+        # Source .env so OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENAI_BASE_URL /
+        # ANTHROPIC_BASE_URL / JUDGE_PROVIDER / JUDGE_MODEL reach the runner.
+        # The thin scripts/bench_*.sh wrappers do this via _bench_load_env; the
+        # `eval.sh bench` path needs the same so it doesn't fail preflight
+        # purely because .env was not exported into the calling shell.
+        if [ -f "$REPO_ROOT/.env" ]; then
+            set -a
+            # shellcheck disable=SC1091
+            . "$REPO_ROOT/.env"
+            set +a
+        fi
         echo -e "${GREEN}▶ Benchmarking MCP vs vanilla LLM${NC}"
         echo "================================================"
         "$PYTHON_BIN" -m evals.runners.run_mcp_vs_vanilla "$@"

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -676,7 +676,10 @@ class TestRunJudgeDocstring:
     def test_run_judge_has_docstring(self):
         from evals.judges.pairwise_judge import run_judge
         doc = run_judge.__doc__
-        assert doc is not None and doc.strip(), "run_judge has no docstring (or one placed after another statement)"
+        # Split per Ruff PT018: distinct assertions give clearer pytest output
+        # — `doc is None` and `doc is "" / whitespace-only` are different bugs.
+        assert doc is not None, "run_judge has no __doc__ (docstring placed after another statement?)"
+        assert doc.strip(), "run_judge.__doc__ is whitespace-only"
         assert "Provider-agnostic" in doc
 
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -668,6 +668,18 @@ class TestPerModelPricing:
         assert p["output"] == 180.00
 
 
+class TestRunJudgeDocstring:
+    """`run_judge.__doc__` must actually be the docstring — a triple-quoted
+    string placed after another statement in the body becomes an unused
+    runtime literal, not `__doc__`, and that broke `help(run_judge)`."""
+
+    def test_run_judge_has_docstring(self):
+        from evals.judges.pairwise_judge import run_judge
+        doc = run_judge.__doc__
+        assert doc is not None and doc.strip(), "run_judge has no docstring (or one placed after another statement)"
+        assert "Provider-agnostic" in doc
+
+
 class TestVerdictValidation:
     """Provider payloads must conform to VERDICT_SCHEMA before being accepted —
     otherwise a malformed response would degrade to a real-looking TIE inside

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -515,7 +515,7 @@ class TestTruncationDetection:
         jc = JudgeCall(winner="tie", reasoning="x", criterion_scores={},
                        usage={"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0})
         verdict = aggregate_with_swap(pos1=jc, pos2=jc, pos1_left_is="vanilla")
-        run = QueryRun(idx=1, query="q", source_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+        run = QueryRun(idx=1, query="q", stream_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
         result = BenchmarkResult(
             config={"provider": "openai", "provider_notes": "", "model": "gpt-4o", "judge_model": "gpt-4o",
                     "seed": 0, "dataset": "wildbench", "commit_sha": "x", "max_tokens": cap,
@@ -804,7 +804,7 @@ class TestPricingSplitBetweenArmAndJudge:
         jc = JudgeCall(winner="tie", reasoning="x", criterion_scores={},
                        usage=usage(1_000_000))
         verdict = aggregate_with_swap(pos1=jc, pos2=jc, pos1_left_is="vanilla")
-        run = QueryRun(idx=1, query="q", source_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+        run = QueryRun(idx=1, query="q", stream_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
         result = BenchmarkResult(
             config={"provider": "openai", "provider_notes": "", "model": "gpt-4o",
                     "judge_provider": "anthropic", "judge_model": "claude-opus-4-7",
@@ -859,6 +859,43 @@ class TestPricingSplitBetweenArmAndJudge:
         )
         assert abs(total - expected) < 1e-4
 
+    def test_total_row_components_consistent_with_total(self):
+        """TOTAL.input + TOTAL.output + TOTAL.cache_read + TOTAL.cache_creation
+        must equal TOTAL.total_usd to 4 decimal places. Regression: components
+        were previously computed by summing already-formatted 4dp strings while
+        total_usd came from raw float, so sub-cent drift could make the visible
+        TOTAL row not add up."""
+        from evals.runners._providers import get_pricing
+
+        arm = get_pricing("gpt-4o")
+        judge = get_pricing("claude-opus-4-7")
+        ctx, _ = self._build_ctx(arm_pricing=arm, judge_pricing=judge)
+        rows = {row["label"]: row for row in ctx["cost_breakdown"]}
+        t = rows["TOTAL"]
+        components = (
+            float(t["input_usd"]) + float(t["output_usd"])
+            + float(t["cache_read_usd"]) + float(t["cache_creation_usd"])
+        )
+        assert abs(components - float(t["total_usd"])) < 1e-4, (
+            f"TOTAL row inconsistent: components={components} vs total={t['total_usd']}"
+        )
+
+
+class TestStreamIdxIsNotSourceIdx:
+    """`source_idx` used to advertise itself as the HuggingFace split row index,
+    but `sample_queries` reads `enumerate` on a shuffled streaming iterator —
+    that's the stream position, not a recoverable provenance pointer. The
+    field was renamed to `stream_idx` to stop misleading downstream readers."""
+
+    def test_queryrun_has_stream_idx_not_source_idx(self):
+        from evals.runners.run_mcp_vs_vanilla import QueryRun
+        fields = {f.name for f in QueryRun.__dataclass_fields__.values()}
+        assert "stream_idx" in fields
+        assert "source_idx" not in fields, (
+            "source_idx is misleading (it's the shuffled-stream position, not the HF row index). "
+            "Use stream_idx so downstream tooling doesn't try to pass it to fetch --idx."
+        )
+
 
 class TestTemplateEscaping:
     """User-supplied query/response text must be HTML-escaped to prevent XSS."""
@@ -886,7 +923,7 @@ class TestTemplateEscaping:
             latency_ms=10,
             mcp_meta={"agent": "x", "tier": "lite", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []},
         )
-        run = QueryRun(idx=1, query=query, source_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+        run = QueryRun(idx=1, query=query, stream_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
 
         result = BenchmarkResult(
             config={

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -897,6 +897,122 @@ class TestStreamIdxIsNotSourceIdx:
         )
 
 
+class TestBuildMcpSystemPromptRoutingFidelity:
+    """The MCP arm must replicate `route_and_load`'s routing path, not bypass
+    it with raw `match_keywords`. Each routing branch (cache hit, keyword
+    override, ambiguous veto, meta-query, cache-miss fallback) must surface
+    via `mcp_meta["routing_path"]` so the report can show how many bench
+    queries reflect real production routing vs. the deterministic fallback."""
+
+    @staticmethod
+    def _patches(*, lookup_cache_result, keyword_veto_result, is_meta, match_keywords_result):
+        """Build a context manager that patches the production routing
+        primitives for build_mcp_system_prompt. The patched _load_and_enrich
+        returns a dummy prompt + empty skill/implant/rule sets so we only
+        observe the routing-decision logic.
+        """
+        import asyncio
+        from unittest.mock import patch, AsyncMock, MagicMock
+
+        # router.lookup_cache returns a RouterDecision-like object or None.
+        cached_decision = None
+        if lookup_cache_result is not None:
+            cached_decision = MagicMock()
+            cached_decision.target_agent = lookup_cache_result
+
+        async def _async_load(agent_name, query, history, *_):
+            return (f"prompt-for-{agent_name}", "ctx-hash", [], [], [], "lite")
+
+        async def _async_lookup(query, ctx):
+            return cached_decision
+
+        fake_router = MagicMock()
+        fake_router.lookup_cache = AsyncMock(side_effect=_async_lookup)
+        fake_router.keyword_veto = MagicMock(return_value=keyword_veto_result)
+        fake_router.match_keywords = MagicMock(return_value=match_keywords_result)
+        return patch.multiple(
+            "evals.runners.run_mcp_vs_vanilla",
+            _get_router=MagicMock(return_value=fake_router),
+            _strip_platform_instructions=MagicMock(side_effect=lambda p: p),
+        ), patch.multiple(
+            "src.server",
+            _load_and_enrich=AsyncMock(side_effect=_async_load),
+            _is_meta_query=MagicMock(return_value=is_meta),
+        )
+
+    def _run(self, **kwargs) -> dict:
+        import asyncio
+        from evals.runners.run_mcp_vs_vanilla import build_mcp_system_prompt
+        patches = self._patches(**kwargs)
+        # ExitStack-like manual entry since _patches returns a tuple
+        ctx0 = patches[0]
+        ctx1 = patches[1]
+        with ctx0, ctx1:
+            _prompt, meta = asyncio.run(build_mcp_system_prompt("any query"))
+        return meta
+
+    def test_cache_hit_no_veto(self):
+        meta = self._run(
+            lookup_cache_result="software_engineer",
+            keyword_veto_result=None,
+            is_meta=False,
+            match_keywords_result=[],
+        )
+        assert meta["agent"] == "software_engineer"
+        assert meta["routing_path"] == "cache_hit"
+
+    def test_cache_hit_keyword_override(self):
+        meta = self._run(
+            lookup_cache_result="software_engineer",
+            keyword_veto_result="lawyer",
+            is_meta=False,
+            match_keywords_result=[],
+        )
+        assert meta["agent"] == "lawyer"
+        assert meta["routing_path"] == "keyword_override_cached"
+
+    def test_cache_hit_ambiguous_veto_falls_back_to_keyword(self):
+        from src.engine.router import KEYWORD_VETO_ROUTE_REQUIRED
+        meta = self._run(
+            lookup_cache_result="software_engineer",
+            keyword_veto_result=KEYWORD_VETO_ROUTE_REQUIRED,
+            is_meta=False,
+            match_keywords_result=[("data_analyst", 3)],
+        )
+        assert meta["agent"] == "data_analyst"
+        assert meta["routing_path"] == "keyword_fallback_after_ambiguous_veto"
+
+    def test_cache_miss_meta_query_picks_universal_agent(self):
+        meta = self._run(
+            lookup_cache_result=None,
+            keyword_veto_result=None,
+            is_meta=True,
+            match_keywords_result=[("software_engineer", 5)],  # ignored — meta wins
+        )
+        assert meta["agent"] == "universal_agent"
+        assert meta["routing_path"] == "meta_query"
+
+    def test_cache_miss_non_meta_uses_keyword_fallback(self):
+        meta = self._run(
+            lookup_cache_result=None,
+            keyword_veto_result=None,
+            is_meta=False,
+            match_keywords_result=[("debate_moderator", 2)],
+        )
+        assert meta["agent"] == "debate_moderator"
+        assert meta["routing_path"] == "keyword_fallback"
+
+    def test_cache_miss_no_keyword_hits_falls_back_to_universal_agent(self):
+        meta = self._run(
+            lookup_cache_result=None,
+            keyword_veto_result=None,
+            is_meta=False,
+            match_keywords_result=[],
+        )
+        assert meta["agent"] == "universal_agent"
+        assert meta["routing_path"] == "keyword_fallback"
+
+
 class TestTemplateEscaping:
     """User-supplied query/response text must be HTML-escaped to prevent XSS."""
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -464,7 +464,13 @@ class TestTruncationDetection:
         )
         from evals.judges.pairwise_judge import aggregate_with_swap
 
-        zero_usage = lambda out: {"input_tokens": 100, "output_tokens": out, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        def zero_usage(out: int) -> dict[str, int]:
+            return {
+                "input_tokens": 100,
+                "output_tokens": out,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            }
         van = TrialResult(arm="vanilla", response_text="x", usage=zero_usage(vanilla_out), latency_ms=10)
         mcp = TrialResult(arm="mcp", response_text="y", usage=zero_usage(mcp_out), latency_ms=10,
                           mcp_meta={"agent": "u", "tier": "lite", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []})
@@ -476,7 +482,8 @@ class TestTruncationDetection:
             config={"provider": "openai", "provider_notes": "", "model": "gpt-4o", "judge_model": "gpt-4o",
                     "seed": 0, "dataset": "wildbench", "commit_sha": "x", "max_tokens": cap,
                     "judge_max_tokens": 4096, "concurrency": 1},
-            runs=[run], dataset_hash="h", wall_time_s=0.0, pricing=PRICING["openai"],
+            runs=[run], dataset_hash="h", wall_time_s=0.0,
+            arm_pricing=PRICING["openai"], judge_pricing=PRICING["openai"],
         )
         return build_template_context(result)
 
@@ -552,6 +559,159 @@ class TestPerModelPricing:
         assert p["input"] >= 5.0
         assert p["output"] >= 25.0
 
+    def test_longest_alias_match_wins_for_overlapping_prefixes(self):
+        """A dated snapshot of a more-specific alias must not match the shorter
+        alias first. Regression: insertion-order iteration let `gpt-5.5-pro-…`
+        match `gpt-5.5-` and pick up the cheaper non-Pro rate."""
+        from evals.runners._providers import get_pricing
+
+        p = get_pricing("gpt-5.5-pro-2026-01-01")
+        # Must resolve to gpt-5.5-pro, not gpt-5.5.
+        assert p["input"] == 30.00
+        assert p["output"] == 180.00
+
+
+class TestVerdictValidation:
+    """Provider payloads must conform to VERDICT_SCHEMA before being accepted —
+    otherwise a malformed response would degrade to a real-looking TIE inside
+    aggregate_with_swap, silently skewing benchmark numbers."""
+
+    @staticmethod
+    def _scores() -> dict[str, int]:
+        return {k: 3 for k in (
+            "left_helpfulness", "left_correctness", "left_depth",
+            "left_structure", "left_intent_fit",
+            "right_helpfulness", "right_correctness", "right_depth",
+            "right_structure", "right_intent_fit",
+        )}
+
+    def test_accepts_well_formed_payload(self):
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+
+        winner, reasoning, scores = _validate_verdict_payload({
+            "winner": "left",
+            "reasoning": "left is more direct.",
+            "criterion_scores": self._scores(),
+        })
+        assert winner == "left"
+        assert reasoning == "left is more direct."
+        assert scores == self._scores()
+
+    def test_rejects_invalid_winner(self):
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+        import pytest
+
+        with pytest.raises(RuntimeError, match="invalid winner"):
+            _validate_verdict_payload({
+                "winner": "banana",
+                "reasoning": "x",
+                "criterion_scores": self._scores(),
+            })
+
+    def test_rejects_missing_reasoning(self):
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+        import pytest
+
+        with pytest.raises(RuntimeError, match="reasoning"):
+            _validate_verdict_payload({
+                "winner": "left",
+                "criterion_scores": self._scores(),
+            })
+
+    def test_rejects_incomplete_criterion_scores(self):
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+        import pytest
+
+        with pytest.raises(RuntimeError, match="criterion_scores"):
+            _validate_verdict_payload({
+                "winner": "left",
+                "reasoning": "x",
+                "criterion_scores": {"left_helpfulness": 3},
+            })
+
+
+class TestPricingSplitBetweenArmAndJudge:
+    """Cross-provider / different-model judge runs must bill arm tokens and
+    judge tokens against their respective per-1M rates. Regression: a single
+    `pricing` field was reused for both, mis-reporting judge spend whenever
+    the judge model differed from the arm model."""
+
+    def _build_ctx(self, *, arm_pricing: dict[str, float], judge_pricing: dict[str, float]):
+        from evals.runners._providers import PRICING
+        from evals.runners.run_mcp_vs_vanilla import (
+            BenchmarkResult, QueryRun, TrialResult, build_template_context,
+        )
+        from evals.judges.pairwise_judge import aggregate_with_swap, JudgeCall
+
+        def usage(out: int, *, cache_create: int = 0) -> dict[str, int]:
+            return {
+                "input_tokens": 1_000_000,
+                "output_tokens": out,
+                "cache_creation_input_tokens": cache_create,
+                "cache_read_input_tokens": 0,
+            }
+
+        van = TrialResult(arm="vanilla", response_text="x", usage=usage(0), latency_ms=10)
+        mcp = TrialResult(arm="mcp", response_text="y", usage=usage(0, cache_create=1_000_000), latency_ms=10,
+                          mcp_meta={"agent": "u", "tier": "lite", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []})
+        jc = JudgeCall(winner="tie", reasoning="x", criterion_scores={},
+                       usage=usage(1_000_000))
+        verdict = aggregate_with_swap(pos1=jc, pos2=jc, pos1_left_is="vanilla")
+        run = QueryRun(idx=1, query="q", source_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+        result = BenchmarkResult(
+            config={"provider": "openai", "provider_notes": "", "model": "gpt-4o",
+                    "judge_provider": "anthropic", "judge_model": "claude-opus-4-7",
+                    "seed": 0, "dataset": "wildbench", "commit_sha": "x", "max_tokens": 2048,
+                    "judge_max_tokens": 4096, "concurrency": 1},
+            runs=[run], dataset_hash="h", wall_time_s=0.0,
+            arm_pricing=arm_pricing, judge_pricing=judge_pricing,
+        )
+        return build_template_context(result), PRICING
+
+    def test_judge_row_uses_judge_pricing_not_arm_pricing(self):
+        # Arm: gpt-4o ($2.50 / $10.00). Judge: claude-opus-4-7 ($5.00 / $25.00).
+        # The judge ran twice (positional swap), so judge usage doubles.
+        from evals.runners._providers import get_pricing
+
+        arm = get_pricing("gpt-4o")
+        judge = get_pricing("claude-opus-4-7")
+        ctx, _ = self._build_ctx(arm_pricing=arm, judge_pricing=judge)
+        rows = {row["label"]: row for row in ctx["cost_breakdown"]}
+        # Judge row's output billing: 2M output tokens × $25/1M = $50.0000.
+        # If arm pricing leaked in here, the result would be $20.0000.
+        assert rows["Judge (×2 swap)"]["output_usd"] == "50.0000"
+        # Vanilla row: 1M input tokens at arm $2.50/1M.
+        assert rows["Vanilla (arm)"]["input_usd"] == "2.5000"
+
+    def test_cache_creation_column_present_in_every_row(self):
+        from evals.runners._providers import get_pricing
+
+        arm = get_pricing("claude-sonnet-4-6")
+        ctx, _ = self._build_ctx(arm_pricing=arm, judge_pricing=arm)
+        for row in ctx["cost_breakdown"]:
+            assert "cache_creation_tokens" in row
+            assert "cache_creation_usd" in row
+        rows = {row["label"]: row for row in ctx["cost_breakdown"]}
+        # MCP row sourced 1M cache_creation tokens; at sonnet $3.75/1M → $3.7500.
+        assert rows["MCP (arm)"]["cache_creation_usd"] == "3.7500"
+
+    def test_total_row_sums_dollars_from_per_role_rows(self):
+        """TOTAL must aggregate the per-role-priced row dollars, not re-cost
+        the summed tokens at a single arbitrary rate."""
+        from evals.runners._providers import get_pricing
+
+        arm = get_pricing("gpt-4o")
+        judge = get_pricing("claude-opus-4-7")
+        ctx, _ = self._build_ctx(arm_pricing=arm, judge_pricing=judge)
+        rows = {row["label"]: row for row in ctx["cost_breakdown"]}
+        total = float(rows["TOTAL"]["total_usd"])
+        expected = (
+            float(rows["Vanilla (arm)"]["total_usd"])
+            + float(rows["MCP (arm)"]["total_usd"])
+            + float(rows["Judge (×2 swap)"]["total_usd"])
+        )
+        assert abs(total - expected) < 1e-4
+
 
 class TestTemplateEscaping:
     """User-supplied query/response text must be HTML-escaped to prevent XSS."""
@@ -595,7 +755,8 @@ class TestTemplateEscaping:
             runs=[run],
             dataset_hash="hash",
             wall_time_s=0.0,
-            pricing=PRICING["openai"],
+            arm_pricing=PRICING["openai"],
+            judge_pricing=PRICING["openai"],
         )
         template_path = REPO_ROOT / "evals" / "templates" / "report.html.j2"
         return render_html(result, template_path)

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -365,7 +365,12 @@ class TestOpenAIMaxCompletionTokensRegression:
         assert "max_completion_tokens" in kwargs and kwargs["max_completion_tokens"] == 700
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
-        assert "reasoning_effort" not in kwargs
+        # gpt-5.x judge: reasoning_effort MUST be "none" so hidden reasoning
+        # tokens don't consume the entire max_completion_tokens budget.
+        assert kwargs.get("reasoning_effort") == "none", (
+            "gpt-5.x judge must pin reasoning_effort='none' — otherwise default 'medium' "
+            "lets hidden reasoning eat max_completion_tokens and message.content is empty"
+        )
         # Critical regression assertion — never go back to tool_calls for the judge.
         assert "tools" not in kwargs, "judge must use response_format, not tools (proxy→Gemini paths drop tool_calls)"
         assert "tool_choice" not in kwargs
@@ -393,6 +398,32 @@ class TestOpenAIMaxCompletionTokensRegression:
 
         with pytest.raises(RuntimeError, match="empty content"):
             call_judge_openai(client, "q", "L", "R", "gpt-5.5", JUDGE_SYSTEM_PROMPT, 100, VERDICT_SCHEMA)
+
+    def test_call_judge_openai_omits_reasoning_effort_for_gpt4o(self):
+        """gpt-4o rejects `reasoning_effort` with HTTP 400. The judge path must
+        only send it for reasoning models — same contract as `complete_openai`."""
+        from unittest.mock import MagicMock
+
+        from evals.runners._providers import call_judge_openai
+        from evals.judges.pairwise_judge import JUDGE_SYSTEM_PROMPT, VERDICT_SCHEMA
+
+        message = MagicMock()
+        message.content = '{"winner": "tie", "reasoning": "x", "criterion_scores": {}}'
+        choice = MagicMock()
+        choice.message = message
+        choice.finish_reason = "stop"
+        response = MagicMock()
+        response.choices = [choice]
+        response.usage = FakeOpenAIUsage(prompt_tokens=30, completion_tokens=15)
+        client = MagicMock()
+        client.chat.completions.create = MagicMock(return_value=response)
+
+        call_judge_openai(client, "q", "L", "R", "gpt-4o", JUDGE_SYSTEM_PROMPT, 500, VERDICT_SCHEMA)
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "reasoning_effort" not in kwargs, (
+            "gpt-4o rejects reasoning_effort — judge must only send it for gpt-5.x/o-series"
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -636,7 +667,9 @@ class TestPricingSplitBetweenArmAndJudge:
     `pricing` field was reused for both, mis-reporting judge spend whenever
     the judge model differed from the arm model."""
 
-    def _build_ctx(self, *, arm_pricing: dict[str, float], judge_pricing: dict[str, float]):
+    def _build_ctx(
+        self, *, arm_pricing: dict[str, float], judge_pricing: dict[str, float],
+    ) -> tuple[dict, dict]:
         from evals.runners._providers import PRICING
         from evals.runners.run_mcp_vs_vanilla import (
             BenchmarkResult, QueryRun, TrialResult, build_template_context,

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -198,6 +198,10 @@ class TestCostSplit:
 
 class TestProviderDispatch:
     def test_openai_provider_resolves(self):
+        # `get_provider("openai")` imports the openai SDK eagerly. Skip the
+        # test cleanly when running outside the `[evals]` extra rather than
+        # erroring on a missing optional dependency.
+        pytest.importorskip("openai")
         from evals.runners._providers import get_provider
 
         p = get_provider("openai")
@@ -207,6 +211,9 @@ class TestProviderDispatch:
         assert "input" in p.pricing and "output" in p.pricing
 
     def test_anthropic_provider_resolves(self):
+        # Same rationale as the openai test — anthropic SDK is also an
+        # `[evals]`-extra dependency.
+        pytest.importorskip("anthropic")
         from evals.runners._providers import get_provider
 
         p = get_provider("anthropic")
@@ -557,6 +564,65 @@ class TestEmptyArmShortCircuit:
         assert "empty" in v.pos1.reasoning.lower()
 
 
+class TestJudgeRetry:
+    """Judge calls must retry on transient API errors — arms already do, and
+    a one-off RateLimitError from the judge should not collapse the whole
+    query into a runtime failure."""
+
+    def test_judge_with_swap_retries_on_transient_error(self):
+        import asyncio
+        from unittest.mock import patch
+
+        from evals.runners.run_mcp_vs_vanilla import judge_with_swap
+        from evals.judges.pairwise_judge import JudgeCall
+
+        # Bypass the retry's SDK-specific exception filter — register our
+        # sentinel as a retryable error type for this test.
+        class _Transient(Exception):
+            pass
+
+        zero_usage = {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        ok_call = JudgeCall(
+            winner="left",
+            reasoning="r",
+            criterion_scores={k: 3 for k in (
+                "left_helpfulness", "left_correctness", "left_depth", "left_structure", "left_intent_fit",
+                "right_helpfulness", "right_correctness", "right_depth", "right_structure", "right_intent_fit",
+            )},
+            usage=dict(zero_usage),
+        )
+
+        calls = {"n": 0}
+
+        def fake_run_judge(**kwargs):
+            calls["n"] += 1
+            # Throw transient once on EACH position so we exercise the retry
+            # path for both pos1 and pos2.
+            if calls["n"] in (1, 3):
+                raise _Transient("simulated rate-limit")
+            return ok_call
+
+        async def _no_sleep(_seconds):
+            return None
+
+        with patch("evals.runners.run_mcp_vs_vanilla._get_retryable", return_value=(_Transient,)), \
+             patch("evals.runners.run_mcp_vs_vanilla.run_judge", side_effect=fake_run_judge), \
+             patch("evals.runners.run_mcp_vs_vanilla.asyncio.sleep", side_effect=_no_sleep):
+            verdict = asyncio.run(judge_with_swap(
+                judge_provider=None,  # not used by the mocked run_judge
+                judge_sync_client=None,
+                query="q",
+                vanilla_text="v",
+                mcp_text="m",
+                judge_model="claude-sonnet-4-6",
+                judge_max_tokens=100,
+            ))
+
+        # Each position retried once (4 total: pos1 fail+ok, pos2 fail+ok).
+        assert calls["n"] == 4
+        assert verdict.final in {"vanilla", "mcp", "tie"}
+
+
 class TestPerModelPricing:
     """Per-model pricing lookup so report $-numbers stay correct regardless
     of which --model is passed."""
@@ -659,6 +725,39 @@ class TestVerdictValidation:
                 "reasoning": "x",
                 "criterion_scores": {"left_helpfulness": 3},
             })
+
+    def test_rejects_non_integer_criterion_score(self):
+        """VERDICT_SCHEMA pins `integer 1..5`; a string score must fail-fast,
+        not bleed into criterion_scores as garbage analytics data."""
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+        import pytest
+
+        bad = self._scores()
+        bad["left_helpfulness"] = "five"  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="non-integer"):
+            _validate_verdict_payload({"winner": "left", "reasoning": "x", "criterion_scores": bad})
+
+    def test_rejects_boolean_score_disguised_as_int(self):
+        """`bool` is a subclass of `int` in Python, so `True` would silently
+        sail through a plain `isinstance(int)` check as 1. The validator must
+        reject it explicitly."""
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+        import pytest
+
+        bad = self._scores()
+        bad["left_helpfulness"] = True  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="non-integer"):
+            _validate_verdict_payload({"winner": "left", "reasoning": "x", "criterion_scores": bad})
+
+    def test_rejects_out_of_range_criterion_score(self):
+        from evals.judges.pairwise_judge import _validate_verdict_payload
+        import pytest
+
+        for bad_value in (0, 6, -1, 100):
+            bad = self._scores()
+            bad["right_correctness"] = bad_value
+            with pytest.raises(RuntimeError, match="out-of-range"):
+                _validate_verdict_payload({"winner": "right", "reasoning": "x", "criterion_scores": bad})
 
 
 class TestPricingSplitBetweenArmAndJudge:

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,618 @@
+"""
+Tests for the MCP-vs-vanilla benchmark harness.
+
+Covers pure-Python logic — no API calls, no HF dataset fetches:
+- swap-aggregation logic (consistency, contradiction, tie handling)
+- token-usage normalisation for both providers (OpenAI, Anthropic)
+- HTML escaping of user-supplied content (XSS-prevention)
+- provider dispatch
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from evals.judges.pairwise_judge import JudgeCall, aggregate_with_swap
+
+
+def _jc(winner: str, *, in_=10, out=20, cc=0, cr=0) -> JudgeCall:
+    return JudgeCall(
+        winner=winner,  # type: ignore[arg-type]
+        reasoning="x",
+        criterion_scores={},
+        usage={"input_tokens": in_, "output_tokens": out, "cache_creation_input_tokens": cc, "cache_read_input_tokens": cr},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# aggregate_with_swap
+# --------------------------------------------------------------------------- #
+
+
+class TestAggregateWithSwap:
+    """pos1: LEFT=vanilla, RIGHT=mcp. pos2 is the swap: LEFT=mcp, RIGHT=vanilla."""
+
+    def test_consistent_mcp_wins(self):
+        v = aggregate_with_swap(pos1=_jc("right"), pos2=_jc("left"), pos1_left_is="vanilla")
+        assert v.final == "mcp"
+        assert v.contradicted is False
+
+    def test_consistent_vanilla_wins(self):
+        v = aggregate_with_swap(pos1=_jc("left"), pos2=_jc("right"), pos1_left_is="vanilla")
+        assert v.final == "vanilla"
+        assert v.contradicted is False
+
+    def test_contradiction_resolves_to_tie(self):
+        v = aggregate_with_swap(pos1=_jc("left"), pos2=_jc("left"), pos1_left_is="vanilla")
+        assert v.final == "tie"
+        assert v.contradicted is True
+
+    def test_both_ties(self):
+        v = aggregate_with_swap(pos1=_jc("tie"), pos2=_jc("tie"), pos1_left_is="vanilla")
+        assert v.final == "tie"
+        assert v.contradicted is False
+
+    def test_one_tie_one_winner_falls_to_winner(self):
+        v = aggregate_with_swap(pos1=_jc("tie"), pos2=_jc("left"), pos1_left_is="vanilla")
+        assert v.final == "mcp"
+        assert v.contradicted is False
+
+    def test_one_winner_one_tie_falls_to_winner(self):
+        v = aggregate_with_swap(pos1=_jc("right"), pos2=_jc("tie"), pos1_left_is="vanilla")
+        assert v.final == "mcp"
+
+    def test_total_usage_is_summed(self):
+        v = aggregate_with_swap(
+            pos1=_jc("left", in_=100, out=50, cc=5, cr=10),
+            pos2=_jc("right", in_=200, out=80, cc=0, cr=30),
+            pos1_left_is="vanilla",
+        )
+        assert v.total_usage["input_tokens"] == 300
+        assert v.total_usage["output_tokens"] == 130
+        assert v.total_usage["cache_creation_input_tokens"] == 5
+        assert v.total_usage["cache_read_input_tokens"] == 40
+
+
+# --------------------------------------------------------------------------- #
+# Token-usage normalisation per provider
+# --------------------------------------------------------------------------- #
+
+
+class FakeAnthropicUsage:
+    def __init__(self, **kwargs):
+        for k in ("input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"):
+            setattr(self, k, kwargs.get(k, 0))
+
+
+class FakeOpenAIPromptDetails:
+    def __init__(self, cached_tokens: int):
+        self.cached_tokens = cached_tokens
+
+
+class FakeOpenAIUsage:
+    def __init__(self, prompt_tokens: int, completion_tokens: int, cached_tokens: int | None = None):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = prompt_tokens + completion_tokens
+        if cached_tokens is not None:
+            self.prompt_tokens_details = FakeOpenAIPromptDetails(cached_tokens)
+
+
+class TestUsageNormalisation:
+    def test_anthropic_extracts_all_fields(self):
+        from evals.runners._providers import normalise_usage_anthropic
+
+        d = normalise_usage_anthropic(
+            FakeAnthropicUsage(input_tokens=500, output_tokens=120, cache_creation_input_tokens=2000, cache_read_input_tokens=1500)
+        )
+        assert d == {
+            "input_tokens": 500,
+            "output_tokens": 120,
+            "cache_creation_input_tokens": 2000,
+            "cache_read_input_tokens": 1500,
+        }
+
+    def test_anthropic_handles_none_cache_fields(self):
+        from evals.runners._providers import normalise_usage_anthropic
+
+        class PartialUsage:
+            input_tokens = 100
+            output_tokens = 50
+            cache_creation_input_tokens = None
+            cache_read_input_tokens = None
+
+        d = normalise_usage_anthropic(PartialUsage())
+        assert d["cache_creation_input_tokens"] == 0
+        assert d["cache_read_input_tokens"] == 0
+
+    def test_openai_without_cache_details(self):
+        from evals.runners._providers import normalise_usage_openai
+
+        d = normalise_usage_openai(FakeOpenAIUsage(prompt_tokens=500, completion_tokens=120))
+        assert d == {
+            "input_tokens": 500,
+            "output_tokens": 120,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+
+    def test_openai_with_cached_tokens(self):
+        """For OpenAI, prompt_tokens is the TOTAL including cached; we subtract cached
+        from input_tokens so the four fields sum cleanly when costed against pricing."""
+        from evals.runners._providers import normalise_usage_openai
+
+        d = normalise_usage_openai(FakeOpenAIUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=600))
+        assert d == {
+            "input_tokens": 400,  # 1000 total - 600 cached
+            "output_tokens": 200,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 600,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Provider dispatch
+# --------------------------------------------------------------------------- #
+
+
+class TestCostSplit:
+    """Verify per-component cost split correctly separates input/output/cache spend."""
+
+    def test_split_uses_correct_prices(self):
+        from evals.runners.run_mcp_vs_vanilla import _cost_split
+
+        usage = {
+            "input_tokens": 1_000_000,
+            "output_tokens": 500_000,
+            "cache_read_input_tokens": 200_000,
+            "cache_creation_input_tokens": 0,
+        }
+        pricing = {"input": 5.0, "output": 30.0, "cache_read": 0.5, "cache_creation": 0.0}
+        split = _cost_split(usage, pricing)
+        assert split["input_usd"] == 5.0   # 1M * $5
+        assert split["output_usd"] == 15.0  # 0.5M * $30
+        assert split["cache_read_usd"] == 0.1  # 0.2M * $0.5
+
+    def test_split_zero_usage(self):
+        from evals.runners.run_mcp_vs_vanilla import _cost_split
+
+        zero = {"input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}
+        split = _cost_split(zero, {"input": 5.0, "output": 30.0, "cache_read": 0.5, "cache_creation": 0.0})
+        assert all(v == 0.0 for v in split.values())
+
+    def test_sum_usages_merges_correctly(self):
+        from evals.runners.run_mcp_vs_vanilla import _sum_usages
+
+        u1 = {"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 10, "cache_creation_input_tokens": 0}
+        u2 = {"input_tokens": 200, "output_tokens": 80, "cache_read_input_tokens": 5, "cache_creation_input_tokens": 3}
+        out = _sum_usages([u1, u2])
+        assert out == {"input_tokens": 300, "output_tokens": 130, "cache_read_input_tokens": 15, "cache_creation_input_tokens": 3}
+
+
+class TestProviderDispatch:
+    def test_openai_provider_resolves(self):
+        from evals.runners._providers import get_provider
+
+        p = get_provider("openai")
+        assert p.name == "openai"
+        assert p.env_key == "OPENAI_API_KEY"
+        assert p.default_model.startswith("gpt-")
+        assert "input" in p.pricing and "output" in p.pricing
+
+    def test_anthropic_provider_resolves(self):
+        from evals.runners._providers import get_provider
+
+        p = get_provider("anthropic")
+        assert p.name == "anthropic"
+        assert p.env_key == "ANTHROPIC_API_KEY"
+        assert p.default_model.startswith("claude-")
+
+    def test_unknown_provider_raises(self):
+        from evals.runners._providers import get_provider
+
+        with pytest.raises(ValueError, match="unknown provider"):
+            get_provider("ollama")
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI API parameter-name regression
+#
+# gpt-5.5 (and other newer OpenAI models) reject `max_tokens` with HTTP 400.
+# These tests pin the forward-compatible `max_completion_tokens` to prevent
+# the bug from recurring on a careless edit.
+# --------------------------------------------------------------------------- #
+
+
+class TestOpenAIMaxCompletionTokensRegression:
+    def _fake_chat_response(self, text: str = "ok"):
+        from unittest.mock import MagicMock
+
+        message = MagicMock()
+        message.content = text
+        message.tool_calls = None
+        choice = MagicMock()
+        choice.message = message
+        choice.finish_reason = "stop"
+        response = MagicMock()
+        response.choices = [choice]
+        response.usage = FakeOpenAIUsage(prompt_tokens=20, completion_tokens=10)
+        return response
+
+    def test_complete_openai_uses_max_completion_tokens(self):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from evals.runners._providers import complete_openai
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=self._fake_chat_response("hi"))
+
+        asyncio.run(complete_openai(client, "gpt-5.5", "hello", None, max_tokens=500))
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "max_completion_tokens" in kwargs
+        assert kwargs["max_completion_tokens"] == 500
+        assert "max_tokens" not in kwargs, "max_tokens is rejected by gpt-5.x — must use max_completion_tokens"
+
+    def test_complete_openai_omits_temperature(self):
+        """gpt-5.x rejects temperature=0; we omit the param so the model uses its default."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from evals.runners._providers import complete_openai
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=self._fake_chat_response("hi"))
+
+        asyncio.run(complete_openai(client, "gpt-5.5", "hello", None, max_tokens=100))
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "temperature" not in kwargs, "temperature must be omitted for gpt-5.x compatibility"
+
+    def test_complete_openai_disables_reasoning_for_gpt5(self):
+        """Without reasoning_effort='none', gpt-5.x reasoning tokens consume
+        the entire max_completion_tokens budget and visible output is empty."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from evals.runners._providers import complete_openai
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=self._fake_chat_response("hi"))
+
+        asyncio.run(complete_openai(client, "gpt-5.5", "hello", None, max_tokens=100))
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs.get("reasoning_effort") == "none", (
+            "reasoning_effort must be 'none' on gpt-5.x or the model burns the token budget on hidden reasoning"
+        )
+
+    def test_complete_openai_no_reasoning_effort_for_gpt4o(self):
+        """gpt-4o is non-reasoning; sending reasoning_effort returns HTTP 400."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from evals.runners._providers import complete_openai
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=self._fake_chat_response("hi"))
+
+        asyncio.run(complete_openai(client, "gpt-4o", "hello", None, max_tokens=100))
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "reasoning_effort" not in kwargs, (
+            "gpt-4o rejects reasoning_effort — must only be sent for gpt-5.x/o-series models"
+        )
+
+    def test_is_reasoning_openai_model_classifier(self):
+        from evals.runners._providers import _is_reasoning_openai_model
+
+        assert _is_reasoning_openai_model("gpt-5.5") is True
+        assert _is_reasoning_openai_model("gpt-5.5-pro") is True
+        assert _is_reasoning_openai_model("gpt-5.4-mini") is True
+        assert _is_reasoning_openai_model("o1-preview") is True
+        assert _is_reasoning_openai_model("o3-mini") is True
+        assert _is_reasoning_openai_model("gpt-4o") is False
+        assert _is_reasoning_openai_model("gpt-4o-2024-11-20") is False
+        assert _is_reasoning_openai_model("gpt-4-turbo") is False
+
+    def test_supports_temperature_anthropic_classifier(self):
+        """Opus 4.7 deprecates temperature; other Claude models accept it."""
+        from evals.runners._providers import _supports_temperature_anthropic
+
+        # Deny — Opus 4.7 returns HTTP 400 on temperature.
+        assert _supports_temperature_anthropic("claude-opus-4-7") is False
+        # Allow — verified via N=30 Sonnet 4.6 bench run.
+        assert _supports_temperature_anthropic("claude-sonnet-4-6") is True
+        assert _supports_temperature_anthropic("claude-sonnet-4-5") is True
+        assert _supports_temperature_anthropic("claude-haiku-4-5") is True
+        assert _supports_temperature_anthropic("claude-opus-4-6") is True
+
+    def test_call_judge_openai_uses_json_schema_not_tools(self):
+        """Judge must use response_format=json_schema (works across proxy→Gemini paths).
+        Tool-calling format does not pass-through some proxies and OpenAI's gpt-5.x
+        also bans tools+reasoning_effort, so json_schema is the universal choice."""
+        from unittest.mock import MagicMock
+
+        from evals.runners._providers import call_judge_openai
+
+        message = MagicMock()
+        message.content = '{"winner": "tie", "reasoning": "x", "criterion_scores": {}}'
+        message.tool_calls = None
+        choice = MagicMock()
+        choice.message = message
+        choice.finish_reason = "stop"
+        response = MagicMock()
+        response.choices = [choice]
+        response.usage = FakeOpenAIUsage(prompt_tokens=30, completion_tokens=15)
+
+        client = MagicMock()
+        client.chat.completions.create = MagicMock(return_value=response)
+
+        from evals.judges.pairwise_judge import JUDGE_SYSTEM_PROMPT, VERDICT_SCHEMA
+
+        payload, _ = call_judge_openai(client, "q", "L", "R", "gpt-5.5", JUDGE_SYSTEM_PROMPT, 700, VERDICT_SCHEMA)
+        assert payload["winner"] == "tie"
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "max_completion_tokens" in kwargs and kwargs["max_completion_tokens"] == 700
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+        assert "reasoning_effort" not in kwargs
+        # Critical regression assertion — never go back to tool_calls for the judge.
+        assert "tools" not in kwargs, "judge must use response_format, not tools (proxy→Gemini paths drop tool_calls)"
+        assert "tool_choice" not in kwargs
+        assert "response_format" in kwargs and kwargs["response_format"]["type"] == "json_schema"
+        # NOTE: `strict` is intentionally NOT set — see _providers.py for the
+        # Gemini-via-OpenAI-compat-proxy compatibility issue with strict nested schemas.
+        assert "strict" not in kwargs["response_format"]["json_schema"]
+
+    def test_call_judge_openai_raises_on_empty_content(self):
+        from unittest.mock import MagicMock
+
+        from evals.runners._providers import call_judge_openai
+        from evals.judges.pairwise_judge import JUDGE_SYSTEM_PROMPT, VERDICT_SCHEMA
+
+        message = MagicMock()
+        message.content = ""
+        choice = MagicMock()
+        choice.message = message
+        choice.finish_reason = "length"
+        response = MagicMock()
+        response.choices = [choice]
+        response.usage = FakeOpenAIUsage(prompt_tokens=10, completion_tokens=0)
+        client = MagicMock()
+        client.chat.completions.create = MagicMock(return_value=response)
+
+        with pytest.raises(RuntimeError, match="empty content"):
+            call_judge_openai(client, "q", "L", "R", "gpt-5.5", JUDGE_SYSTEM_PROMPT, 100, VERDICT_SCHEMA)
+
+
+# --------------------------------------------------------------------------- #
+# Template / XSS escaping
+# --------------------------------------------------------------------------- #
+
+
+class TestPlatformInstructionStripping:
+    """Footer-stripping fix for the BLOCKER: MCP system prompts contain
+    Claude-Code-only protocol directives (Agent/Skills/Implants/Rules footer,
+    route_and_load imperatives) that would otherwise be echoed by the LLM,
+    polluting the bench comparison."""
+
+    def test_strips_append_at_end_footer_instruction(self):
+        from evals.runners.run_mcp_vs_vanilla import _strip_platform_instructions
+
+        prompt = (
+            "You are a helpful agent.\n"
+            "Append at the end (labels in English, values are canonical IDs):\n"
+            "**Agent**: [name] · **Skills**: [skills] · **Implants**: [implants] · **Rules**: [rules]\n"
+            "\nAnswer the user."
+        )
+        out = _strip_platform_instructions(prompt)
+        assert "Append at the end" not in out
+        assert "**Agent**: [name]" not in out
+        assert "BENCH MODE" in out
+
+    def test_strips_route_and_load_imperatives(self):
+        from evals.runners.run_mcp_vs_vanilla import _strip_platform_instructions
+
+        prompt = (
+            "Persona text.\n"
+            "CRITICAL: You MUST call `route_and_load(query)` BEFORE answering ANY user query.\n"
+            "This is a BLOCKING REQUIREMENT — do NOT answer without routing first.\n"
+            "Body of agent prompt continues."
+        )
+        out = _strip_platform_instructions(prompt)
+        assert "route_and_load" not in out
+        assert "BLOCKING REQUIREMENT" not in out
+        assert "Body of agent prompt continues." in out  # non-platform content preserved
+
+    def test_appends_bench_mode_override(self):
+        from evals.runners.run_mcp_vs_vanilla import _strip_platform_instructions
+
+        out = _strip_platform_instructions("Anything.")
+        assert "BENCH MODE" in out
+        assert "Do NOT append any platform metadata footer" in out
+
+    def test_preserves_unrelated_content(self):
+        from evals.runners.run_mcp_vs_vanilla import _strip_platform_instructions
+
+        prompt = "## Role\nYou are a senior engineer.\n## Skills\n- Python\n- Rust\n"
+        out = _strip_platform_instructions(prompt)
+        assert "You are a senior engineer." in out
+        assert "Python" in out
+        assert "Rust" in out
+
+
+class TestTruncationDetection:
+    """Per-query truncation flag fires when output_tokens approach the arm cap.
+    Catches the case where a long-form prompt hits --max-tokens and gets cut
+    mid-sentence — the report shows a ⚠ TRUNCATED badge so the reader knows
+    the comparison is unfair."""
+
+    def _build(self, vanilla_out: int, mcp_out: int, cap: int):
+        from evals.runners._providers import PRICING
+        from evals.runners.run_mcp_vs_vanilla import (
+            BenchmarkResult, QueryRun, TrialResult, build_template_context,
+        )
+        from evals.judges.pairwise_judge import aggregate_with_swap
+
+        zero_usage = lambda out: {"input_tokens": 100, "output_tokens": out, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        van = TrialResult(arm="vanilla", response_text="x", usage=zero_usage(vanilla_out), latency_ms=10)
+        mcp = TrialResult(arm="mcp", response_text="y", usage=zero_usage(mcp_out), latency_ms=10,
+                          mcp_meta={"agent": "u", "tier": "lite", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []})
+        jc = JudgeCall(winner="tie", reasoning="x", criterion_scores={},
+                       usage={"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0})
+        verdict = aggregate_with_swap(pos1=jc, pos2=jc, pos1_left_is="vanilla")
+        run = QueryRun(idx=1, query="q", source_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+        result = BenchmarkResult(
+            config={"provider": "openai", "provider_notes": "", "model": "gpt-4o", "judge_model": "gpt-4o",
+                    "seed": 0, "dataset": "wildbench", "commit_sha": "x", "max_tokens": cap,
+                    "judge_max_tokens": 4096, "concurrency": 1},
+            runs=[run], dataset_hash="h", wall_time_s=0.0, pricing=PRICING["openai"],
+        )
+        return build_template_context(result)
+
+    def test_truncated_when_output_near_cap(self):
+        from evals.judges.pairwise_judge import JudgeCall  # noqa: F401 — used by _build
+
+        ctx = self._build(vanilla_out=2048, mcp_out=2048, cap=2048)
+        assert ctx["per_query"][0]["vanilla_truncated"] is True
+        assert ctx["per_query"][0]["mcp_truncated"] is True
+        assert ctx["summary"]["truncation_count"] == 1
+
+    def test_not_truncated_when_well_under_cap(self):
+        ctx = self._build(vanilla_out=500, mcp_out=800, cap=8192)
+        assert ctx["per_query"][0]["vanilla_truncated"] is False
+        assert ctx["per_query"][0]["mcp_truncated"] is False
+        assert ctx["summary"]["truncation_count"] == 0
+
+    def test_one_arm_truncated_other_not(self):
+        ctx = self._build(vanilla_out=400, mcp_out=8100, cap=8192)
+        assert ctx["per_query"][0]["vanilla_truncated"] is False
+        assert ctx["per_query"][0]["mcp_truncated"] is True
+        assert ctx["summary"]["truncation_count"] == 1
+
+
+class TestEmptyArmShortCircuit:
+    """When either arm returns empty text, the judge can't tell quality
+    from length. We short-circuit to a synthetic TIE without burning judge
+    tokens."""
+
+    def test_synthetic_empty_tie_returns_tie_no_contradiction(self):
+        from evals.runners.run_mcp_vs_vanilla import _synthetic_empty_tie
+
+        v = _synthetic_empty_tie("vanilla arm empty")
+        assert v.final == "tie"
+        assert v.contradicted is False
+        assert v.pos1.winner == "tie"
+        assert v.pos2.winner == "tie"
+        assert v.total_usage["input_tokens"] == 0
+        assert v.total_usage["output_tokens"] == 0
+        assert "empty" in v.pos1.reasoning.lower()
+
+
+class TestPerModelPricing:
+    """Per-model pricing lookup so report $-numbers stay correct regardless
+    of which --model is passed."""
+
+    def test_exact_match(self):
+        from evals.runners._providers import get_pricing
+
+        p = get_pricing("gpt-4o")
+        assert p["input"] == 2.50
+        assert p["output"] == 10.00
+
+    def test_dated_snapshot_falls_back_to_alias(self):
+        from evals.runners._providers import get_pricing
+
+        # gpt-4o-2024-11-20 should match the gpt-4o entry via prefix.
+        p = get_pricing("gpt-4o-2024-11-20")
+        assert p["input"] == 2.50
+
+    def test_anthropic_sonnet(self):
+        from evals.runners._providers import get_pricing
+
+        p = get_pricing("claude-sonnet-4-6")
+        assert p["input"] == 3.00
+        assert p["output"] == 15.00
+
+    def test_unknown_model_returns_conservative_fallback(self):
+        from evals.runners._providers import get_pricing
+
+        p = get_pricing("some-future-mystery-model")
+        # Should be higher than any real model so we never under-report cost.
+        assert p["input"] >= 5.0
+        assert p["output"] >= 25.0
+
+
+class TestTemplateEscaping:
+    """User-supplied query/response text must be HTML-escaped to prevent XSS."""
+
+    def _render(self, query: str, response_text: str) -> str:
+        from evals.runners.run_mcp_vs_vanilla import (
+            BenchmarkResult,
+            QueryRun,
+            TrialResult,
+            render_html,
+        )
+        from evals.runners._providers import PRICING
+        from evals.judges.pairwise_judge import aggregate_with_swap
+
+        jc_left = _jc("left")
+        jc_right = _jc("right")
+        verdict = aggregate_with_swap(pos1=jc_left, pos2=jc_right, pos1_left_is="vanilla")
+
+        usage = {"input_tokens": 1, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        van = TrialResult(arm="vanilla", response_text=response_text, usage=usage, latency_ms=10)
+        mcp = TrialResult(
+            arm="mcp",
+            response_text=response_text,
+            usage=usage,
+            latency_ms=10,
+            mcp_meta={"agent": "x", "tier": "lite", "skills_loaded": [], "implants_loaded": [], "rules_loaded": []},
+        )
+        run = QueryRun(idx=1, query=query, source_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+
+        result = BenchmarkResult(
+            config={
+                "provider": "openai",
+                "provider_notes": "test provider",
+                "model": "m",
+                "judge_model": "m",
+                "seed": 0,
+                "dataset": "d",
+                "commit_sha": "sha",
+                "max_tokens": 1,
+            },
+            runs=[run],
+            dataset_hash="hash",
+            wall_time_s=0.0,
+            pricing=PRICING["openai"],
+        )
+        template_path = REPO_ROOT / "evals" / "templates" / "report.html.j2"
+        return render_html(result, template_path)
+
+    def test_script_tag_in_query_is_escaped(self):
+        pytest.importorskip("jinja2")
+        html = self._render('<script>alert("xss")</script>', "ok")
+        assert "<script>alert" not in html
+        assert "&lt;script&gt;alert" in html
+
+    def test_script_tag_in_response_is_escaped(self):
+        pytest.importorskip("jinja2")
+        html = self._render("benign", '<img src=x onerror="alert(1)">')
+        assert '<img src=x onerror="alert(1)">' not in html
+        assert "&lt;img src=x onerror=" in html
+
+    def test_html_entities_in_query_are_preserved_literally(self):
+        pytest.importorskip("jinja2")
+        html = self._render("Hello & welcome <user>", "ok")
+        assert "Hello &amp; welcome &lt;user&gt;" in html


### PR DESCRIPTION
## Summary

- End-to-end benchmark that measures whether Agents-Core MCP enrichment improves LLM answer quality vs a vanilla (no-system-prompt) baseline.
- Two arms run in parallel per query (vanilla + MCP-enriched with platform footer stripped), then a pairwise LLM-as-judge scores them with positional swap to control position bias.
- Cross-provider judge: arms and judge can use different providers via `JUDGE_PROVIDER` / `JUDGE_MODEL` env (e.g. Gemini arms judged by Claude). All endpoints, API keys, and the judge live in `.env` as the single source of truth.
- Single-file HTML report (Jinja2 + Chart.js via CDN) with overall-winner card, per-query verdicts + judge reasoning, cost breakdown (input/output/cache per arm/judge/total), token overhead, latency, truncation badges, routing agent distribution.
- Robustness: exponential-backoff retries on transient errors, concurrency cap via `asyncio.Semaphore`, lazy `SemanticRouter` singleton, model-conditional API quirks (`reasoning_effort` for gpt-5.x only; temperature dropped for opus-4-7; `response_format=json_schema` for the OpenAI judge to work across OpenAI-compat proxy layers).
- 40 unit tests covering swap aggregation, per-provider usage normalisation, footer stripping, empty-arm TIE, per-model pricing, JSON-schema judge regression, and OpenAI parameter quirks.

## What's added / changed

- `evals/runners/_providers.py` — OpenAI + Anthropic providers, `MODEL_PRICING` table, model-conditional API params, retry-able error detection.
- `evals/runners/run_mcp_vs_vanilla.py` — main async runner, CLI, in-process MCP prompt builder, footer stripping, swap-judge orchestration, HTML rendering.
- `evals/judges/pairwise_judge.py` — `JudgeCall` / `SwapVerdict` types, `aggregate_with_swap`, `run_judge` provider-agnostic dispatch, `VERDICT_SCHEMA`.
- `evals/templates/report.html.j2` — report template (dark theme, summary cards, cost breakdown table, per-query collapsible details).
- `evals/scripts/fetch.py` — added `lmsys-chat-1m` dataset spec.
- `scripts/_bench_common.sh` — shared bash helpers (load env, probe proxy, preflight model, run, open report).
- `scripts/bench_{sonnet_4_6,opus_4_7,gpt_5_5,gemini_3_1_pro_low}.sh` — thin per-model launchers (~25 lines each, single MODEL var at top).
- `scripts/eval.sh` — new `bench` subcommand.
- `pyproject.toml` — added `jinja2` and `openai` to `[evals]` extras.
- `tests/test_bench.py` — 40 unit tests.
- `.gitignore` — broadened patterns for evals reports and Russian docs.

## Test plan

- [ ] `pytest tests/test_bench.py` — 40/40 pass.
- [ ] `./scripts/eval.sh bench --dry-run --n 3` — sample queries, no API calls.
- [ ] `./scripts/bench_sonnet_4_6.sh --n 3 --save-json` — full smoke through a local proxy on :8317.
- [ ] Inspect generated HTML report: overall winner card, per-query verdicts, cost breakdown, no platform footer in MCP responses.
- [ ] Swap a judge via `JUDGE_MODEL=claude-opus-4-7` in `.env` and re-run; verify the report's `cross-provider` badge appears only when judge ≠ arm provider.
- [ ] Verify model preflight fail-fast: pick a model not in `/v1/models` of the local proxy; script exits with helpful message before any tokens are spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new eval surface that calls external LLM APIs and imports production routing (`SemanticRouter`, `src.server`); misconfiguration or API quirks could skew results or incur cost, but changes are isolated under `evals/` with heavy test coverage and no production path changes.
> 
> **Overview**
> Adds an **MCP vs vanilla** quality benchmark: sample HF queries, run **vanilla** (no system prompt) and **MCP-enriched** arms in parallel, score with a **pairwise LLM judge** and **positional swap**, then emit a **single-file HTML report** (optional JSON).
> 
> New pieces include **`evals/runners/run_mcp_vs_vanilla.py`** (async runner, in-process routing via `SemanticRouter` / `_load_and_enrich`, platform-footer stripping, retries, concurrency), **`evals/judges/pairwise_judge.py`** (verdict schema + strict validation + swap aggregation), and **`evals/runners/_providers.py`** (OpenAI/Anthropic completion + judge paths, unified usage, per-model pricing, gpt-5.x / Opus API quirks). **`evals/templates/report.html.j2`** drives KPIs, cost split (arm vs judge), routing-path stats, and per-query details.
> 
> **`eval.sh bench`**, **`scripts/_bench_common.sh`**, and thin **`scripts/bench_*.sh`** launchers add proxy/model preflight from `.env` (`JUDGE_PROVIDER` / `JUDGE_MODEL` for cross-provider judging). **`fetch.py`** gains **`lmsys_chat_1m`**; **`pyproject.toml`** adds `jinja2` / `openai` under `[evals]`; **`tests/test_bench.py`** covers judging, pricing, and regressions. **`.gitignore`** broadens ignored eval reports and `docs/*-ru.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b053253212c1831462794293760b547460f4519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New MCP vs vanilla benchmark: deterministic sampling, positional-swap pairwise judging, HTML report with KPIs/charts/per-query details, optional JSON export, CLI "bench" command, provider-agnostic OpenAI/Anthropic support, unified token-usage/pricing and judge flow, and convenience benchmark entry scripts.

* **Tests**
  * Extensive end-to-end tests for judging, usage/pricing normalization, aggregation/truncation, cost attribution, and safe report rendering.

* **Chores**
  * Updated ignore rules, added templating/API optional deps, and added lmsys/lmsys-chat-1m dataset support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WonderMr/Agents/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->