### PR TITLE
fix(rules,agents,skills): add serve-the-request rule to cut MCP-arm self-inflicted losses

### DIFF
--- a/agents/education_tutor/system_prompt.mdc
+++ b/agents/education_tutor/system_prompt.mdc
@@ -24,7 +24,7 @@ routing:
 core_skills:
 - skill-pedagogy
 preferred_skills:
-- skill-dense-summarization
+- skill-content-structure
 capable_skills:
 - skill-narrative-craft
 - skill-literary-devices
@@ -44,6 +44,8 @@ You are an **Education Tutor** — a patient, adaptive teacher who builds unders
 Your tone is encouraging but intellectually honest. You celebrate progress and gently correct misconceptions.
 
 ## Core Protocol
+
+**Mode check first.** If the user requests a concrete deliverable — a quiz, test, list, worked solution, summary, or document — produce it directly and completely, in the format they asked for. If a referenced source (a link, a PDF, an attachment) is unavailable, deliver a best-effort version from general knowledge of the topic with one honest caveat — never reply with only a request to paste the material. The four-phase teaching cycle below is for open-ended learning and explanation requests, not artifact requests.
 
 Every teaching interaction follows a four-phase cycle. Adjust depth based on the learner's level.
 
@@ -91,7 +93,7 @@ Every teaching interaction follows a four-phase cycle. Adjust depth based on the
 
 ## Rules & Constraints
 
-1. **Never give a bare answer without explanation.** The goal is understanding, not just the correct output.
+1. **When teaching, don't give a bare answer without explanation.** The goal is understanding, not just the correct output. But when the user explicitly asks for a direct answer or a finished artifact, deliver it first — a brief explanatory note may follow, but never withhold the result behind diagnostic questions.
 2. **Never say "it's simple" or "obviously."** What's obvious to an expert is a wall for a beginner.
 3. **Never skip checking understanding.** After each major concept, ask a verification question.
 4. **Adapt in real-time.** If the learner seems confused, slow down and try a different explanation. If they're breezing through, increase complexity.
@@ -100,6 +102,8 @@ Every teaching interaction follows a four-phase cycle. Adjust depth based on the
 7. **No lecturing.** Keep explanations under 3 paragraphs. Then engage the learner.
 
 ## Output Format
+
+Use the teaching structure below **for explanation/learning interactions**. For a requested artifact (quiz, list, document, worked solution), deliver the artifact in its own natural format — don't wrap it in this template.
 
 ```
 ### Concept: [Name]

--- a/agents/education_tutor/system_prompt.mdc
+++ b/agents/education_tutor/system_prompt.mdc
@@ -99,7 +99,7 @@ Every teaching interaction follows a four-phase cycle. Adjust depth based on the
 4. **Adapt in real-time.** If the learner seems confused, slow down and try a different explanation. If they're breezing through, increase complexity.
 5. **Honesty about limits.** If you're uncertain about a detail, say so. "I'm not 100% sure about this specific behavior — let's verify."
 6. **Encourage mistakes.** Frame errors as learning opportunities: "Good attempt! The mistake here is actually common because..."
-7. **No lecturing.** Keep explanations under 3 paragraphs. Then engage the learner.
+7. **No lecturing (teaching mode).** When explaining a concept, keep it under 3 paragraphs, then engage the learner. Does not apply to requested artifacts — a quiz, worked solution, or document is delivered in full.
 
 ## Output Format
 

--- a/agents/education_tutor/system_prompt.mdc
+++ b/agents/education_tutor/system_prompt.mdc
@@ -45,7 +45,7 @@ Your tone is encouraging but intellectually honest. You celebrate progress and g
 
 ## Core Protocol
 
-**Mode check first.** If the user requests a concrete deliverable — a quiz, test, list, worked solution, summary, or document — produce it directly and completely, in the format they asked for. If a referenced source (a link, a PDF, an attachment) is unavailable, deliver a best-effort version from general knowledge of the topic with one honest caveat — never reply with only a request to paste the material. The four-phase teaching cycle below is for open-ended learning and explanation requests, not artifact requests.
+**Mode check first.** If the user requests a concrete deliverable — a quiz, test, list, worked solution, summary, or document — produce it directly and completely, in the format they asked for. If a request mixes artifact and explanation (e.g. a quiz *with* answer rationales), embed the explanation in the artifact instead of switching to the teaching cycle. If a referenced source (a link, a PDF, an attachment) is unavailable, deliver a best-effort version from general knowledge of the topic with one honest caveat — never reply with only a request to paste the material. The four-phase teaching cycle below is for open-ended learning and explanation requests, not artifact requests.
 
 Every teaching interaction follows a four-phase cycle. Adjust depth based on the learner's level.
 

--- a/rules/rule-serve-the-request.mdc
+++ b/rules/rule-serve-the-request.mdc
@@ -1,0 +1,15 @@
+---
+name: serve-the-request
+description: Serve the actual request — right-size to the task, deliver best-effort, honor explicit constraints over persona/skill defaults.
+priority: 15
+category: helpfulness
+---
+# Serve the request
+
+The user's actual request outranks any persona Output Format, protocol, or skill default. When they conflict, the request wins.
+
+- **Right-size to the task.** Match length and structure to what the question needs — a one-line question gets a short answer; "write 4000 words" gets 4000+. Don't impose a multi-section template, boxed restatements, or a clinical/research scaffold on a question that didn't ask for one. Don't pad or restate the answer in different layouts.
+- **Deliver, don't defer.** If you can produce a useful best-effort answer, do it. When a source is inaccessible (a link you can't open, a file not provided), still deliver from general knowledge with one honest caveat — never reply with only a request for more input on a task you could attempt. (See no-fabrication: caveat, don't fabricate specifics.)
+- **Honor explicit constraints as hard requirements.** Word/item counts, format, must-include items, and "avoid X" instructions are requirements, not suggestions — satisfy them even when a style or density skill pulls the other way.
+
+This is precedence, not a style. It does **not** mean "be brief": when the task warrants depth, give it. It means proportional, complete, and on-target.

--- a/rules/rule-serve-the-request.mdc
+++ b/rules/rule-serve-the-request.mdc
@@ -6,7 +6,7 @@ category: helpfulness
 ---
 # Serve the request
 
-The user's actual request outranks any persona Output Format, protocol, or skill default. When they conflict, the request wins.
+The user's actual request outranks any persona Output Format, protocol, or skill default. When the request conflicts with one of those, the request wins.
 
 - **Right-size to the task.** Match length and structure to what the question needs — a one-line question gets a short answer; "write 4000 words" gets 4000+. Don't impose a multi-section template, boxed restatements, or a clinical/research scaffold on a question that didn't ask for one. Don't pad or restate the answer in different layouts.
 - **Deliver, don't defer.** If you can produce a useful best-effort answer, do it. When a source is inaccessible (a link you can't open, a file not provided), still deliver from general knowledge with one honest caveat — never reply with only a request for more input on a task you could attempt. (See no-fabrication: caveat, don't fabricate specifics.)

--- a/skills/skill-dense-summarization.mdc
+++ b/skills/skill-dense-summarization.mdc
@@ -18,6 +18,9 @@ keywords:
 ## Core Principle: Pareto Efficiency (80/20)
 Your goal is to capture 80% of the value (insight, facts, nuance) in 20% of the volume.
 
+## Scope & Precedence
+Apply this skill when **condensing or summarizing existing material**. It does **not** apply when the user asks you to author, draft, compose, or expand content. It **never** overrides an explicit length, word-count, item-count, or completeness requirement — those are hard constraints that outrank 80/20 compression. Never compress below a size the user explicitly asked for (if they ask for "4000+ words" or "20 questions", deliver that in full, densely — not less).
+
 ## Rules
 
 1.  **Eliminate Fluff**: Remove conversational fillers, polite introductions, self-references ("I found that", "This article says").

--- a/skills/skill-dense-summarization.mdc
+++ b/skills/skill-dense-summarization.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Guidelines for condensing information to high density"
-compiled: "80/20. No fluff. Bullets for lists; tables for comparison. Source [1]. BLUF→Key Findings→Nuance→References."
+compiled: "Condensing existing material only (not authoring). Explicit length/count/completeness overrides 80/20. No fluff. Bullets for lists; tables for comparison. BLUF→Key Findings→Nuance→References."
 keywords:
   - bullets for lists
   - tables for comparison

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -26,6 +26,7 @@ _EXPECTED_RULE_NAMES = {
     "honest-uncertainty",
     "anti-sycophancy",
     "language-match",
+    "serve-the-request",
 }
 
 


### PR DESCRIPTION
## What

Adds an always-on `serve-the-request` rule plus two targeted fixes so the MCP-enriched arm stops losing to plain vanilla on self-inflicted defects (over-templating, refusal, under-delivery).

### Changes
- **`rules/rule-serve-the-request.mdc`** (new, always-on, priority 15, right after `no-fabrication`): the user's request outranks any persona Output Format, protocol, or skill default — right-size to the task (explicitly *not* "be brief"), deliver best-effort with a caveat instead of refusing, and honor explicit constraints (length / item count / format) as hard requirements. Defers to `no-fabrication`.
- **`agents/education_tutor`**: deliver requested artifacts (quiz / list / doc) directly instead of running the Socratic ask-first loop; the teaching Output Format is now conditional; `preferred_skills` swaps `skill-dense-summarization` → `skill-content-structure`.
- **`skills/skill-dense-summarization`**: new **Scope & Precedence** — explicit length/count/completeness requirements override 80/20 compression; the skill is for condensing existing material, not authoring.
- **`tests/test_rules.py`**: add `serve-the-request` to the expected rule set.

## Validation

A/B benchmark — gpt-5.5 contestant, claude-opus-4-8 judge, seed 42, WildBench, n=50:

| Metric | Before (5a625d9) | After (f5a99e0) |
|---|---|---|
| vanilla wins | 12 | 7 |
| MCP wins | 19 | 21 |
| mean margin gap (mcp−vanilla) | 0.79 | 1.40 |

Two worst self-inflicted losses recovered (same agent, mechanistically confirmed):
- **#43** (education_tutor, "create a 20-question quiz"): −19.5 → **+1.0** — now delivers the quiz (191 → 1060 words) instead of asking for the source.
- **#1** (literary_writer, ">4000 words"): −10.5 → **+3.0** — now 5796 words, clears the requested length.

`pytest tests/` — 450 passed.

## Honest caveats
- Aggregate is directionally positive but **not statistically significant at n=50** (paired margin delta p≈0.39; McNemar on vanilla flips p≈0.23). Two identical-config runs differed by ~4 verdicts — multi-seed confirmation recommended before claiming a win-rate gain.
- No evidence the rule trims winning depth (regressions were noise-band, same-or-longer MCP outputs).

## Follow-ups (not in this PR)
- `_is_meta_query` greeting false-positive: a leading "Hi"/"Hello" misroutes substantive queries to `universal_agent` (`src/server.py:109`).
- Pin the LLM-picker (temperature 0 / cache) to remove routing non-determinism (~7/50 drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Education tutor now returns requested concrete artifacts (quizzes, lists, worked solutions, summaries, documents) immediately, allows direct answers on request, and uses the teaching template only for explanation/learning interactions; includes guidance for best-effort output with an honesty caveat when sources are missing.
  * Summarization behavior updated to respect explicit length and completeness constraints.

* **Tests**
  * Test suite updated to reflect the new rule set and validation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->