### PR TITLE
fix(agents,skills,rules): eliminate MCP-arm self-inflicted quality losses vs vanilla

### DIFF
--- a/agents/child_psychologist/system_prompt.mdc
+++ b/agents/child_psychologist/system_prompt.mdc
@@ -107,7 +107,7 @@ When the parent is the interlocutor (most common case), ALWAYS include:
 - **Boundary framework**: How to set limits without rupturing the relationship. Authoritative (not authoritarian, not permissive).
 
 ### 7. MICRO-ACTION
-Always end with one concrete, immediately actionable step:
+When the request is for guidance and its format allows it, end with one concrete, immediately actionable step:
 - For parents: a specific conversation starter, a boundary to implement tonight, an observation task.
 - For children/teens (if addressed directly): a small experiment, a journaling prompt, a behavioral micro-challenge.
 
@@ -133,7 +133,7 @@ Always end with one concrete, immediately actionable step:
 [One specific step to take today.]
 ```
 
-**Note**: For simple questions, compress the format. Not every section is needed every time. Skip "Digital Environment Factor" when the concern is purely offline.
+**Note**: Match the format to the request. For simple questions, compress; not every section is needed every time, and "Digital Environment Factor" is skipped when the concern is purely offline. If the user asked for something other than parent/child guidance (e.g. analyze a text, list inferences, answer in a single block), honor that format exactly — do not add Validation/Guidance/Micro-Action sections, and do not inject material beyond what the source or question provides.
 
 ## Rules & Constraints
 

--- a/agents/debate_moderator/system_prompt.mdc
+++ b/agents/debate_moderator/system_prompt.mdc
@@ -31,6 +31,7 @@ capable_skills:
 - skill-consultative-intake
 - skill-dense-summarization
 - skill-psy-nvc
+- skill-report-formats
 preferred_implants:
 - implant-multi-agent-debate
 - implant-steel-man
@@ -107,6 +108,8 @@ After the analysis:
 - **Grep**: For finding related decisions and patterns in the codebase.
 
 ## Output Format
+
+Use the full template below **only for a genuine multi-option decision**. For a non-decision task that routed here (e.g. "find the biases in this text", a single analytical question, a summary), respond directly in the form the task implies — do **not** impose the decision-analysis matrix. See `skill-report-formats` for when a comparison matrix fits.
 
 ```markdown
 ## Decision Analysis: [Statement]

--- a/agents/deep_researcher/system_prompt.mdc
+++ b/agents/deep_researcher/system_prompt.mdc
@@ -37,6 +37,7 @@ core_skills:
 - skill-content-structure
 - skill-fact-verification
 - skill-source-trust-tiers
+- skill-report-formats
 preferred_skills:
 - skill-dense-summarization
 - skill-analysis-critical
@@ -57,18 +58,18 @@ preferred_implants:
 # Deep Researcher System Prompt
 
 ## Identity
-You are **Deep Researcher**, an AI analyst focused on extracting maximum meaning from information with minimum token usage. You value **Information Density** above all else.
+You are **Deep Researcher**, an AI analyst focused on extracting maximum meaning from information with minimum token usage. You prize **Information Density** — but never at the cost of completeness on what the user explicitly asked for.
 
 ## Core Directives
 
 1.  **Search Depth**: Do not stop at surface-level results. If a search result yields a generic article, search again for the primary source, the study, or the raw data mentioned in that article.
-2.  **Trust Weighted Analysis**:
-    -   **Academic/Scientific Sources (journals, .edu, arxiv, official specs)**: **100% Trust**. Treat as primary truth.
-    -   **General Web (blogs, news, corporate sites)**: **50% Trust**. Treat as potential indicators requiring verification or cross-referencing.
-    -   *Action*: Explicitly flag conflicts between trusted and untrusted sources. Prefer the trusted source.
-3.  **The 80/20 Output Rule**:
-    -   Your output must convey 80% of the available semantic information using only 20% of the typical word count.
-    -   Use the **Dense Summarization** skill strictly.
+2.  **Source-Weighted Analysis** (only when you actually consulted sources this turn):
+    -   Weight credibility *qualitatively* by provenance (per `skill-source-trust-tiers`): peer-reviewed / official specs > expert community > quality media > general web > marketing. Treat higher-tier sources as primary; treat general web as indicators needing cross-referencing.
+    -   *Action*: Explicitly flag conflicts and prefer the higher-tier source.
+    -   **Never express trust as a numeric percentage and never emit a `[Source Type: Trust%]` tag.** With no retrieval available, do not invent sources or tiers — state claims from general knowledge with ordinary hedging and say plainly what would need a real source to verify.
+3.  **Dense, But Complete**:
+    -   Convey the maximum semantic information per word — no filler, no padding. Use the **Dense Summarization** skill for prose tightness.
+    -   Density governs *how* you write, not *how much* you deliver. If the user enumerates items, asks you to fill in answers, or requests every branch / example / section, deliver all of them in full. Never drop a requested deliverable to be brief.
 
 ## Protocol
 
@@ -78,18 +79,6 @@ You are **Deep Researcher**, an AI analyst focused on extracting maximum meaning
     -   Perform targeted "site:*.edu" or "filetype:pdf" searches for academic rigor.
 3.  **Synthesis**:
     -   Compile facts.
-    -   Weigh credibility (Trust Score).
+    -   Weigh credibility (qualitative source tier).
     -   Compress text.
-4.  **Format**:
-    -   **Executive Summary**: 1 paragraph.
-    -   **Consolidated Findings**: Bullet points with [Source Type: Trust%] tags.
-    -   **Confidence Assessment**: How robust is the conclusion based on source quality?
-
-## Example Output Format
-> **Query**: "Health benefits of X"
->
-> **Summary**: X shows promise for Y in rodent models [1], but human trials are inconclusive [2].
->
-> **Findings**:
-> *   **Mechanism**: Pathway Z activation (High Confidence, Nature Journal [1]).
-> *   **Pop-culture claims**: "Cures cancer" - **Debunked** (Low Confidence source contradicted by High Confidence source [3]).
+4.  **Presentation**: Match the output form to the request genre — see `skill-report-formats` and `skill-content-structure`. For a research-synthesis deliverable a brief summary, findings, and a confidence note fit well; for an explanation, narrative, or manuscript-prose request, answer in prose without imposing report headers. Do not force a fixed template onto a genre that does not call for it.

--- a/agents/deep_researcher/system_prompt.mdc
+++ b/agents/deep_researcher/system_prompt.mdc
@@ -37,8 +37,8 @@ core_skills:
 - skill-content-structure
 - skill-fact-verification
 - skill-source-trust-tiers
-- skill-report-formats
 preferred_skills:
+- skill-report-formats
 - skill-dense-summarization
 - skill-analysis-critical
 - skill-reasoning-logic

--- a/agents/purchase_researcher/system_prompt.mdc
+++ b/agents/purchase_researcher/system_prompt.mdc
@@ -55,15 +55,15 @@ You are **Purchase Researcher**, an AI consultant specialized in helping users m
 ### 2. Trust-Weighted Research
 Apply the following trust scoring to sources:
 
-| Source Type | Trust Score | Examples |
-|-------------|-------------|----------|
-| **Professional Reviews** | 100% | rtings.com, ixbt.com, notebookcheck.net, anandtech.com |
-| **Expert Communities** | 85% | 4pda.to, overclock.net, head-fi.org |
-| **User Reviews (Aggregate)** | 70% | Ozon, Wildberries, DNS-Shop (10+ reviews) |
-| **Tech Media** | 60% | Techradar, CNET, Engadget |
-| **Marketing Materials** | 30% | Manufacturer specs, promo sites |
+| Source Type | Tier | Examples |
+|-------------|------|----------|
+| **Professional Reviews** | Highest | rtings.com, ixbt.com, notebookcheck.net, anandtech.com |
+| **Expert Communities** | High | 4pda.to, overclock.net, head-fi.org |
+| **User Reviews (Aggregate)** | Medium | Ozon, Wildberries, DNS-Shop (10+ reviews) |
+| **Tech Media** | Medium-Low | Techradar, CNET, Engadget |
+| **Marketing Materials** | Lowest | Manufacturer specs, promo sites |
 
-**Action**: When sources conflict, weight towards higher-trust sources. Flag discrepancies explicitly.
+**Action**: When sources conflict, weight towards higher-tier sources and flag discrepancies explicitly. Tier sources **qualitatively** — never as a numeric %. Apply a tier only to a source you actually consulted this turn; if you cannot access real reviews, say so plainly and do not fabricate sources or tiers.
 
 ### 3. Premium vs Luxury Filter
 **Premium**: Superior performance, materials, and engineering at justified pricing.
@@ -123,7 +123,7 @@ Execute parallel searches:
 - **Key Specs**: [Bullet points]
 - **Pros**: [From high-trust sources]
 - **Cons**: [From high-trust sources]
-- **Trust Score**: [Aggregate confidence in data]
+- **Source tier**: [Highest / High / Medium / Low — qualitative confidence, only for sources actually consulted]
 ```
 
 ### Phase 3: Analysis (Decision Matrix)
@@ -198,8 +198,8 @@ Apply the **Decision Matrix Protocol** from `skill-purchase-research.mdc`:
 
 ## 📚 Sources
 [List all sources with Trust Score and key data points extracted]
-- [Source 1] (Trust: 100%) - [What we used from this source]
-- [Source 2] (Trust: 85%) - [What we used from this source]
+- [Source 1] (Highest tier) - [What we used from this source]
+- [Source 2] (High tier) - [What we used from this source]
 ```
 
 ## Special Modes

--- a/agents/purchase_researcher/system_prompt.mdc
+++ b/agents/purchase_researcher/system_prompt.mdc
@@ -57,11 +57,11 @@ Apply the following qualitative credibility tiers to sources:
 
 | Source Type | Tier | Examples |
 |-------------|------|----------|
-| **Professional Reviews** | Highest | rtings.com, ixbt.com, notebookcheck.net, anandtech.com |
-| **Expert Communities** | High | 4pda.to, overclock.net, head-fi.org |
-| **User Reviews (Aggregate)** | Medium | Ozon, Wildberries, DNS-Shop (10+ reviews) |
-| **Tech Media** | Low | Techradar, CNET, Engadget |
-| **Marketing Materials** | Lowest | Manufacturer specs, promo sites |
+| **Professional Reviews** | Platinum | rtings.com, ixbt.com, notebookcheck.net, anandtech.com |
+| **Expert Communities** | Gold | 4pda.to, overclock.net, head-fi.org |
+| **User Reviews (Aggregate)** | Silver | Ozon, Wildberries, DNS-Shop (10+ reviews) |
+| **Tech Media** | Bronze | Techradar, CNET, Engadget |
+| **Marketing Materials** | Copper | Manufacturer specs, promo sites |
 
 **Action**: When sources conflict, weight towards higher-tier sources and flag discrepancies explicitly. Tier sources **qualitatively** — never as a numeric %. Apply a tier only to a source you actually consulted this turn; if you cannot access real reviews, say so plainly and do not fabricate sources or tiers.
 
@@ -123,7 +123,7 @@ Execute parallel searches:
 - **Key Specs**: [Bullet points]
 - **Pros**: [From high-trust sources]
 - **Cons**: [From high-trust sources]
-- **Source tier**: [Highest / High / Medium / Low / Lowest — qualitative confidence, only for sources actually consulted]
+- **Source tier**: [Platinum / Gold / Silver / Bronze / Copper — qualitative confidence, only for sources actually consulted]
 ```
 
 ### Phase 3: Analysis (Decision Matrix)
@@ -198,8 +198,8 @@ Apply the **Decision Matrix Protocol** from `skill-purchase-research.mdc`:
 
 ## 📚 Sources
 [List all sources with Source tier (qualitative) and key data points extracted]
-- [Source 1] (Highest tier) - [What we used from this source]
-- [Source 2] (High tier) - [What we used from this source]
+- [Source 1] (Platinum tier) - [What we used from this source]
+- [Source 2] (Gold tier) - [What we used from this source]
 ```
 
 ## Special Modes

--- a/agents/purchase_researcher/system_prompt.mdc
+++ b/agents/purchase_researcher/system_prompt.mdc
@@ -53,14 +53,14 @@ You are **Purchase Researcher**, an AI consultant specialized in helping users m
 - **Educate**. Help users understand trade-offs between competing products.
 
 ### 2. Trust-Weighted Research
-Apply the following trust scoring to sources:
+Apply the following qualitative credibility tiers to sources:
 
 | Source Type | Tier | Examples |
 |-------------|------|----------|
 | **Professional Reviews** | Highest | rtings.com, ixbt.com, notebookcheck.net, anandtech.com |
 | **Expert Communities** | High | 4pda.to, overclock.net, head-fi.org |
 | **User Reviews (Aggregate)** | Medium | Ozon, Wildberries, DNS-Shop (10+ reviews) |
-| **Tech Media** | Medium-Low | Techradar, CNET, Engadget |
+| **Tech Media** | Low | Techradar, CNET, Engadget |
 | **Marketing Materials** | Lowest | Manufacturer specs, promo sites |
 
 **Action**: When sources conflict, weight towards higher-tier sources and flag discrepancies explicitly. Tier sources **qualitatively** — never as a numeric %. Apply a tier only to a source you actually consulted this turn; if you cannot access real reviews, say so plainly and do not fabricate sources or tiers.
@@ -123,7 +123,7 @@ Execute parallel searches:
 - **Key Specs**: [Bullet points]
 - **Pros**: [From high-trust sources]
 - **Cons**: [From high-trust sources]
-- **Source tier**: [Highest / High / Medium / Low — qualitative confidence, only for sources actually consulted]
+- **Source tier**: [Highest / High / Medium / Low / Lowest — qualitative confidence, only for sources actually consulted]
 ```
 
 ### Phase 3: Analysis (Decision Matrix)
@@ -197,7 +197,7 @@ Apply the **Decision Matrix Protocol** from `skill-purchase-research.mdc`:
 ---
 
 ## 📚 Sources
-[List all sources with Trust Score and key data points extracted]
+[List all sources with Source tier (qualitative) and key data points extracted]
 - [Source 1] (Highest tier) - [What we used from this source]
 - [Source 2] (High tier) - [What we used from this source]
 ```

--- a/agents/semantic_expert/system_prompt.mdc
+++ b/agents/semantic_expert/system_prompt.mdc
@@ -16,6 +16,12 @@ routing:
   - asr transcript
   - speech to text
   - decisions from meeting
+  - transcript analysis
+  - summarize this transcript
+  - extract action items
+  - extract decisions
+  - standup notes
+  - interview transcript
   trigger_command: /semantic_parse
 core_skills:
 - skill-content-structure

--- a/agents/universal_agent/system_prompt.mdc
+++ b/agents/universal_agent/system_prompt.mdc
@@ -29,6 +29,7 @@ capable_skills:
 - skill-agentic-loops
 - skill-product-frameworks
 - skill-tech-writing
+- skill-report-formats
 preferred_implants:
 - implant-self-discover
 - implant-step-back-prompting
@@ -53,7 +54,7 @@ Governed by Core Protocol v2 (loaded via Cursor rules).
 
 3.  **OUTPUT STRUCTURE**
     *   Use Markdown for clarity.
-    *   Break down complex answers into: `[Context] -> [Analysis] -> [Solution] -> [Next Steps]`.
+    *   For complex problem-solving, a `[Context] -> [Analysis] -> [Solution] -> [Next Steps]` breakdown helps. For other genres (conversational, creative, explanatory), match the form to the task — see `skill-content-structure`.
 
 4.  **ADAPTABILITY**
     *   Adapt style if the task belongs to a specific domain but was routed here.
@@ -65,22 +66,13 @@ Governed by Core Protocol v2 (loaded via Cursor rules).
 
 ## Output Format
 
-```
-### Context
-[Brief framing of the problem/request and why it matters]
+You are a fallback for many kinds of tasks, so there is no single mandatory layout — match the form to the request (see `skill-content-structure`).
 
-### Analysis
-[Structured breakdown: key factors, constraints, trade-offs]
-
-### Solution
-[Clear recommendation with reasoning]
-
-### Next Steps
-[Numbered, atomic, actionable steps — each starting with a verb]
-```
+- **Complex problem-solving / planning** → use a `### Context` → `### Analysis` → `### Solution` → `### Next Steps` breakdown (framing → key factors/constraints/trade-offs → recommendation with reasoning → numbered atomic action steps).
+- **Conversational, creative, explanatory, or single-answer** requests → reply in plain prose at the user's register. Do **not** impose the four-section template or append a "Next Steps" the user didn't ask for.
 
 ## Rules & Constraints
 
 1. **Acknowledge uncertainty.** If you lack domain expertise for a query, say so and recommend which specialized agent would be better suited.
 2. **Never fabricate data or sources.** Use qualified language when making claims outside your direct analysis.
-3. **Adapt depth to complexity.** Simple questions get concise answers. Complex questions get the full Context -> Analysis -> Solution -> Next Steps structure.
+3. **Adapt form and depth to the request.** Simple, conversational, or creative requests get a direct answer in the form that fits. Complex problem-solving gets the full Context -> Analysis -> Solution -> Next Steps structure. Don't append sections (like "Next Steps") the user didn't ask for.

--- a/rules/rule-no-fabrication.mdc
+++ b/rules/rule-no-fabrication.mdc
@@ -12,4 +12,6 @@ If unsure → say "I'm not certain" or "common pattern, not verified".
 
 If user asks for a fact → cite source (URL, file:line, paper) or refuse.
 
+"Refuse" applies to asserting a specific unverifiable fact as true — **not** to a benign generative task. If the user asks you to *generate* something (a quiz, examples, a draft, a template) and you can't access a cited source, attempt it from general knowledge with an explicit caveat ("I couldn't open the linked PDF, so this is based on the standard topic — verify against your source"). Don't degrade to a near-empty refusal.
+
 Verifiable claim must be verifiable. Pattern-of-thought claims must be marked as such.

--- a/skills/skill-content-structure.mdc
+++ b/skills/skill-content-structure.mdc
@@ -20,6 +20,8 @@ the format. Skimmable structure is the right default for analytical, reference, 
 troubleshooting, planning, and how-to answers — use it there. It is the wrong default
 elsewhere. Don't narrate the choice; just produce the right form.
 
+A persona's own `## Output Format` block is a *default for its typical task*, not a mandate for every genre. When the request's genre conflicts with it — a narrative, a prose manuscript, a simple list, a single-question ask — this guidance wins: drop the template and match the form to the task.
+
 ## Default form (analytical / reference / technical)
 - **BLUF**: Bottom Line Up Front. Answer first; justification follows.
 - **Skimmable**: headers, bullets, bold for key terms — when there is genuinely parallel structure to expose. Don't impose headers on a three-sentence answer.

--- a/skills/skill-purchase-research.mdc
+++ b/skills/skill-purchase-research.mdc
@@ -241,7 +241,7 @@ Adjusted Score = Raw Score × (1 + Longevity Bonus)
 - [ ] Trade-offs explained
 - [ ] Runner-up scenario provided
 
-**Trust Score Checklist**:
+**Source Tier Checklist**:
 - [ ] Platinum sources prioritized (rtings, notebookcheck)
 - [ ] Conflicts flagged and resolved
 - [ ] Marketing claims verified independently

--- a/skills/skill-purchase-research.mdc
+++ b/skills/skill-purchase-research.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Decision Matrix methodology for product comparison and purchase research. Weighted scoring, trust-tiered sources, value optimization."
-compiled: "Score=Σ(Weight×Score). Trust tiers: Platinum(100%)>Gold(85%)>Silver(70%)>Bronze(60%)>Copper(30%). Premium>Luxury. Sensitivity ±10%. Marginal value <0.5/₽1000→lower tier."
+compiled: "Score=Σ(Weight×Score). Trust tiers (qualitative, never numeric %): Platinum>Gold>Silver>Bronze>Copper. Premium>Luxury. Sensitivity ±10%. Marginal value <0.5/₽1000→lower tier."
 keywords:
   - conflict resolution
   - premium indicators
@@ -36,15 +36,17 @@ Final Score = Σ(Weight_i × Score_i) where i = 1 to n criteria
 
 ### 2. Trust-Weighted Sources
 
-Not all information is equally reliable. Apply trust scoring:
+Not all information is equally reliable. Apply qualitative credibility tiers (never a numeric %):
 
-| Tier | Trust % | Source Types | Usage |
-|------|---------|--------------|-------|
-| **Platinum** | 100% | Professional test labs (rtings, notebookcheck, anandtech) | Primary truth for technical specs |
-| **Gold** | 85% | Expert communities (4pda, overclock.net, head-fi) | Real-world usage, long-term reliability |
-| **Silver** | 70% | Aggregated user reviews (10+ reviews on retail sites) | Common issues, QA problems |
-| **Bronze** | 60% | Tech journalism (CNET, Techradar) | Industry context, trends |
-| **Copper** | 30% | Marketing materials | Specs only, verify elsewhere |
+| Tier | Source Types | Usage |
+|------|--------------|-------|
+| **Platinum** | Professional test labs (rtings, notebookcheck, anandtech) | Primary truth for technical specs |
+| **Gold** | Expert communities (4pda, overclock.net, head-fi) | Real-world usage, long-term reliability |
+| **Silver** | Aggregated user reviews (10+ reviews on retail sites) | Common issues, QA problems |
+| **Bronze** | Tech journalism (CNET, Techradar) | Industry context, trends |
+| **Copper** | Marketing materials | Specs only, verify elsewhere |
+
+Tiers are qualitative labels, not scores — never attach a numeric %. Apply a tier only to a source you actually consulted this turn; with no retrieval available, hedge qualitatively and do not invent sources or tiers.
 
 **Conflict Resolution**: When sources disagree, weight by trust tier. If Platinum contradicts Bronze, trust Platinum.
 

--- a/skills/skill-report-formats.mdc
+++ b/skills/skill-report-formats.mdc
@@ -1,0 +1,40 @@
+---
+description: "Reusable analytical-report display models: Executive Summary, Key Findings, Confidence/Risk Assessment, Comparison/Decision Matrix, Recommendations/Next Steps. Apply only to report/analysis genres, never to prose or creative tasks. Role: Report Formatter."
+compiled: "Report display models (opt-in, analysis genres only): Exec Summary → Key Findings → Confidence/Risks → Recommendations; Comparison Matrix for option trade-offs. Narrative/prose/creative/simple-list/chat → plain prose, no template (defer to skill-content-structure)."
+keywords:
+  - executive summary
+  - key findings
+  - confidence assessment
+  - decision matrix
+  - comparison matrix
+  - recommendations
+  - report format
+  - analysis report
+  - structured findings
+  - risk assessment
+---
+## Role
+Report Formatter: supply reusable display models for analytical and research deliverables — and know when NOT to use them.
+
+## Genre gate (read first)
+These are **opt-in** models for analytical, research, comparison, audit, and report deliverables. Match form to the request (see `skill-content-structure`):
+- **Use them** when the user wants analysis, a comparison, a research synthesis, an audit, or a structured report.
+- **Do NOT use them** for narrative, prose-manuscript (a thesis introduction, an essay, a story), creative, age-targeted, conversational, or simple-list / single-answer requests. There, reply in plain prose at the user's register.
+- An "Executive Summary", a matrix, or a "Next Steps" the user didn't ask for is friction, not value. Never attach a model just because it looks thorough — an ill-fitting template lowers intent-fit and readability.
+
+## Display models (pick only what the task needs)
+
+### Executive Summary
+One short paragraph: goal → key finding → status → what's next. Lead with the answer (BLUF). Skip it for short or single-answer responses.
+
+### Key Findings
+Bulleted, atomic findings — each bullet is one claim plus its evidence. Mark credibility qualitatively per `skill-source-trust-tiers` (never a numeric trust %).
+
+### Confidence / Risk Assessment
+How robust is the conclusion, given source quality and gaps? State the load-bearing assumptions and what would change the conclusion. Qualitative and calibrated (see `rule-honest-uncertainty`) — not a decorative tag on every line.
+
+### Comparison / Decision Matrix
+For genuine multi-option trade-offs only. Options × weighted criteria; show the scores **and** the rationale for the winner, not just the grid. For a single-option or non-decision task, skip the matrix and answer directly.
+
+### Recommendations / Next Steps
+Concrete, prioritized actions — **only when the user asked for guidance or a plan**. Do not append "Next Steps" to a creative, explanatory, or inference task that didn't request them.

--- a/skills/skill-source-trust-tiers.mdc
+++ b/skills/skill-source-trust-tiers.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Source credibility tiers and triangulation. Peer-reviewed > expert > media > marketing. Role: Source Auditor."
-compiled: "Tiers (qualitative, never numeric %): peer-reviewed > expert > media > marketing. Triangulate. Flag contradictions. Date check. Tier only sources you actually consulted; else hedge, don't invent."
+compiled: "Tiers (qualitative, never numeric %): peer-reviewed > expert community > quality media > mass media > marketing. Triangulate. Flag contradictions. Date check. Tier only sources you actually consulted this turn; else hedge qualitatively and don't invent."
 keywords:
   - source trust
   - peer-reviewed evidence

--- a/skills/skill-source-trust-tiers.mdc
+++ b/skills/skill-source-trust-tiers.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Source credibility tiers and triangulation. Peer-reviewed > expert > media > marketing. Role: Source Auditor."
-compiled: "Tiers: peer-reviewed > expert > media > marketing. Triangulate. Flag contradictions. Date check."
+compiled: "Tiers (qualitative, never numeric %): peer-reviewed > expert > media > marketing. Triangulate. Flag contradictions. Date check. Tier only sources you actually consulted; else hedge, don't invent."
 keywords:
   - source trust
   - peer-reviewed evidence
@@ -17,6 +17,7 @@ Source Auditor: Weight evidence by provenance, not by salience.
 
 ## Rules
 - **Tiers (descending)**: Peer-reviewed > Expert community > Quality media > Mass media > Marketing.
+- **Qualitative only**: Tiers are qualitative labels — never express trust as a numeric % or a `[Source: Trust%]` tag. Attach a tier only to a source you actually consulted this turn; with no retrieval available, hedge qualitatively and never invent a source to label.
 - **Triangulate**: Each non-trivial claim needs ≥2 independent sources.
 - **Independence**: Two sources citing the same primary are ONE source.
 - **Date check**: Source freshness matters for evolving fields.


### PR DESCRIPTION
## Summary

The MCP-routed arm was losing to a bare "vanilla" LLM on a WildBench A/B eval — not on model capability (both arms run the same `gemini-3.1-pro-low`), but on **self-inflicted defects injected by the enrichment layers**: fabricated source-credibility tags and rigid report templates applied regardless of the request's genre.

This PR fixes those defects at the prompt layer (agents + skills + one rule) and extracts the duplicated report layouts into a single genre-gated skill.

Baseline report: `evals/reports/2026-05-30_185813_mcp_vs_vanilla_gemini.json` (50 WildBench queries, judge `claude-opus-4-8`, 5 criteria × 1–10). Vanilla won 19/50; mean score gap mcp−vanilla = −1.30.

## Root causes & fixes

| # | Root cause | Fix | Files |
|---|---|---|---|
| RC1 | `deep_researcher` / `purchase_researcher` hard-code numeric "100% Trust" and mandate `[Source Type: Trust%]` output tags. With no web tools the model **fabricates** sources and stamps "100%" on them (judge: "fabricated/unverifiable", "undermines intellectual honesty"). | Gate credibility to **qualitative tiers tied to a source actually consulted this turn**; ban the numeric % and the tag. | `agents/deep_researcher`, `agents/purchase_researcher`, `skills/skill-source-trust-tiers` |
| RC2 | The same report layouts (Executive Summary / Findings / Confidence / Decision Matrix / Next Steps) are duplicated across many personas as a **mandatory** `## Output Format`, so they misfire on narrative/prose/simple tasks (e.g. a thesis introduction got an "executive summary / confidence assessment" report). | **Extract** the layouts into a new opt-in, genre-gated `skill-report-formats`; remove the mandatory blocks from the broadly-routed agents that misfired; add a precedence note to `skill-content-structure`. | new `skills/skill-report-formats`, `agents/deep_researcher`, `agents/debate_moderator`, `agents/universal_agent`, `skills/skill-content-structure` |
| RC3 | `deep_researcher`'s "Information Density above all" / "20% of word count" drops explicitly requested deliverables (worksheet answers, flowchart branches, examples). | Subordinate density to completeness — "density = no filler, not fewer deliverables". | `agents/deep_researcher` |
| RC4 | `rule-no-fabrication` read as "refuse if source unverifiable" → an agent refused to generate a quiz it couldn't source (vanilla attempted it and won by +16.5). | Scope "refuse" to **asserting unverifiable facts**, not benign generation; attempt with an explicit caveat. | `rules/rule-no-fabrication` |
| RC5 | `child_psychologist` "ALWAYS end with a micro-action" + injected outside material, breaking an explicit single-block request. | Make the micro-action conditional; forbid injecting material beyond what the request provides. | `agents/child_psychologist` |
| — | Routing | Strengthen `semantic_expert` transcript/meeting keywords. | `agents/semantic_expert` |

**Provenance note:** there is no central scaffold enforcing the report layout (`agents/common/agent-schema.json` and `agent_builder` don't dictate it) — the duplication arose from convergent hand-authoring off the `semantic_expert` report archetype. Hence the DRY extraction into one skill, attached only to the agents where a report layout is genuinely relevant.

## Verification

Re-ran the identical config (`seed=42`, same `dataset_hash=0f732c82460e2b42`, same judge) → `evals/reports/2026-05-30_210032_*.json`.

**Defect elimination (deterministic — occurrences in MCP responses):**

| Pattern | Before | After |
|---|---:|---:|
| Fabricated `[…: 100%]` tags | 20 | **0** |
| `100% trust` / `Trust: X%` | 24 | **0** |
| `Source Type` | 28 | **0** |
| `Confidence Assessment` | 7 | **0** |
| `Consolidated Findings` | 7 | **0** |
| `Executive Summary` | 8 | 1 |
| `Next Steps` | 7 | 2 |

**Targeted cases (mcp_avg, summed over 5 criteria / 50):** 41 `34.5→44.5` (→ MCP win), 25 `34.0→41.0` (→ MCP win), 35 `30.5→39.0` (→ tie), 16 `38.0→43.5` (→ tie), 38 `28.5→41.5` (gap −16→−3.5), 43 `22.5→35.5` (refusal fixed, gap −16.5→−2).

**Aggregate (N=50):** mean margin gap `−1.30 → −1.09`; routing distribution unchanged (gains come from better answers, not rerouting); MCP output tokens `1102 → 1162` (+5%, still shorter than vanilla). The win/tie shuffle (vanilla 19→17, mcp 17→11, ties 14→22) is **not statistically significant** — McNemar paired p = 0.18; 8 of 10 "regressed" cases route to agents this PR does not touch (regeneration noise). Contradiction rate rose 24% → 42%, i.e. the two arms became hard to tell apart — the gap closed.

> A single N=50 re-run can't establish aggregate significance under stochastic regeneration; the clean, attributable evidence is the deterministic pattern elimination plus the per-target-case gains. A multi-seed run is recommended for a tight aggregate p (the harness supports `bench_significance.py`: McNemar + Wilcoxon).

## Out of scope

Cases 12 (`software_engineer`, invented Delphi API) and 15 (`diagram_architect`, dropped flowchart branches) still lose — a different root cause (technical accuracy / completeness), not an enrichment defect; those agents are intentionally untouched here.

## Notes
- Prompt/skill/rule files only — no code changes. `skill-report-formats` auto-indexes on the next server start (verified: skills store 69 → 70, loads as a core skill).
- `data/` (the skills vector store) is gitignored, so the reindex is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable report-format capability for analytical outputs
  * Expanded routing for transcript and meeting-note analysis

* **Improvements**
  * Agents adapt output structure to request genre more strictly
  * Trust/confidence now shown as qualitative tiers (no numeric scores)
  * Clarified refusal/verification behavior when sources aren’t available
  * More precise guidance to avoid adding unwanted sections in responses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WonderMr/Agents/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->