### PR TITLE
feat(evals): per-category scores per answer in MCP-vs-vanilla report

### DIFF
--- a/evals/judges/pairwise_judge.py
+++ b/evals/judges/pairwise_judge.py
@@ -136,6 +136,42 @@ def _arm_total(scores: dict[str, int], side: str) -> float | None:
     return float(sum(scores[k] for k in keys))
 
 
+def per_criterion_breakdown(
+    pos1_scores: dict[str, int] | None,
+    pos2_scores: dict[str, int] | None,
+    *,
+    pos1_left_is: Literal["vanilla", "mcp"] = "vanilla",
+) -> list[dict[str, Any]] | None:
+    """Swap-averaged per-criterion scores for each arm, re-derived from the two
+    judge calls' criterion_scores. One row per criterion, in `_CRITERIA` order:
+
+        {"criterion": "helpfulness", "vanilla": 9.0, "mcp": 7.5, "margin": -1.5}
+
+    Side mapping mirrors `aggregate_with_swap` (for pos1_left_is='vanilla':
+    pos1 right=mcp/left=vanilla, pos2 left=mcp/right=vanilla), so summing a
+    column yields exactly the SwapVerdict `vanilla_avg` / `mcp_avg`. Returns
+    None if either payload is missing any of the 10 keys (legacy/partial
+    verdict, synthetic empty-tie) so callers render 'unscored' rather than
+    half a table.
+    """
+    if not pos1_scores or not pos2_scores:
+        return None
+    pos2_left_is = "mcp" if pos1_left_is == "vanilla" else "vanilla"
+    mcp_side_p1 = "right" if pos1_left_is == "vanilla" else "left"
+    van_side_p1 = "left" if pos1_left_is == "vanilla" else "right"
+    mcp_side_p2 = "right" if pos2_left_is == "vanilla" else "left"
+    van_side_p2 = "left" if pos2_left_is == "vanilla" else "right"
+    rows: list[dict[str, Any]] = []
+    for c in _CRITERIA:
+        try:
+            mcp = (pos1_scores[f"{mcp_side_p1}_{c}"] + pos2_scores[f"{mcp_side_p2}_{c}"]) / 2.0
+            vanilla = (pos1_scores[f"{van_side_p1}_{c}"] + pos2_scores[f"{van_side_p2}_{c}"]) / 2.0
+        except KeyError:
+            return None
+        rows.append({"criterion": c, "vanilla": vanilla, "mcp": mcp, "margin": mcp - vanilla})
+    return rows
+
+
 class JudgeValidationError(RuntimeError):
     """A judge response did not conform to VERDICT_SCHEMA.
 
@@ -266,20 +302,17 @@ def aggregate_with_swap(
     # calls, so averaging the two orders cancels an additive L/R position offset
     # exactly. This recovers signal the holistic-winner contradiction→TIE rule
     # discards. None if either call lacks complete scores (then 'unscored').
-    mcp_side_p1 = "right" if pos1_left_is == "vanilla" else "left"
-    van_side_p1 = "left" if pos1_left_is == "vanilla" else "right"
-    mcp_side_p2 = "right" if pos2_left_is == "vanilla" else "left"
-    van_side_p2 = "left" if pos2_left_is == "vanilla" else "right"
-
-    mcp_p1, mcp_p2 = _arm_total(pos1.criterion_scores, mcp_side_p1), _arm_total(pos2.criterion_scores, mcp_side_p2)
-    van_p1, van_p2 = _arm_total(pos1.criterion_scores, van_side_p1), _arm_total(pos2.criterion_scores, van_side_p2)
-
-    if None in (mcp_p1, mcp_p2, van_p1, van_p2):
+    # Single-sourced via `per_criterion_breakdown` so the per-category report
+    # rows sum to exactly these totals — the side mapping lives in one place.
+    rows = per_criterion_breakdown(
+        pos1.criterion_scores, pos2.criterion_scores, pos1_left_is=pos1_left_is
+    )
+    if rows is None:
         mcp_avg = vanilla_avg = margin = None
         final_by_score: str = "unscored"
     else:
-        mcp_avg = (mcp_p1 + mcp_p2) / 2.0
-        vanilla_avg = (van_p1 + van_p2) / 2.0
+        mcp_avg = sum(r["mcp"] for r in rows)
+        vanilla_avg = sum(r["vanilla"] for r in rows)
         margin = mcp_avg - vanilla_avg
         if margin > epsilon:
             final_by_score = "mcp"

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -753,7 +753,7 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
         return arm_max > 0 and usage["output_tokens"] >= truncation_threshold
 
     def _cat_winner(margin: float) -> str:
-        """Per-category Δ winner for badge colour — sign of (mcp − vanilla)."""
+        """Per-category Δ winner for badge colour — sign of (mcp - vanilla)."""
         return "mcp" if margin > 0 else "vanilla" if margin < 0 else "tie"
 
     truncation_count = 0
@@ -766,7 +766,7 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
         # Per-category (swap-averaged) scores per arm — None when the verdict is
         # unscored (synthetic empty-tie / missing scores); the template hides the
         # table in that case. Column sums equal vanilla_avg / mcp_avg by construction.
-        cat_rows = per_criterion_breakdown(r.verdict.pos1.criterion_scores, r.verdict.pos2.criterion_scores)
+        cat_rows = per_criterion_breakdown(r.verdict.pos1.criterion_scores, r.verdict.pos2.criterion_scores, pos1_left_is="vanilla")
         category_scores = None
         if cat_rows is not None:
             category_scores = {

--- a/evals/runners/run_mcp_vs_vanilla.py
+++ b/evals/runners/run_mcp_vs_vanilla.py
@@ -56,6 +56,7 @@ from evals.judges.pairwise_judge import (  # noqa: E402
     _SCORE_MAX as JUDGE_SCORE_MAX,
     _SCORE_MIN as JUDGE_SCORE_MIN,
     aggregate_with_swap,
+    per_criterion_breakdown,
     run_judge,
 )
 from evals.runners._providers import ContaminatedResponseError, ProviderImpl, get_pricing, get_provider  # noqa: E402
@@ -751,6 +752,10 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
     def _is_truncated(usage: dict[str, int]) -> bool:
         return arm_max > 0 and usage["output_tokens"] >= truncation_threshold
 
+    def _cat_winner(margin: float) -> str:
+        """Per-category Δ winner for badge colour — sign of (mcp − vanilla)."""
+        return "mcp" if margin > 0 else "vanilla" if margin < 0 else "tie"
+
     truncation_count = 0
     per_query: list[dict[str, Any]] = []
     for r in runs:
@@ -758,6 +763,30 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
         mcp_truncated = _is_truncated(r.mcp.usage)
         if vanilla_truncated or mcp_truncated:
             truncation_count += 1
+        # Per-category (swap-averaged) scores per arm — None when the verdict is
+        # unscored (synthetic empty-tie / missing scores); the template hides the
+        # table in that case. Column sums equal vanilla_avg / mcp_avg by construction.
+        cat_rows = per_criterion_breakdown(r.verdict.pos1.criterion_scores, r.verdict.pos2.criterion_scores)
+        category_scores = None
+        if cat_rows is not None:
+            category_scores = {
+                "rows": [
+                    {
+                        "criterion": row["criterion"].replace("_", "-"),
+                        "vanilla": f"{row['vanilla']:.1f}",
+                        "mcp": f"{row['mcp']:.1f}",
+                        "margin_str": f"{row['margin']:+.1f}",
+                        "winner": _cat_winner(row["margin"]),
+                    }
+                    for row in cat_rows
+                ],
+                "total": {
+                    "vanilla": f"{r.verdict.vanilla_avg:.1f}",
+                    "mcp": f"{r.verdict.mcp_avg:.1f}",
+                    "margin_str": f"{r.verdict.margin:+.1f}",
+                    "winner": _cat_winner(r.verdict.margin),
+                },
+            }
         per_query.append({
             "query": r.query,
             "query_preview": r.query[:120] + ("…" if len(r.query) > 120 else ""),
@@ -767,6 +796,7 @@ def build_template_context(result: BenchmarkResult) -> dict[str, Any]:
             "final_by_score": r.verdict.final_by_score,
             "margin_str": ("n/a" if r.verdict.margin is None else f"{r.verdict.margin:+.1f}"),
             "margin_scale": len(_CRITERIA) * (result.config.get("judge_score_max", JUDGE_SCORE_MAX) - JUDGE_SCORE_MIN),  # max |mcp−vanilla|: len(_CRITERIA) × (max − min)
+            "category_scores": category_scores,
             "vanilla_response": r.vanilla.response_text,
             "vanilla_usage": r.vanilla.usage,
             "vanilla_latency_ms": r.vanilla.latency_ms,

--- a/evals/templates/report.html.j2
+++ b/evals/templates/report.html.j2
@@ -275,7 +275,7 @@
           </tr>
         </tbody>
       </table>
-      <div class="reason">Each arm's swap-averaged score per category (judge ran both orders; additive L/R position bias cancels). Column sums equal the Score margin above.</div>
+      <div class="reason">Each arm's swap-averaged score per category (judge ran both orders; additive L/R position bias cancels). The TOTAL row is each arm's total; their difference is the Score margin above.</div>
     </div>
     {% endif %}
     <div class="judge-block">

--- a/evals/templates/report.html.j2
+++ b/evals/templates/report.html.j2
@@ -251,6 +251,33 @@
       <div class="reason">Per-criterion 1–{{ judge_score_max }} scores summed per arm and averaged across both orders — additive L/R position bias cancels. Independent of the holistic winner below.</div>
     </div>
     {% endif %}
+    {% if r.category_scores %}
+    <div class="judge-block">
+      <strong>Per-category scores</strong> (swap-averaged, 1–{{ judge_score_max }} per category)
+      <table style="margin-top: 8px;">
+        <thead><tr>
+          <th>Category</th><th class="num">Vanilla</th><th class="num">MCP</th><th class="num">Δ mcp−van</th>
+        </tr></thead>
+        <tbody>
+          {% for c in r.category_scores.rows %}
+          <tr>
+            <td>{{ c.criterion }}</td>
+            <td class="num">{{ c.vanilla }}</td>
+            <td class="num">{{ c.mcp }}</td>
+            <td class="num"><span class="delta {% if c.winner == 'mcp' %}good{% elif c.winner == 'vanilla' %}bad{% endif %}">{{ c.margin_str }}</span></td>
+          </tr>
+          {% endfor %}
+          <tr style="font-weight: 600; border-top: 2px solid var(--border);">
+            <td>TOTAL</td>
+            <td class="num">{{ r.category_scores.total.vanilla }}</td>
+            <td class="num">{{ r.category_scores.total.mcp }}</td>
+            <td class="num"><span class="delta {% if r.category_scores.total.winner == 'mcp' %}good{% elif r.category_scores.total.winner == 'vanilla' %}bad{% endif %}">{{ r.category_scores.total.margin_str }}</span></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="reason">Each arm's swap-averaged score per category (judge ran both orders; additive L/R position bias cancels). Column sums equal the Score margin above.</div>
+    </div>
+    {% endif %}
     <div class="judge-block">
       <strong>Round 1</strong> — left corner=vanilla, right corner=mcp ·
       winner: <code>{{ r.judge_pos1.winner_corner }}</code>

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -20,6 +21,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from evals.judges.pairwise_judge import JudgeCall, aggregate_with_swap
+
+if TYPE_CHECKING:
+    from evals.runners.run_mcp_vs_vanilla import BenchmarkResult
 
 
 def _jc(winner: str, *, in_=10, out=20, cc=0, cr=0) -> JudgeCall:
@@ -1585,7 +1589,7 @@ class TestPerCategoryScoresInReport:
         d.update({f"right_{c}": right_val for c in _CRITERIA})
         return d
 
-    def _build(self, *, scored: bool):
+    def _build(self, *, scored: bool) -> tuple[BenchmarkResult, dict[str, Any]]:
         from evals.runners._providers import PRICING
         from evals.runners.run_mcp_vs_vanilla import (
             BenchmarkResult, QueryRun, TrialResult, build_template_context,

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1509,3 +1509,146 @@ class TestTemplateEscaping:
         # Old vocabulary gone
         assert "Position 1" not in html and "Position 2" not in html
         assert "LEFT=" not in html and "RIGHT=" not in html
+
+
+# --------------------------------------------------------------------------- #
+# Per-category (swap-averaged) scores — helper, context, and render
+# --------------------------------------------------------------------------- #
+
+
+class TestPerCriterionBreakdown:
+    """`per_criterion_breakdown` re-derives each arm's swap-averaged score per
+    category. Convention (judge_with_swap): pos1 left=vanilla/right=mcp;
+    pos2 left=mcp/right=vanilla."""
+
+    def test_swap_averaged_values_and_order(self):
+        from evals.judges.pairwise_judge import per_criterion_breakdown, _CRITERIA
+
+        pos1 = {f"left_{c}": 8 for c in _CRITERIA}   # vanilla in pos1
+        pos1.update({f"right_{c}": 6 for c in _CRITERIA})  # mcp in pos1
+        pos2 = {f"left_{c}": 7 for c in _CRITERIA}   # mcp in pos2
+        pos2.update({f"right_{c}": 9 for c in _CRITERIA})  # vanilla in pos2
+
+        rows = per_criterion_breakdown(pos1, pos2)
+        assert [row["criterion"] for row in rows] == list(_CRITERIA)
+        for row in rows:
+            assert row["vanilla"] == 8.5   # (8 + 9) / 2
+            assert row["mcp"] == 6.5       # (6 + 7) / 2
+            assert row["margin"] == -2.0
+
+    def test_sums_match_aggregate_with_swap(self):
+        """Column sums must equal the SwapVerdict vanilla_avg / mcp_avg — the
+        per-category table and the headline Score margin cannot drift."""
+        from evals.judges.pairwise_judge import (
+            per_criterion_breakdown, aggregate_with_swap, JudgeCall, _CRITERIA,
+        )
+
+        zero = {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        pos1_scores: dict[str, int] = {}
+        pos2_scores: dict[str, int] = {}
+        for i, c in enumerate(_CRITERIA):
+            pos1_scores[f"left_{c}"] = 5 + i        # vanilla, pos1
+            pos1_scores[f"right_{c}"] = 8 - i       # mcp, pos1
+            pos2_scores[f"left_{c}"] = 6 + (i % 3)  # mcp, pos2
+            pos2_scores[f"right_{c}"] = 4 + i       # vanilla, pos2
+        pos1 = JudgeCall(winner="left", reasoning="r", criterion_scores=pos1_scores, usage=dict(zero))
+        pos2 = JudgeCall(winner="right", reasoning="r", criterion_scores=pos2_scores, usage=dict(zero))
+
+        v = aggregate_with_swap(pos1=pos1, pos2=pos2, pos1_left_is="vanilla")
+        rows = per_criterion_breakdown(pos1_scores, pos2_scores)
+        assert sum(r["mcp"] for r in rows) == v.mcp_avg
+        assert sum(r["vanilla"] for r in rows) == v.vanilla_avg
+        assert abs(sum(r["margin"] for r in rows) - v.margin) < 1e-9
+        # Pin the convention on the first criterion.
+        assert rows[0]["vanilla"] == (pos1_scores["left_helpfulness"] + pos2_scores["right_helpfulness"]) / 2.0
+        assert rows[0]["mcp"] == (pos1_scores["right_helpfulness"] + pos2_scores["left_helpfulness"]) / 2.0
+
+    def test_missing_or_partial_scores_return_none(self):
+        from evals.judges.pairwise_judge import per_criterion_breakdown, _CRITERIA
+
+        full = {f"{side}_{c}": 5 for side in ("left", "right") for c in _CRITERIA}
+        assert per_criterion_breakdown({}, full) is None
+        assert per_criterion_breakdown(full, None) is None
+        assert per_criterion_breakdown(full, {"left_helpfulness": 5}) is None  # partial
+
+
+class TestPerCategoryScoresInReport:
+    """`build_template_context` must surface per-category scores per test, and
+    the template must render them as a table — present when scored, absent when
+    the verdict is unscored (synthetic empty-tie)."""
+
+    @staticmethod
+    def _scores(left_val: int, right_val: int) -> dict[str, int]:
+        from evals.judges.pairwise_judge import _CRITERIA
+
+        d = {f"left_{c}": left_val for c in _CRITERIA}
+        d.update({f"right_{c}": right_val for c in _CRITERIA})
+        return d
+
+    def _build(self, *, scored: bool):
+        from evals.runners._providers import PRICING
+        from evals.runners.run_mcp_vs_vanilla import (
+            BenchmarkResult, QueryRun, TrialResult, build_template_context,
+        )
+        from evals.judges.pairwise_judge import aggregate_with_swap, JudgeCall
+
+        usage = {"input_tokens": 100, "output_tokens": 50, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+        van = TrialResult(arm="vanilla", response_text="x", usage=dict(usage), latency_ms=10)
+        mcp = TrialResult(arm="mcp", response_text="y", usage=dict(usage), latency_ms=10,
+                          mcp_meta={"agent": "u", "tier": "lite", "routing_path": "cache_hit",
+                                    "skills_loaded": [], "implants_loaded": [], "rules_loaded": []})
+        if scored:
+            pos1 = JudgeCall(winner="left", reasoning="r", criterion_scores=self._scores(8, 6), usage=dict(usage))
+            pos2 = JudgeCall(winner="right", reasoning="r", criterion_scores=self._scores(7, 9), usage=dict(usage))
+        else:
+            empty = {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+            pos1 = JudgeCall(winner="tie", reasoning="r", criterion_scores={}, usage=dict(empty))
+            pos2 = JudgeCall(winner="tie", reasoning="r", criterion_scores={}, usage=dict(empty))
+        verdict = aggregate_with_swap(pos1=pos1, pos2=pos2, pos1_left_is="vanilla")
+        run = QueryRun(idx=1, query="q", stream_idx=0, vanilla=van, mcp=mcp, verdict=verdict)
+        result = BenchmarkResult(
+            config={"provider": "openai", "provider_notes": "", "model": "gpt-4o", "judge_model": "gpt-4o",
+                    "seed": 0, "dataset": "wildbench", "commit_sha": "x", "max_tokens": 8192,
+                    "judge_max_tokens": 4096, "concurrency": 1},
+            runs=[run], dataset_hash="h", wall_time_s=0.0,
+            arm_pricing=PRICING["openai"], judge_pricing=PRICING["openai"],
+        )
+        return result, build_template_context(result)
+
+    def test_category_scores_present_and_correct_when_scored(self):
+        from evals.judges.pairwise_judge import _CRITERIA
+
+        _result, ctx = self._build(scored=True)
+        cs = ctx["per_query"][0]["category_scores"]
+        assert cs is not None
+        assert [row["criterion"] for row in cs["rows"]] == [c.replace("_", "-") for c in _CRITERIA]
+        # vanilla_c=(8+9)/2=8.5 ; mcp_c=(6+7)/2=6.5 ; Δ=-2.0 → vanilla better.
+        first = cs["rows"][0]
+        assert (first["vanilla"], first["mcp"], first["margin_str"], first["winner"]) == ("8.5", "6.5", "-2.0", "vanilla")
+        # Totals (5 criteria) tie to the headline margin.
+        assert cs["total"]["vanilla"] == "42.5"
+        assert cs["total"]["mcp"] == "32.5"
+        assert cs["total"]["margin_str"] == ctx["per_query"][0]["margin_str"]
+        assert cs["total"]["winner"] == "vanilla"
+
+    def test_category_scores_none_when_unscored(self):
+        _result, ctx = self._build(scored=False)
+        assert ctx["per_query"][0]["category_scores"] is None
+
+    def test_render_includes_per_category_table(self):
+        pytest.importorskip("jinja2")
+        from evals.runners.run_mcp_vs_vanilla import render_html
+
+        result, _ctx = self._build(scored=True)
+        html = render_html(result, REPO_ROOT / "evals" / "templates" / "report.html.j2")
+        assert "Per-category scores" in html
+        assert "intent-fit" in html          # criterion label uses hyphen form
+        assert "<td>TOTAL</td>" in html
+
+    def test_render_omits_table_when_unscored(self):
+        pytest.importorskip("jinja2")
+        from evals.runners.run_mcp_vs_vanilla import render_html
+
+        result, _ctx = self._build(scored=False)
+        html = render_html(result, REPO_ROOT / "evals" / "templates" / "report.html.j2")
+        assert "Per-category scores" not in html


### PR DESCRIPTION
## What

Adds a per-category score breakdown to every test in the MCP-vs-vanilla HTML report. Each test now shows, for **both answers** (vanilla and MCP), the swap-averaged score in each of the 5 judge categories — helpfulness, correctness, depth, structure, intent-fit — plus a **TOTAL** row, instead of only the holistic margin.

## Why

The report previously showed only the aggregate `mcp − vanilla` margin per test. The per-category signal was already computed and stored by the judge (`verdict.pos1/pos2.criterion_scores`, 1–10 per criterion) but was never surfaced to the template.

## How

- **`evals/judges/pairwise_judge.py`** — new `per_criterion_breakdown()`: swap-averaged per-category score per arm, re-derived from the two judge calls. `aggregate_with_swap()` now derives `mcp_avg`/`vanilla_avg` from it, so the side-mapping is single-sourced and the table TOTAL ties **exactly** to the existing Score margin. Behaviour-preserving.
- **`evals/runners/run_mcp_vs_vanilla.py`** — `build_template_context()` emits `category_scores` per query (`None` when the verdict is unscored).
- **`evals/templates/report.html.j2`** — renders a `Category / Vanilla / MCP / Δ` table with a TOTAL row, reusing existing styles; Δ is colour-coded (green = MCP better, red = Vanilla better). Hidden on unscored verdicts.
- **`tests/test_bench.py`** — 7 new tests: helper math + ordering, sum-equality with `aggregate_with_swap`, missing/partial → `None`, context shape, and render present/absent.

## Scope

Applies to **newly generated** reports. Existing static HTML files are untouched (no `--from-json` re-render path added).

## Verification

- `tests/test_bench.py`: **97 passed**; full suite: **450 passed, 16 deselected**.
- `per_criterion_breakdown` validated against a real report JSON (`2026-05-30_…_gpt55.json`): per-category column sums match the stored `mcp_avg` / `vanilla_avg` for **all 50 scored runs (0 mismatches)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include per-category score breakdowns showing Vanilla vs MCP performance across individual criteria with margins and winner labels, helping identify key factors driving verdicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WonderMr/Agents/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->