### PR TITLE
feat(server): background self-update on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,35 @@ AGENTS_DEBUG=0                # Set to 1 for JSON debug logging in logs/
 
 > **Note**: Embeddings are handled locally by `fastembed` (ONNX Runtime). Model is selected during setup — no external API key is required for core routing.
 
+### Background Auto-Update
+
+The server can keep itself current. On startup a daemon thread (non-blocking, so it
+never delays serving) fast-forwards the install's own git repo and rebuilds the vector
+stores; the pulled code takes effect on the **next** start (for per-session stdio
+servers, the next spawn). The heavy reindex runs in the background of the current
+session so the next one starts fast.
+
+It is **safe by default**:
+
+- acts **only** when the checked-out branch is `AGENTS_AUTO_UPDATE_BRANCH` (default
+  `main`) — a **no-op on feature branches**, so local development is never touched;
+- only when the working tree is clean, and only **fast-forward** (never merge, rebase,
+  or switch branches);
+- a failed reindex (e.g. broken new code) is **rolled back** to the previous commit;
+- any error (offline, lock held by another process, timeout) is logged and the server
+  keeps serving the current code. Dependencies are **not** auto-installed.
+
+```env
+AGENTS_AUTO_UPDATE=1                     # 0 to disable
+AGENTS_AUTO_UPDATE_REMOTE=origin
+AGENTS_AUTO_UPDATE_BRANCH=main           # only updates when this branch is checked out
+AGENTS_AUTO_UPDATE_TIMEOUT=30            # seconds per git op
+AGENTS_AUTO_UPDATE_INTERVAL=900          # throttle network checks (0 = every start)
+AGENTS_AUTO_UPDATE_REINDEX_TIMEOUT=600
+```
+
+Run a manual rebuild any time with `python -m src.reindex`.
+
 ---
 
 ## 🎯 How It Works

--- a/env.example
+++ b/env.example
@@ -11,3 +11,16 @@ AGENTS_DEBUG=0                # Set to 1 for JSON debug logging in logs/
 # Optional: override fastembed model cache directory (default: ~/.cache/fastembed)
 # Must be persistent — avoid /tmp on macOS (launchd auto-cleans it).
 # FASTEMBED_CACHE_DIR=
+
+# --- Background auto-update --------------------------------------------------
+# On startup the server fast-forwards its own git repo and rebuilds the vector
+# stores in a background thread (non-blocking); the new code applies on the NEXT
+# start. It acts ONLY when the checked-out branch is AGENTS_AUTO_UPDATE_BRANCH
+# and the tree is clean (fast-forward only) — a no-op on feature branches, so
+# local development is never disturbed.
+AGENTS_AUTO_UPDATE=1                     # 0 disables auto-update
+AGENTS_AUTO_UPDATE_REMOTE=origin         # git remote to track
+AGENTS_AUTO_UPDATE_BRANCH=main           # only update when this branch is checked out
+AGENTS_AUTO_UPDATE_TIMEOUT=30            # seconds per git op (fetch/merge/...)
+AGENTS_AUTO_UPDATE_INTERVAL=900          # throttle: skip fetch if checked within N s (0 = always)
+AGENTS_AUTO_UPDATE_REINDEX_TIMEOUT=600   # seconds allowed for the reindex subprocess

--- a/src/engine/config.py
+++ b/src/engine/config.py
@@ -133,6 +133,26 @@ def _float_env(name: str, default: float, lo: float = 0.0, hi: float = 1.0) -> f
     return value
 
 
+def _int_env(name: str, default: int, lo: int = 0, hi: Optional[int] = None) -> int:
+    """Parse an int from an env var, falling back to *default* on bad values or out-of-range.
+
+    Mirrors :func:`_float_env`; ``hi=None`` means no upper bound (used for
+    timeouts / intervals that have no natural ceiling).
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid value for %s=%r, using default %d", name, raw, default)
+        return default
+    if value < lo or (hi is not None and value > hi):
+        logger.warning("Out-of-range value for %s=%d, using default %d", name, value, default)
+        return default
+    return value
+
+
 ROUTER_SIMILARITY_THRESHOLD = _float_env("ROUTER_SIMILARITY_THRESHOLD", 0.95)
 # Sticky agent: auto-switch to a different agent without LLM if cosine distance
 # is below this value. Intentionally tighter than the router's distance cutoff
@@ -165,6 +185,25 @@ AGENTS_DEBUG = os.getenv("AGENTS_DEBUG", "").lower() in ("1", "true")
 # Rules layer — universal directives loaded into every enriched prompt.
 # Disable with RULES_ENABLED=0 to compare behavior with/without the layer.
 RULES_ENABLED = os.getenv("RULES_ENABLED", "1").lower() in ("1", "true")
+
+# --- Auto-update (background self-update) ------------------------------------
+# The server can keep itself current by pulling its own git repo (INSTALL_ROOT)
+# in a daemon thread at startup — non-blocking — and rebuilding the vector
+# stores; the new code takes effect on the *next* start. It acts ONLY when the
+# checked-out branch is AUTO_UPDATE_BRANCH and the tree is clean, fast-forward
+# only. On any other branch (feature branches / local development) it is a
+# no-op. Opt out with AGENTS_AUTO_UPDATE=0.
+AUTO_UPDATE_ENABLED = os.getenv("AGENTS_AUTO_UPDATE", "1").lower() in ("1", "true")
+AUTO_UPDATE_REMOTE = os.getenv("AGENTS_AUTO_UPDATE_REMOTE", "origin")
+AUTO_UPDATE_BRANCH = os.getenv("AGENTS_AUTO_UPDATE_BRANCH", "main")
+# Seconds allotted to each git CLI/network op (status/fetch/merge/...).
+AUTO_UPDATE_GIT_TIMEOUT = _int_env("AGENTS_AUTO_UPDATE_TIMEOUT", 30, lo=1)
+# Throttle: skip the network fetch if the last check was within this many
+# seconds (stdio servers respawn frequently). 0 disables throttling.
+AUTO_UPDATE_MIN_INTERVAL = _int_env("AGENTS_AUTO_UPDATE_INTERVAL", 900, lo=0)
+# The reindex subprocess loads the embedding model and re-embeds all .mdc
+# files, so it needs a generous ceiling.
+AUTO_UPDATE_REINDEX_TIMEOUT = _int_env("AGENTS_AUTO_UPDATE_REINDEX_TIMEOUT", 600, lo=1)
 
 # --- Deprecated name aliases (PEP 562) ---------------------------------------
 # Issue #36: `REPO_ROOT`/`DATA_DIR`/`DEBUG_LOG_DIR` used to conflate the Agents

--- a/src/reindex.py
+++ b/src/reindex.py
@@ -1,0 +1,52 @@
+"""Rebuild the skills/implants vector stores from the .mdc source files.
+
+Run manually with ``python -m src.reindex`` after editing skills/implants, or
+automatically by the background auto-updater (``src/self_update.py``) right
+after a ``git pull`` so the *next* server start finds the indexes already built
+and starts fast.
+
+Constructing ``SkillRetriever`` / ``ImplantRetriever`` is all that's needed:
+their ``__init__`` compares a content hash (EMBEDDING_MODEL + every ``.mdc``
+file) against the stored ``.skills_hash`` / ``.implants_hash`` and re-embeds
+only when something changed. The router cache invalidates itself on model
+change at server startup, so it needs no action here.
+"""
+
+import logging
+import os
+import sys
+
+import dotenv
+
+# Make ``src`` importable both as ``python -m src.reindex`` and as a direct
+# script — mirrors src/server.py.
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Load .env so EMBEDDING_MODEL et al. match the server's configuration even
+# when this module is run standalone (subprocess invocations inherit the
+# parent env, but a manual run would not).
+dotenv.load_dotenv(os.path.join(os.path.dirname(__file__), "../.env"))
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("reindex")
+
+
+def main() -> int:
+    """Reindex skills and implants. Returns a process exit code (0 = success)."""
+    from src.engine.skills import SkillRetriever
+    from src.engine.implants import ImplantRetriever
+
+    logger.info("Reindex: building skills store...")
+    skills = SkillRetriever()
+    logger.info("Reindex: skills store ready (%d entries)", skills.store.count())
+
+    logger.info("Reindex: building implants store...")
+    implants = ImplantRetriever()
+    logger.info("Reindex: implants store ready (%d entries)", implants.store.count())
+
+    logger.info("Reindex complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/self_update.py
+++ b/src/self_update.py
@@ -237,7 +237,7 @@ def log_last_update() -> None:
         with open(STATE_FILE, "r", encoding="utf-8") as f:
             state = json.load(f)
         logger.info(
-            "Auto-update: last run %s (%s -> %s) at %s",
+            "Auto-update: last applied update %s (%s -> %s) at %s",
             state.get("status"),
             (state.get("old_sha") or "")[:9],
             (state.get("new_sha") or "")[:9],
@@ -308,9 +308,11 @@ def check_and_apply_update(
         logger.info("Auto-update: %s is not a git work tree; skipping.", repo_root)
         return UpdateStatus.NO_GIT
 
-    # Tracks whether we reached the network (fetch). A timeout before that point
-    # is a local-op failure that must not write the throttle stamp.
+    # State read by the exception handler below: whether we reached the network
+    # (fetch), and whether the fast-forward already mutated the working tree.
     network_reached = False
+    merged = False
+    old_sha = ""
     try:
         # Step 2 — branch guard: only act on the target branch.
         cur = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], repo_root, git_timeout)
@@ -388,6 +390,7 @@ def check_and_apply_update(
         if merge.returncode != 0:
             logger.warning("Auto-update: fast-forward merge failed; skipping. %s", merge.stderr.strip())
             return UpdateStatus.MERGE_FAILED
+        merged = True  # tree is now mutated; any later failure must roll back
         new = _run_git(["rev-parse", "HEAD"], repo_root, git_timeout)
         new_sha = new.stdout.strip() if new.returncode == 0 else ""
         logger.info("Auto-update: fast-forwarded %s -> %s on %s.", old_sha[:9], new_sha[:9], branch)
@@ -420,13 +423,23 @@ def check_and_apply_update(
         )
         _write_state(UpdateStatus.UPDATED, old_sha, new_sha)
         return UpdateStatus.UPDATED
-    except subprocess.TimeoutExpired:
-        # A git op should not time out under the budget; if one does, the system
-        # is in a bad state, so fail open rather than crash the thread. Only a
-        # post-fetch timeout is a network failure (FETCH_FAILED, which writes the
-        # throttle stamp); a pre-fetch local-op timeout stays pre-network (NO_GIT)
-        # so it does not suppress the next real attempt.
-        logger.warning("Auto-update: a git operation timed out; serving current code.")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        # A git op should not time out (or git vanish) under the budget. Fail open
+        # rather than crash the thread. If the fast-forward already mutated the
+        # tree, roll back so we never strand the install on new code without
+        # rebuilt indexes.
+        if merged and old_sha:
+            logger.error("Auto-update: exception after fast-forward; rolling back to %s.", old_sha[:9])
+            try:
+                rollback = _run_git(["reset", "--hard", old_sha], repo_root, git_timeout)
+                if rollback.returncode != 0:
+                    logger.error("Auto-update: rollback after exception failed. %s", rollback.stderr.strip())
+            except Exception:
+                logger.error("Auto-update: rollback after exception raised.", exc_info=True)
+        # Only a post-fetch failure counts as a network failure (FETCH_FAILED,
+        # which writes the throttle stamp); a pre-fetch local-op failure stays
+        # pre-network (NO_GIT) so it does not suppress the next real attempt.
+        logger.warning("Auto-update: a git operation failed; serving current code.")
         return UpdateStatus.FETCH_FAILED if network_reached else UpdateStatus.NO_GIT
 
 

--- a/src/self_update.py
+++ b/src/self_update.py
@@ -64,6 +64,7 @@ class UpdateStatus:
     FETCH_FAILED = "FETCH_FAILED"
     UP_TO_DATE = "UP_TO_DATE"
     SKIPPED_DIVERGED = "SKIPPED_DIVERGED"
+    SKIPPED_AHEAD = "SKIPPED_AHEAD"
     MERGE_FAILED = "MERGE_FAILED"
     REINDEX_FAILED = "REINDEX_FAILED"
     UPDATED = "UPDATED"
@@ -307,6 +308,9 @@ def check_and_apply_update(
         logger.info("Auto-update: %s is not a git work tree; skipping.", repo_root)
         return UpdateStatus.NO_GIT
 
+    # Tracks whether we reached the network (fetch). A timeout before that point
+    # is a local-op failure that must not write the throttle stamp.
+    network_reached = False
     try:
         # Step 2 — branch guard: only act on the target branch.
         cur = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], repo_root, git_timeout)
@@ -337,6 +341,7 @@ def check_and_apply_update(
 
         # Step 4 — fetch the target branch.
         try:
+            network_reached = True
             fetch = _run_git(["fetch", remote, branch], repo_root, git_timeout)
         except subprocess.TimeoutExpired:
             logger.warning("Auto-update: git fetch timed out after %ds; serving current code.", git_timeout)
@@ -365,15 +370,18 @@ def check_and_apply_update(
         except ValueError:
             logger.warning("Auto-update: unexpected rev-list output %r; skipping.", counts.stdout)
             return UpdateStatus.FETCH_FAILED
+        if ahead > 0:
+            # Local has commits the remote lacks: diverged (when also behind) or
+            # purely ahead. Either way, never fast-forward over local work.
+            outcome = UpdateStatus.SKIPPED_DIVERGED if behind > 0 else UpdateStatus.SKIPPED_AHEAD
+            logger.info(
+                "Auto-update: local branch has unpushed commits vs %s (ahead %d, behind %d); skipping.",
+                remote_ref, ahead, behind,
+            )
+            return outcome
         if behind == 0:
             logger.info("Auto-update: already up to date with %s.", remote_ref)
             return UpdateStatus.UP_TO_DATE
-        if ahead > 0:
-            logger.info(
-                "Auto-update: local branch diverged from %s (ahead %d, behind %d); skipping.",
-                remote_ref, ahead, behind,
-            )
-            return UpdateStatus.SKIPPED_DIVERGED
 
         # Step 6 — fast-forward only.
         merge = _run_git(["merge", "--ff-only", "FETCH_HEAD"], repo_root, git_timeout)
@@ -413,10 +421,13 @@ def check_and_apply_update(
         _write_state(UpdateStatus.UPDATED, old_sha, new_sha)
         return UpdateStatus.UPDATED
     except subprocess.TimeoutExpired:
-        # A local git op should not time out under the budget; if one does the
-        # system is in a bad state — fail open rather than crash the thread.
+        # A git op should not time out under the budget; if one does, the system
+        # is in a bad state, so fail open rather than crash the thread. Only a
+        # post-fetch timeout is a network failure (FETCH_FAILED, which writes the
+        # throttle stamp); a pre-fetch local-op timeout stays pre-network (NO_GIT)
+        # so it does not suppress the next real attempt.
         logger.warning("Auto-update: a git operation timed out; serving current code.")
-        return UpdateStatus.FETCH_FAILED
+        return UpdateStatus.FETCH_FAILED if network_reached else UpdateStatus.NO_GIT
 
 
 # --- Background orchestration -------------------------------------------------

--- a/src/self_update.py
+++ b/src/self_update.py
@@ -58,6 +58,7 @@ class UpdateStatus:
     """Outcome of one :func:`check_and_apply_update` run (string constants)."""
 
     NO_GIT = "NO_GIT"
+    SKIPPED_BAD_CONFIG = "SKIPPED_BAD_CONFIG"
     SKIPPED_WRONG_BRANCH = "SKIPPED_WRONG_BRANCH"
     SKIPPED_DIRTY = "SKIPPED_DIRTY"
     FETCH_FAILED = "FETCH_FAILED"
@@ -72,7 +73,12 @@ class UpdateStatus:
 # stamp for these, so a wrong-branch / dirty skip never delays a later
 # legitimate check (the branch guard is local and instant).
 _PRE_NETWORK_STATUSES = frozenset(
-    {UpdateStatus.NO_GIT, UpdateStatus.SKIPPED_WRONG_BRANCH, UpdateStatus.SKIPPED_DIRTY}
+    {
+        UpdateStatus.NO_GIT,
+        UpdateStatus.SKIPPED_BAD_CONFIG,
+        UpdateStatus.SKIPPED_WRONG_BRANCH,
+        UpdateStatus.SKIPPED_DIRTY,
+    }
 )
 
 
@@ -84,6 +90,7 @@ try:  # pragma: no cover - platform-specific
     import fcntl as _fcntl
 
     def _try_lock(fh) -> bool:
+        """Acquire an exclusive non-blocking lock; return False if already held."""
         try:
             _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
             return True
@@ -91,6 +98,7 @@ try:  # pragma: no cover - platform-specific
             return False
 
     def _unlock(fh) -> None:
+        """Release the lock held on *fh* (best effort)."""
         try:
             _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
         except OSError:
@@ -98,9 +106,11 @@ try:  # pragma: no cover - platform-specific
 
 except ImportError:  # pragma: no cover - Windows
     def _try_lock(fh) -> bool:
+        """No-op lock on platforms without fcntl; always reports success."""
         return True
 
     def _unlock(fh) -> None:
+        """No-op unlock on platforms without fcntl."""
         return None
 
 
@@ -119,6 +129,16 @@ def _process_lock(path: str):
 
 
 # --- git / reindex helpers ---------------------------------------------------
+
+def _is_safe_arg(value: str) -> bool:
+    """True if *value* is a non-empty token git won't mistake for an option.
+
+    Guards against argument injection when a remote or branch name (sourced from
+    AGENTS_AUTO_UPDATE_REMOTE / _BRANCH) begins with ``-`` and git would parse it
+    as a flag rather than a positional argument.
+    """
+    return bool(value) and not value.startswith("-")
+
 
 def _run_git(args, cwd: str, timeout: int) -> subprocess.CompletedProcess:
     """Run ``git <args>`` capturing output. Does not raise on non-zero exit.
@@ -191,6 +211,7 @@ def _warn_if_deps_changed(repo_root: str, old_sha: str, new_sha: str, timeout: i
 # --- State + throttle persistence --------------------------------------------
 
 def _write_state(status: str, old_sha: str, new_sha: str) -> None:
+    """Atomically persist the latest update outcome to ``STATE_FILE``."""
     payload = {
         "status": status,
         "old_sha": old_sha,
@@ -226,6 +247,7 @@ def log_last_update() -> None:
 
 
 def _recently_checked(interval: int) -> bool:
+    """True if the throttle stamp was written within the last *interval* seconds."""
     if interval <= 0:
         return False
     try:
@@ -235,6 +257,7 @@ def _recently_checked(interval: int) -> bool:
 
 
 def _touch_check_stamp() -> None:
+    """Record 'now' as the time of the last network check (for throttling)."""
     try:
         os.makedirs(os.path.dirname(CHECK_STAMP) or ".", exist_ok=True)
         with open(CHECK_STAMP, "w", encoding="utf-8") as f:
@@ -261,6 +284,15 @@ def check_and_apply_update(
     ``python -m src.reindex``. Returns an :class:`UpdateStatus` value.
     """
     reindex = reindex_fn or (lambda rr: _run_reindex(rr, reindex_timeout))
+
+    # Step 0 — reject config values git could misread as options (argument
+    # injection via AGENTS_AUTO_UPDATE_REMOTE / _BRANCH starting with '-').
+    if not (_is_safe_arg(remote) and _is_safe_arg(branch)):
+        logger.warning(
+            "Auto-update: refusing unsafe remote/branch (%r / %r); skipping.",
+            remote, branch,
+        )
+        return UpdateStatus.SKIPPED_BAD_CONFIG
 
     # Step 1 — git available and repo_root is a work tree.
     try:
@@ -298,6 +330,10 @@ def check_and_apply_update(
 
         head = _run_git(["rev-parse", "HEAD"], repo_root, git_timeout)
         old_sha = head.stdout.strip() if head.returncode == 0 else ""
+        if not old_sha:
+            # Without a baseline commit we cannot roll back, so refuse to mutate.
+            logger.warning("Auto-update: could not resolve current HEAD; skipping.")
+            return UpdateStatus.NO_GIT
 
         # Step 4 — fetch the target branch.
         try:
@@ -351,7 +387,14 @@ def check_and_apply_update(
         _warn_if_deps_changed(repo_root, old_sha, new_sha, git_timeout)
 
         # Step 7 — rebuild the vector stores with the new code; roll back on failure.
-        if not reindex(repo_root):
+        # reindex_fn may raise (injected fns, unexpected errors); treat any raise
+        # as a failure so the rollback below always runs.
+        try:
+            reindex_ok = bool(reindex(repo_root))
+        except Exception:
+            logger.error("Auto-update: reindex raised; treating as failure.", exc_info=True)
+            reindex_ok = False
+        if not reindex_ok:
             logger.error("Auto-update: reindex failed; rolling back to %s.", old_sha[:9])
             rollback = _run_git(["reset", "--hard", old_sha], repo_root, git_timeout)
             if rollback.returncode != 0:

--- a/src/self_update.py
+++ b/src/self_update.py
@@ -1,0 +1,411 @@
+"""Background self-update for the Agents-Core MCP server.
+
+At startup the server spawns a daemon thread (``start_background_update``) that
+keeps the install current **without blocking startup**:
+
+    1. take a non-blocking cross-process lock (only one of N concurrent stdio
+       servers updates),
+    2. throttle redundant network checks,
+    3. fast-forward the install's git repo to the configured branch, and
+    4. rebuild the vector stores in a subprocess running the freshly-pulled code.
+
+The pull updates files on disk; the *running* process keeps its already-imported
+code and in-memory vectors, so the new code takes effect on the **next** start —
+which, for per-session stdio servers, is the next spawn. The expensive reindex
+runs now (in the background) so that next start is fast.
+
+Safety invariants:
+    * acts **only** when the checked-out branch is the target branch
+      (``AUTO_UPDATE_BRANCH``) — a no-op on feature branches / local dev,
+    * only when the working tree is clean, and only **fast-forward** (never
+      merge / rebase / auto-checkout),
+    * a failed reindex (e.g. broken new code) is **rolled back** via
+      ``git reset --hard`` to the pre-merge commit,
+    * every failure is logged and swallowed — the server is never crashed or
+      blocked by the updater.
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+
+from src.engine.config import (
+    INSTALL_ROOT,
+    INSTALL_DATA_DIR,
+    AUTO_UPDATE_ENABLED,
+    AUTO_UPDATE_REMOTE,
+    AUTO_UPDATE_BRANCH,
+    AUTO_UPDATE_GIT_TIMEOUT,
+    AUTO_UPDATE_MIN_INTERVAL,
+    AUTO_UPDATE_REINDEX_TIMEOUT,
+)
+
+logger = logging.getLogger(__name__)
+
+# Runtime artifacts (all under data/, which is gitignored — so they never make
+# the working tree look dirty). Module-level so tests can redirect them.
+LOCK_FILE = os.path.join(INSTALL_DATA_DIR, ".update.lock")
+CHECK_STAMP = os.path.join(INSTALL_DATA_DIR, ".last_update_check")
+STATE_FILE = os.path.join(INSTALL_DATA_DIR, ".last_update.json")
+
+
+class UpdateStatus:
+    """Outcome of one :func:`check_and_apply_update` run (string constants)."""
+
+    NO_GIT = "NO_GIT"
+    SKIPPED_WRONG_BRANCH = "SKIPPED_WRONG_BRANCH"
+    SKIPPED_DIRTY = "SKIPPED_DIRTY"
+    FETCH_FAILED = "FETCH_FAILED"
+    UP_TO_DATE = "UP_TO_DATE"
+    SKIPPED_DIVERGED = "SKIPPED_DIVERGED"
+    MERGE_FAILED = "MERGE_FAILED"
+    REINDEX_FAILED = "REINDEX_FAILED"
+    UPDATED = "UPDATED"
+
+
+# Statuses reached *before* any network access. We don't write the throttle
+# stamp for these, so a wrong-branch / dirty skip never delays a later
+# legitimate check (the branch guard is local and instant).
+_PRE_NETWORK_STATUSES = frozenset(
+    {UpdateStatus.NO_GIT, UpdateStatus.SKIPPED_WRONG_BRANCH, UpdateStatus.SKIPPED_DIRTY}
+)
+
+
+# --- Cross-process lock (non-blocking) ---------------------------------------
+# fcntl.flock on POSIX; no-op on Windows where stdio MCP doesn't run concurrent
+# sessions. Mirrors the helper in src/memory/history.py but uses LOCK_NB so a
+# held lock means "another server is already updating" -> skip immediately.
+try:  # pragma: no cover - platform-specific
+    import fcntl as _fcntl
+
+    def _try_lock(fh) -> bool:
+        try:
+            _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def _unlock(fh) -> None:
+        try:
+            _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+except ImportError:  # pragma: no cover - Windows
+    def _try_lock(fh) -> bool:
+        return True
+
+    def _unlock(fh) -> None:
+        return None
+
+
+@contextmanager
+def _process_lock(path: str):
+    """Yield True if the exclusive lock was acquired, False otherwise."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    fh = open(path, "w")
+    acquired = _try_lock(fh)
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            _unlock(fh)
+        fh.close()
+
+
+# --- git / reindex helpers ---------------------------------------------------
+
+def _run_git(args, cwd: str, timeout: int) -> subprocess.CompletedProcess:
+    """Run ``git <args>`` capturing output. Does not raise on non-zero exit.
+
+    May raise ``FileNotFoundError`` (git missing) or ``subprocess.TimeoutExpired``;
+    callers handle those where the distinction matters.
+    """
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _run_reindex(repo_root: str, timeout: int) -> bool:
+    """Rebuild the vector stores in a subprocess running the freshly-pulled code.
+
+    Spawned with ``cwd=repo_root`` so ``-m src.reindex`` resolves, and with the
+    inherited environment so a per-process ``LD_LIBRARY_PATH`` (NixOS) survives.
+    Returns True on success.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "src.reindex"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.warning("Auto-update: reindex subprocess error: %s", e)
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "Auto-update: reindex subprocess failed (rc=%d): %s",
+            result.returncode, (result.stderr or "")[-2000:],
+        )
+        return False
+    return True
+
+
+def _warn_if_deps_changed(repo_root: str, old_sha: str, new_sha: str, timeout: int) -> None:
+    """Log a warning if the pulled range touched dependency manifests.
+
+    We deliberately do NOT run ``pip install`` automatically; this just makes
+    the need visible to the operator.
+    """
+    if not old_sha or not new_sha:
+        return
+    try:
+        diff = _run_git(["diff", "--name-only", f"{old_sha}..{new_sha}"], repo_root, timeout)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return
+    if diff.returncode != 0:
+        return
+    changed = set(diff.stdout.split())
+    hit = {"requirements.txt", "pyproject.toml"} & changed
+    if hit:
+        logger.warning(
+            "Auto-update: dependency files changed (%s) but pip install is NOT run "
+            "automatically — update the environment manually if needed.",
+            ", ".join(sorted(hit)),
+        )
+
+
+# --- State + throttle persistence --------------------------------------------
+
+def _write_state(status: str, old_sha: str, new_sha: str) -> None:
+    payload = {
+        "status": status,
+        "old_sha": old_sha,
+        "new_sha": new_sha,
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE) or ".", exist_ok=True)
+        tmp = STATE_FILE + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False)
+        os.replace(tmp, STATE_FILE)
+    except OSError as e:
+        logger.debug("Auto-update: could not write state file: %s", e)
+
+
+def log_last_update() -> None:
+    """Log the last recorded update outcome (startup observability)."""
+    try:
+        if not os.path.exists(STATE_FILE):
+            return
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            state = json.load(f)
+        logger.info(
+            "Auto-update: last run %s (%s -> %s) at %s",
+            state.get("status"),
+            (state.get("old_sha") or "")[:9],
+            (state.get("new_sha") or "")[:9],
+            state.get("ts"),
+        )
+    except (OSError, ValueError) as e:
+        logger.debug("Auto-update: could not read state file: %s", e)
+
+
+def _recently_checked(interval: int) -> bool:
+    if interval <= 0:
+        return False
+    try:
+        return (time.time() - os.path.getmtime(CHECK_STAMP)) < interval
+    except OSError:
+        return False
+
+
+def _touch_check_stamp() -> None:
+    try:
+        os.makedirs(os.path.dirname(CHECK_STAMP) or ".", exist_ok=True)
+        with open(CHECK_STAMP, "w", encoding="utf-8") as f:
+            f.write(time.strftime("%Y-%m-%dT%H:%M:%S%z"))
+    except OSError as e:
+        logger.debug("Auto-update: could not write check stamp: %s", e)
+
+
+# --- Core state machine ------------------------------------------------------
+
+def check_and_apply_update(
+    repo_root: str = INSTALL_ROOT,
+    remote: str = AUTO_UPDATE_REMOTE,
+    branch: str = AUTO_UPDATE_BRANCH,
+    *,
+    git_timeout: int = AUTO_UPDATE_GIT_TIMEOUT,
+    reindex_timeout: int = AUTO_UPDATE_REINDEX_TIMEOUT,
+    reindex_fn=None,
+) -> str:
+    """Fast-forward *repo_root* to ``<remote>/<branch>`` and rebuild stores.
+
+    Pure of threading/locking so it can be unit-tested directly. ``reindex_fn``
+    (``repo_root -> bool``) is injected in tests; defaults to spawning
+    ``python -m src.reindex``. Returns an :class:`UpdateStatus` value.
+    """
+    reindex = reindex_fn or (lambda rr: _run_reindex(rr, reindex_timeout))
+
+    # Step 1 — git available and repo_root is a work tree.
+    try:
+        rev = _run_git(["rev-parse", "--is-inside-work-tree"], repo_root, git_timeout)
+    except FileNotFoundError:
+        logger.info("Auto-update: git not found; skipping.")
+        return UpdateStatus.NO_GIT
+    except subprocess.TimeoutExpired:
+        logger.warning("Auto-update: git timed out; skipping.")
+        return UpdateStatus.NO_GIT
+    if rev.returncode != 0 or rev.stdout.strip() != "true":
+        logger.info("Auto-update: %s is not a git work tree; skipping.", repo_root)
+        return UpdateStatus.NO_GIT
+
+    try:
+        # Step 2 — branch guard: only act on the target branch.
+        cur = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], repo_root, git_timeout)
+        current_branch = cur.stdout.strip() if cur.returncode == 0 else ""
+        if current_branch != branch:
+            logger.info(
+                "Auto-update: on '%s', target is '%s'; skipping (local development).",
+                current_branch or "?", branch,
+            )
+            return UpdateStatus.SKIPPED_WRONG_BRANCH
+
+        # Step 3 — clean working tree (tracked files only; an incoming file that
+        # collides with an untracked one makes the ff-merge fail loudly at step 6).
+        status = _run_git(["status", "--porcelain", "--untracked-files=no"], repo_root, git_timeout)
+        if status.returncode != 0:
+            logger.warning("Auto-update: git status failed; skipping. %s", status.stderr.strip())
+            return UpdateStatus.SKIPPED_DIRTY
+        if status.stdout.strip():
+            logger.info("Auto-update: working tree has uncommitted changes; skipping.")
+            return UpdateStatus.SKIPPED_DIRTY
+
+        head = _run_git(["rev-parse", "HEAD"], repo_root, git_timeout)
+        old_sha = head.stdout.strip() if head.returncode == 0 else ""
+
+        # Step 4 — fetch the target branch.
+        try:
+            fetch = _run_git(["fetch", remote, branch], repo_root, git_timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning("Auto-update: git fetch timed out after %ds; serving current code.", git_timeout)
+            return UpdateStatus.FETCH_FAILED
+        if fetch.returncode != 0:
+            logger.warning("Auto-update: git fetch failed; serving current code. %s", fetch.stderr.strip())
+            return UpdateStatus.FETCH_FAILED
+
+        remote_ref = f"{remote}/{branch}"
+
+        # Compare against FETCH_HEAD — fetch always points it at the just-fetched
+        # branch tip, so this avoids depending on remote-tracking-ref refspec
+        # nuances (and it's exactly what `git pull` would merge).
+
+        # Step 5 — how far behind / ahead are we?
+        counts = _run_git(
+            ["rev-list", "--left-right", "--count", "FETCH_HEAD...HEAD"],
+            repo_root, git_timeout,
+        )
+        if counts.returncode != 0:
+            logger.warning("Auto-update: could not compare with %s; skipping. %s", remote_ref, counts.stderr.strip())
+            return UpdateStatus.FETCH_FAILED
+        try:
+            behind_str, ahead_str = counts.stdout.split()
+            behind, ahead = int(behind_str), int(ahead_str)
+        except ValueError:
+            logger.warning("Auto-update: unexpected rev-list output %r; skipping.", counts.stdout)
+            return UpdateStatus.FETCH_FAILED
+        if behind == 0:
+            logger.info("Auto-update: already up to date with %s.", remote_ref)
+            return UpdateStatus.UP_TO_DATE
+        if ahead > 0:
+            logger.info(
+                "Auto-update: local branch diverged from %s (ahead %d, behind %d); skipping.",
+                remote_ref, ahead, behind,
+            )
+            return UpdateStatus.SKIPPED_DIVERGED
+
+        # Step 6 — fast-forward only.
+        merge = _run_git(["merge", "--ff-only", "FETCH_HEAD"], repo_root, git_timeout)
+        if merge.returncode != 0:
+            logger.warning("Auto-update: fast-forward merge failed; skipping. %s", merge.stderr.strip())
+            return UpdateStatus.MERGE_FAILED
+        new = _run_git(["rev-parse", "HEAD"], repo_root, git_timeout)
+        new_sha = new.stdout.strip() if new.returncode == 0 else ""
+        logger.info("Auto-update: fast-forwarded %s -> %s on %s.", old_sha[:9], new_sha[:9], branch)
+
+        _warn_if_deps_changed(repo_root, old_sha, new_sha, git_timeout)
+
+        # Step 7 — rebuild the vector stores with the new code; roll back on failure.
+        if not reindex(repo_root):
+            logger.error("Auto-update: reindex failed; rolling back to %s.", old_sha[:9])
+            rollback = _run_git(["reset", "--hard", old_sha], repo_root, git_timeout)
+            if rollback.returncode != 0:
+                logger.error(
+                    "Auto-update: ROLLBACK FAILED — repo is on new code without rebuilt indexes. %s",
+                    rollback.stderr.strip(),
+                )
+            _write_state(UpdateStatus.REINDEX_FAILED, old_sha, new_sha)
+            return UpdateStatus.REINDEX_FAILED
+
+        # Step 8 — record; new code applies on the next start.
+        logger.info(
+            "Auto-update: prepared update %s -> %s; takes effect on next restart.",
+            old_sha[:9], new_sha[:9],
+        )
+        _write_state(UpdateStatus.UPDATED, old_sha, new_sha)
+        return UpdateStatus.UPDATED
+    except subprocess.TimeoutExpired:
+        # A local git op should not time out under the budget; if one does the
+        # system is in a bad state — fail open rather than crash the thread.
+        logger.warning("Auto-update: a git operation timed out; serving current code.")
+        return UpdateStatus.FETCH_FAILED
+
+
+# --- Background orchestration -------------------------------------------------
+
+def _run_update_safely() -> None:
+    """Lock + throttle + run the update, swallowing every error."""
+    try:
+        with _process_lock(LOCK_FILE) as acquired:
+            if not acquired:
+                logger.debug("Auto-update: another process holds the update lock; skipping.")
+                return
+            if _recently_checked(AUTO_UPDATE_MIN_INTERVAL):
+                logger.debug("Auto-update: checked within the throttle window; skipping.")
+                return
+            status = check_and_apply_update()
+            # Only throttle once we've actually hit the network, so a
+            # wrong-branch / dirty skip never delays a later real check.
+            if status not in _PRE_NETWORK_STATUSES:
+                _touch_check_stamp()
+            logger.debug("Auto-update: finished with status %s", status)
+    except Exception:
+        logger.warning("Auto-update: background update crashed (ignored).", exc_info=True)
+
+
+def start_background_update():
+    """Spawn the daemon update thread, unless disabled. Returns it (or None).
+
+    Non-blocking: returns immediately so ``mcp.run()`` can start serving.
+    """
+    if not AUTO_UPDATE_ENABLED:
+        logger.debug("Auto-update: disabled (AGENTS_AUTO_UPDATE=0).")
+        return None
+    thread = threading.Thread(target=_run_update_safely, name="auto-update", daemon=True)
+    thread.start()
+    return thread

--- a/src/server.py
+++ b/src/server.py
@@ -1126,4 +1126,12 @@ def _warmup_rules():
 if __name__ == "__main__":
     _warmup_embedding_model()
     _warmup_rules()
+    # Background self-update: fast-forwards the install's git repo and rebuilds
+    # the vector stores in a daemon thread WITHOUT blocking startup; the pulled
+    # code takes effect on the next start. No-op unless on the target branch.
+    # See src/self_update.py. Started after warmup so the hot path is already
+    # imported and the reindex subprocess doesn't contend for the model load.
+    from src.self_update import log_last_update, start_background_update
+    log_last_update()
+    start_background_update()
     mcp.run()

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -1,0 +1,237 @@
+"""Tests for the background self-updater (src/self_update.py).
+
+Fast by design: real temporary git repos (git is quick) but the reindex step is
+injected as a recorder, so no embedding model is ever loaded. Not marked slow.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src import self_update
+from src.self_update import UpdateStatus, check_and_apply_update
+
+
+# --- git fixture helpers -----------------------------------------------------
+
+def _git(cwd, *args, check=True):
+    r = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed in {cwd}: {r.stderr}")
+    return r
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    # Pin the initial branch to 'main' portably (no reliance on init.defaultBranch).
+    _git(path, "symbolic-ref", "HEAD", "refs/heads/main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    _git(path, "config", "commit.gpgsign", "false")
+    return path
+
+
+def _commit(path: Path, filename: str, content: str, msg: str):
+    (path / filename).write_text(content)
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", msg)
+
+
+def _head(path) -> str:
+    return _git(path, "rev-parse", "HEAD").stdout.strip()
+
+
+@pytest.fixture
+def repos(tmp_path):
+    """An 'upstream' repo on main with one commit, plus a 'local' clone of it."""
+    upstream = _init_repo(tmp_path / "upstream")
+    _commit(upstream, "file.txt", "v1\n", "init")
+    local = tmp_path / "local"
+    _git(tmp_path, "clone", "-q", str(upstream), str(local))
+    _git(local, "config", "user.email", "test@example.com")
+    _git(local, "config", "user.name", "Test")
+    _git(local, "config", "commit.gpgsign", "false")
+    return SimpleNamespace(upstream=upstream, local=local)
+
+
+@pytest.fixture
+def recorder():
+    calls = []
+
+    def fn(repo_root):
+        calls.append(repo_root)
+        return True
+
+    fn.calls = calls
+    return fn
+
+
+# --- check_and_apply_update: the state machine -------------------------------
+
+def test_up_to_date_no_reindex(repos, recorder):
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+    assert status == UpdateStatus.UP_TO_DATE
+    assert recorder.calls == []
+
+
+def test_fast_forward_applies_and_reindexes(repos, recorder):
+    _commit(repos.upstream, "file.txt", "v2\n", "update")
+    old = _head(repos.local)
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+
+    assert status == UpdateStatus.UPDATED
+    new = _head(repos.local)
+    assert new == _head(repos.upstream)  # fast-forwarded to upstream tip
+    assert new != old
+    assert recorder.calls == [str(repos.local)]  # reindex ran against the repo
+
+
+def test_reindex_failure_rolls_back(repos):
+    _commit(repos.upstream, "file.txt", "v2\n", "update")
+    old = _head(repos.local)
+
+    status = check_and_apply_update(
+        str(repos.local), "origin", "main", reindex_fn=lambda rr: False
+    )
+
+    assert status == UpdateStatus.REINDEX_FAILED
+    assert _head(repos.local) == old  # rolled back to the pre-merge commit
+
+
+def test_skip_on_wrong_branch(repos, recorder):
+    _commit(repos.upstream, "file.txt", "v2\n", "update")
+    _git(repos.local, "checkout", "-q", "-b", "feature")
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+
+    assert status == UpdateStatus.SKIPPED_WRONG_BRANCH
+    assert recorder.calls == []
+
+
+def test_skip_on_dirty_tree(repos, recorder):
+    (repos.local / "file.txt").write_text("uncommitted change\n")
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+
+    assert status == UpdateStatus.SKIPPED_DIRTY
+    assert recorder.calls == []
+
+
+def test_skip_on_diverged(repos, recorder):
+    _commit(repos.upstream, "file.txt", "remote-change\n", "remote")
+    _commit(repos.local, "other.txt", "local-change\n", "local")
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+
+    assert status == UpdateStatus.SKIPPED_DIVERGED
+    assert recorder.calls == []
+    # local commit is preserved
+    assert _head(repos.local) != _head(repos.upstream)
+
+
+def test_fetch_failure_is_fail_open(repos, recorder):
+    # Clean tree, correct branch, but a bogus remote -> fetch fails, no raise.
+    status = check_and_apply_update(
+        str(repos.local), "no-such-remote", "main", reindex_fn=recorder
+    )
+    assert status == UpdateStatus.FETCH_FAILED
+    assert recorder.calls == []
+
+
+def test_not_a_git_tree(tmp_path, recorder):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    status = check_and_apply_update(str(plain), "origin", "main", reindex_fn=recorder)
+    assert status == UpdateStatus.NO_GIT
+    assert recorder.calls == []
+
+
+# --- start_background_update / _run_update_safely: orchestration -------------
+
+def test_disabled_spawns_no_thread(monkeypatch):
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_ENABLED", False)
+    assert self_update.start_background_update() is None
+
+
+def test_background_thread_runs_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_ENABLED", True)
+    monkeypatch.setattr(self_update, "LOCK_FILE", str(tmp_path / ".update.lock"))
+    monkeypatch.setattr(self_update, "CHECK_STAMP", str(tmp_path / ".check"))
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_MIN_INTERVAL", 0)
+    calls = []
+    monkeypatch.setattr(self_update, "check_and_apply_update",
+                        lambda: calls.append(1) or UpdateStatus.UP_TO_DATE)
+
+    thread = self_update.start_background_update()
+    assert thread is not None
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert calls == [1]
+
+
+def test_throttle_skips_check(tmp_path, monkeypatch):
+    monkeypatch.setattr(self_update, "LOCK_FILE", str(tmp_path / ".update.lock"))
+    monkeypatch.setattr(self_update, "CHECK_STAMP", str(tmp_path / ".check"))
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_MIN_INTERVAL", 9999)
+    self_update._touch_check_stamp()  # fresh stamp -> within the window
+    calls = []
+    monkeypatch.setattr(self_update, "check_and_apply_update",
+                        lambda: calls.append(1) or UpdateStatus.UP_TO_DATE)
+
+    self_update._run_update_safely()
+    assert calls == []  # throttled before any check
+
+
+def test_lock_contention_skips_check(tmp_path, monkeypatch):
+    fcntl = pytest.importorskip("fcntl")
+    lock = str(tmp_path / ".update.lock")
+    monkeypatch.setattr(self_update, "LOCK_FILE", lock)
+    monkeypatch.setattr(self_update, "CHECK_STAMP", str(tmp_path / ".check"))
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_MIN_INTERVAL", 0)
+    calls = []
+    monkeypatch.setattr(self_update, "check_and_apply_update",
+                        lambda: calls.append(1) or UpdateStatus.UP_TO_DATE)
+
+    holder = open(lock, "w")
+    fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        self_update._run_update_safely()
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+    assert calls == []  # another holder -> skipped
+
+
+def test_wrong_branch_does_not_write_throttle_stamp(repos, tmp_path, monkeypatch):
+    # A pre-network skip must not stamp the throttle, so a later on-branch check
+    # is never delayed.
+    monkeypatch.setattr(self_update, "LOCK_FILE", str(tmp_path / ".update.lock"))
+    stamp = tmp_path / ".check"
+    monkeypatch.setattr(self_update, "CHECK_STAMP", str(stamp))
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_MIN_INTERVAL", 0)
+    monkeypatch.setattr(self_update, "check_and_apply_update",
+                        lambda: UpdateStatus.SKIPPED_WRONG_BRANCH)
+
+    self_update._run_update_safely()
+    assert not stamp.exists()
+
+
+# --- state file round-trip ---------------------------------------------------
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(self_update, "STATE_FILE", str(tmp_path / ".last_update.json"))
+    self_update._write_state(UpdateStatus.UPDATED, "a" * 40, "b" * 40)
+    assert os.path.exists(self_update.STATE_FILE)
+    # Must not raise on a present, well-formed file.
+    self_update.log_last_update()
+
+
+def test_log_last_update_missing_file_is_silent(tmp_path, monkeypatch):
+    monkeypatch.setattr(self_update, "STATE_FILE", str(tmp_path / "does-not-exist.json"))
+    self_update.log_last_update()  # no exception

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -276,6 +276,76 @@ def test_wrong_branch_does_not_write_throttle_stamp(repos, tmp_path, monkeypatch
     assert not stamp.exists()
 
 
+def test_network_reached_failure_writes_throttle_stamp(tmp_path, monkeypatch):
+    # A post-network outcome (e.g. FETCH_FAILED) must write the throttle stamp.
+    monkeypatch.setattr(self_update, "LOCK_FILE", str(tmp_path / ".update.lock"))
+    stamp = tmp_path / ".check"
+    monkeypatch.setattr(self_update, "CHECK_STAMP", str(stamp))
+    monkeypatch.setattr(self_update, "AUTO_UPDATE_MIN_INTERVAL", 0)
+    monkeypatch.setattr(self_update, "check_and_apply_update",
+                        lambda: UpdateStatus.FETCH_FAILED)
+
+    self_update._run_update_safely()
+    assert stamp.exists()
+
+
+# --- timeout / network-reached boundary --------------------------------------
+
+def test_timeout_before_fetch_is_pre_network(repos, recorder, monkeypatch):
+    # A timeout on a pre-fetch local op (status) is not a network failure: it
+    # returns NO_GIT (pre-network), so the throttle stamp is not written later.
+    real = self_update._run_git
+
+    def fake(args, cwd, timeout):
+        if args and args[0] == "status":
+            raise subprocess.TimeoutExpired(cmd="git status", timeout=timeout)
+        return real(args, cwd, timeout)
+
+    monkeypatch.setattr(self_update, "_run_git", fake)
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+    assert status == UpdateStatus.NO_GIT
+    assert recorder.calls == []
+
+
+def test_timeout_after_fetch_is_network_failure(repos, recorder, monkeypatch):
+    # A timeout after a successful fetch (here on rev-list) is a network-reached
+    # failure, so it returns FETCH_FAILED.
+    real = self_update._run_git
+
+    def fake(args, cwd, timeout):
+        if args and args[0] == "rev-list":
+            raise subprocess.TimeoutExpired(cmd="git rev-list", timeout=timeout)
+        return real(args, cwd, timeout)
+
+    monkeypatch.setattr(self_update, "_run_git", fake)
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+    assert status == UpdateStatus.FETCH_FAILED
+    assert recorder.calls == []
+
+
+def test_exception_after_merge_rolls_back(repos, monkeypatch):
+    # If a git op raises AFTER the fast-forward, the tree must be rolled back.
+    _commit(repos.upstream, "file.txt", "v2\n", "update")
+    old = _head(repos.local)
+    real = self_update._run_git
+    head_calls = {"n": 0}
+
+    def fake(args, cwd, timeout):
+        # Blow up only on the post-merge `rev-parse HEAD` (the 2nd bare one;
+        # the 1st is the pre-merge old_sha lookup).
+        if args[:2] == ["rev-parse", "HEAD"]:
+            head_calls["n"] += 1
+            if head_calls["n"] >= 2:
+                raise subprocess.TimeoutExpired(cmd="git rev-parse HEAD", timeout=timeout)
+        return real(args, cwd, timeout)
+
+    monkeypatch.setattr(self_update, "_run_git", fake)
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=lambda rr: True)
+
+    assert status == UpdateStatus.FETCH_FAILED  # network was reached
+    assert _head(repos.local) == old  # rolled back despite the post-merge failure
+
+
 # --- state file round-trip ---------------------------------------------------
 
 def test_state_roundtrip(tmp_path, monkeypatch):

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -175,6 +175,19 @@ def test_skip_on_diverged(repos, recorder):
     assert _head(repos.local) != _head(repos.upstream)
 
 
+def test_skip_when_ahead_only(repos, recorder):
+    # Local has a commit the remote lacks and the remote has nothing new
+    # (ahead>0, behind==0): must skip, not report UP_TO_DATE, and not reindex.
+    _commit(repos.local, "local-only.txt", "local\n", "local only")
+    ahead_head = _head(repos.local)
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=recorder)
+
+    assert status == UpdateStatus.SKIPPED_AHEAD
+    assert recorder.calls == []
+    assert _head(repos.local) == ahead_head  # untouched
+
+
 def test_fetch_failure_is_fail_open(repos, recorder):
     # Clean tree, correct branch, but a bogus remote -> fetch fails, no raise.
     status = check_and_apply_update(

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -5,6 +5,7 @@ injected as a recorder, so no embedding model is ever loaded. Not marked slow.
 """
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,10 @@ import pytest
 
 from src import self_update
 from src.self_update import UpdateStatus, check_and_apply_update
+
+# These tests shell out to the real `git` CLI; skip cleanly where it's absent
+# (minimal CI sandboxes, some Windows runners) instead of erroring the suite.
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git CLI not available")
 
 
 # --- git fixture helpers -----------------------------------------------------
@@ -101,6 +106,42 @@ def test_reindex_failure_rolls_back(repos):
 
     assert status == UpdateStatus.REINDEX_FAILED
     assert _head(repos.local) == old  # rolled back to the pre-merge commit
+
+
+def test_reindex_failure_rollback_removes_added_file(repos):
+    # The pulled update ADDS a new path. git reset --hard must remove it and
+    # leave a clean tree (covers the added-file rollback case, not just edits).
+    (repos.upstream / "newdir").mkdir()
+    _commit(repos.upstream, "newdir/added.txt", "added\n", "add new file")
+    old = _head(repos.local)
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=lambda rr: False)
+
+    assert status == UpdateStatus.REINDEX_FAILED
+    assert _head(repos.local) == old
+    assert not (repos.local / "newdir" / "added.txt").exists()
+    assert _git(repos.local, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_reindex_exception_triggers_rollback(repos):
+    # A reindex that *raises* (not just returns False) must still roll back.
+    _commit(repos.upstream, "file.txt", "v2\n", "update")
+    old = _head(repos.local)
+
+    def boom(repo_root):
+        raise RuntimeError("reindex crashed")
+
+    status = check_and_apply_update(str(repos.local), "origin", "main", reindex_fn=boom)
+
+    assert status == UpdateStatus.REINDEX_FAILED
+    assert _head(repos.local) == old
+
+
+def test_bad_remote_or_branch_is_skipped(repos, recorder):
+    # A remote/branch starting with '-' would be argument injection; refuse early.
+    status = check_and_apply_update(str(repos.local), "-x", "main", reindex_fn=recorder)
+    assert status == UpdateStatus.SKIPPED_BAD_CONFIG
+    assert recorder.calls == []
 
 
 def test_skip_on_wrong_branch(repos, recorder):


### PR DESCRIPTION
## Summary

Adds an opt-out background self-updater so the MCP server keeps its install
current without blocking startup. On launch a daemon thread fast-forwards the
repo to the target branch and rebuilds the vector stores in a subprocess; the
pulled code takes effect on the next start (for per-session stdio servers, the
next spawn). The heavy reindex runs in the background of the current session so
the next one starts fast. No os.execv, no pip install.

## Behavior and safety

- Enabled by default; disable with `AGENTS_AUTO_UPDATE=0`.
- Acts only when the checked-out branch is `AGENTS_AUTO_UPDATE_BRANCH` (default
  `main`) and the working tree is clean, fast-forward only. It is a no-op on any
  other branch, so local development is never disturbed.
- Never switches branches, merges, or rebases.
- A failed reindex (for example, broken new code) is rolled back with
  `git reset --hard` to the pre-merge commit.
- Cross-process non-blocking lock so multiple concurrent stdio servers do not
  race on git; an optional throttle avoids repeated network fetches.
- Offline or any error is logged and the server keeps serving the current code.

## Config (env vars)

| Variable | Default | Purpose |
| :-- | :-- | :-- |
| `AGENTS_AUTO_UPDATE` | `1` | Master on/off switch |
| `AGENTS_AUTO_UPDATE_REMOTE` | `origin` | Git remote to track |
| `AGENTS_AUTO_UPDATE_BRANCH` | `main` | Only updates when this branch is checked out |
| `AGENTS_AUTO_UPDATE_TIMEOUT` | `30` | Seconds per git op |
| `AGENTS_AUTO_UPDATE_INTERVAL` | `900` | Throttle network checks (0 = every start) |
| `AGENTS_AUTO_UPDATE_REINDEX_TIMEOUT` | `600` | Seconds for the reindex subprocess |

## Files

- New: `src/self_update.py`, `src/reindex.py`, `tests/test_self_update.py`
- Changed: `src/engine/config.py`, `src/server.py`, `env.example`, `README.md`

## Testing

- 15 new tests in `tests/test_self_update.py` over temporary git repos (reindex
  mocked, no model load): up-to-date, fast-forward applies, wrong-branch skip,
  dirty skip, diverged skip, fetch failure fail-open, reindex failure rollback,
  disabled, lock contention, throttle.
- Full fast suite: 469 passed. The 6 failures in `test_language.py` are
  pre-existing (langdetect not installed in the local venv) and unrelated.
- `python -m src.reindex` runs to completion (exit 0).
- On `feat/auto_update` the updater is a verified no-op (SKIPPED_WRONG_BRANCH),
  working tree untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background auto-update daemon that non-blockingly fast-forwards the repo and rebuilds vector stores at startup, with safe rollback on failed reindex and continued serving on errors.
  * CLI entry to run a manual rebuild of vector stores.

* **Configuration**
  * New env vars to enable/control auto-update, choose remote/branch, and tune timeouts and throttle intervals.

* **Documentation**
  * README updated with auto-update usage and configuration.

* **Tests**
  * Added tests covering updates, rollback, throttling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->